### PR TITLE
Add WP.site static convenience method for creating new sites

### DIFF
--- a/tests/wp.js
+++ b/tests/wp.js
@@ -35,4 +35,14 @@ describe( 'wp', function() {
 
 	});
 
+	describe( '.site()', function() {
+
+		it( 'Creates and returns a new WP instance', function() {
+			var site = WP.site( 'endpoint/url' );
+			expect( site instanceof WP ).to.be.true;
+			expect( site._options.endpoint ).to.equal( 'endpoint/url/' );
+		});
+
+	});
+
 });

--- a/wp.js
+++ b/wp.js
@@ -54,6 +54,23 @@ function WP( options ) {
 }
 
 /**
+ * Convenience method for making a new WP instance
+ *
+ * @example
+ *    // These are equivalent:
+ *    var wp = WP.site( 'http://my.blog.url/wp-json' );
+ *    var wp = new WP({ endpoint: 'http://my.blog.url/wp-json' });
+ *
+ * @method site
+ * @static
+ * @param {String} endpoint The URI for a WP-API endpoint
+ * @return {WP} A new WP instance, bound to the provided endpoint
+ */
+WP.site = function( endpoint ) {
+	return new WP({ endpoint: endpoint });
+};
+
+/**
  * @method posts
  * @param {Object} [options] An options hash for a new PostsRequest
  * @return {PostsRequest} A PostsRequest instance


### PR DESCRIPTION
The [WP.com API client](https://github.com/Automattic/wpcom.js) provides a useful `wpcom.site()` method, for constructing a client instance bound to a particular url. This seems like a convenient shortcut and will be familiar for people coming in from that API, as well as a nice abstraction for any prospective users who aren't familiar with the `new` syntax, so I've added .site() as a static method on the WP object.
