### PR TITLE
Fix for missing dependency and reporter

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function( grunt ) {
 			tests: {
 				src: files.tests,
 				options: {
-					reporter: 'Nyan'
+					reporter: 'nyan'
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt-simple-mocha": "^0.4.0",
     "jscs-stylish": "^0.3.0",
     "jshint-stylish": "^0.2.0",
+    "load-grunt-tasks": "^0.6.0",
     "mocha": "^1.20.1",
     "sinon": "^1.10.2",
     "sinon-chai": "^2.5.0"


### PR DESCRIPTION
The reporter was incorrectly capitalized, not sure how or if this was working
before? Perhaps Windows isn't case sensitive with this or something.

The module `load-grunt-tasks` was missing from the `devDependencies`.
