### PR TITLE
Add NPM script aliases for the registered Grunt tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "homepage": "https://github.com/kadamwhite/wordpress-rest-api",
   "scripts": {
     "prepublish": "grunt",
+    "docs": "grunt yuidoc",
+    "lint": "grunt jscs jshint",
+    "mocha": "grunt test",
+    "watch": "grunt watch",
     "test": "grunt"
   },
   "dependencies": {


### PR DESCRIPTION
Not everybody has or should need to have grunt-cli installed globally: This allows people to use NPM to trigger grunt builds, without worrying how they work under the hood.
