### PR TITLE
Change WPRequest.then to accept a failure callback

### DIFF
--- a/lib/WPRequest.js
+++ b/lib/WPRequest.js
@@ -331,16 +331,16 @@ WPRequest.prototype.head = function( callback ) {
 };
 
 /**
- * Calling .then on a query chain will invoke it as a GET and return a promise
+ * Calling .then on a query chain will invoke the query as a GET and return a promise
  *
  * @method then
  * @async
- * @param {Function} [callback] A callback to invoke with the results of the GET request
- * @param {Object} callback.results The body of the server response
+ * @param {Function} [successCallback] A callback to handle the data returned from the GET request
+ * @param {Function} [failureCallback] A callback to handle any errors encountered by the request
  * @return {Promise} A promise to the results of the HTTP request
  */
-WPRequest.prototype.then = function( callback ) {
-	return this.get().then( callback );
+WPRequest.prototype.then = function( successCallback, failureCallback ) {
+	return this.get().then( successCallback, failureCallback );
 };
 
 module.exports = WPRequest;

--- a/tests/lib/WPRequest.js
+++ b/tests/lib/WPRequest.js
@@ -99,10 +99,27 @@ describe( 'WPRequest', function() {
 				});
 			});
 
-			it( 'should be invoked automatically by .then()', function() {
+		});
+
+		describe( '.then()', function() {
+
+			it( 'should invoke GET and pass the results to the provided callback', function() {
 				mockAgent._response = { body: 'data' };
+				var get = sinon.spy( wpRequest, 'get' );
+
 				return wpRequest.then(function( data ) {
+					expect( get ).to.have.been.calledWith();
 					expect( data ).to.equal( 'data' );
+				});
+			});
+
+			it( 'should call the failure callback if GET fails', function() {
+				mockAgent._err = 'Something went wrong';
+				var success = sinon.stub();
+				success.throws( new Error( 'success handler should not have been called' ) );
+
+				return wpRequest.then( success, function failure( err ) {
+					expect( err ).to.equal( 'Something went wrong' );
 				});
 			});
 

--- a/tests/mocks/mock-superagent.js
+++ b/tests/mocks/mock-superagent.js
@@ -15,7 +15,7 @@ MockAgent.prototype = {
 	set: function() { return this; },
 	end: function( cb ) {
 		cb = cb || noop;
-		cb( null, this._response || {} );
+		cb( this._err || null, this._response || {} );
 	}
 };
 


### PR DESCRIPTION
@jugglinmike suggested the `.then` method on `WPRequest` should expose the full signature of Promise#then, and accept both success and failure callbacks. Thanks for the feedback, the change has been made!
