### PR TITLE
Change NPM package name to "wordpress-rest-api" and add install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ A Node.js-based client for the [WordPress JSON API](http://wp-api.org/).
 
 This library is designed to make it easy for your [Node.js](http://nodejs.org) application to request specific resources from a WordPress install. It uses a query builder-style syntax to let you craft the request being made to the WP-API endpoints, then returns the data to your application as a JavaScript object.
 
+## Installation
+
+To use the library, install it with [npm](http://npmjs.org):
+```bash
+npm install --save wordpress-rest-api
+```
+Then, within your application's script files, `require` the module to gain access to it:
+```javascript
+var WP_API = require( 'wordpress-rest-api' );
+```
+
 ## Using The Client
 
 The module is a constructor, so you can create an instance of the API client bound to the endpoint for your WordPress install:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "node-wp-api",
-  "version": "0.0.2",
-  "description": "A Node.js client for interacting with the WordPress REST API",
+  "name": "wordpress-rest-api",
+  "version": "0.1.0",
+  "description": "A client for interacting with the WordPress REST API",
   "main": "wp.js",
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "bluebird": "^2.1.3",
+    "lodash": "^2.4.1",
     "node.extend": "^1.0.10",
     "superagent": "^0.18.0"
   },
@@ -36,7 +37,6 @@
     "jscs-stylish": "^0.3.0",
     "jshint-stylish": "^0.2.0",
     "load-grunt-tasks": "^0.6.0",
-    "lodash": "^2.4.1",
     "mocha": "^1.20.1",
     "sandboxed-module": "^1.0.0",
     "sinon": "^1.10.2",


### PR DESCRIPTION
This cleans things up a bit so that it should be publishable on NPM. This is NOT a final release and is NOT considered stable, but this thing needs to be put out into the wild so the community can kick the tires. We intend to iterate rapidly on the NPM package versions.

Bumps version to 0.1.0.
