### PR TITLE
Changed PostsRequest to set comment targets via comment(), not id()

### DIFF
--- a/lib/pages.js
+++ b/lib/pages.js
@@ -126,7 +126,7 @@ PagesRequest.prototype.id = function( id ) {
 };
 
 /**
- * Specify that we are getting the comments for a specific post
+ * Specify that we are getting the comments for a specific page
  *
  * @method comments
  * @chainable

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -104,29 +104,19 @@ PostsRequest.prototype._pathValidators = {
 	 * @type {RegExp}
 	 */
 	action: /(meta|comments|revisions)/
-
-	// No validation for actionId: it can be numeric or a string
 };
 
 /**
  * Specify a post ID to query
  *
  * @method id
+ * @chainable
+ * @param {Number} id The ID of a post to retrieve
  * @return {PostsRequest} The PostsRequest instance (for chaining)
  */
 PostsRequest.prototype.id = function( id ) {
-	var action = this._path.action;
-
-	if ( ! action ) {
-		this._path.id = parseInt( id, 10 );
-		this._supportedMethods = [ 'head', 'get', 'put', 'post', 'delete' ];
-	} else if ( action === 'comments' ) {
-		this._path.actionId = parseInt( id, 10 );
-		this._supportedMethods = [ 'head', 'get', 'put', 'post', 'delete' ];
-	} else if ( action === 'types' ) {
-		this._path.actionId = id;
-		this._supportedMethods = [ 'head', 'get' ];
-	}
+	this._path.id = parseInt( id, 10 );
+	this._supportedMethods = [ 'head', 'get', 'put', 'post', 'delete' ];
 
 	return this;
 };
@@ -135,6 +125,7 @@ PostsRequest.prototype.id = function( id ) {
  * Specify that we are getting the comments for a specific post
  *
  * @method comments
+ * @chainable
  * @return {PostsRequest} The PostsRequest instance (for chaining)
  */
 PostsRequest.prototype.comments = function() {
@@ -144,12 +135,31 @@ PostsRequest.prototype.comments = function() {
 };
 
 /**
+ * Specify a particular comment to retrieve
+ * (forces action "comments")
+ *
+ * @method comment
+ * @chainable
+ * @param {Number} id The ID of the comment to retrieve
+ * @return {PostsRequest}
+ */
+PostsRequest.prototype.comment = function( id ) {
+	this._path.action = 'comments';
+	this._path.actionId = parseInt( id, 10 );
+	this._supportedMethods = [ 'head', 'get', 'delete' ];
+
+	return this;
+};
+
+/**
  * @method types
+ * @chainable
  * @return {PostsRequest} The PostsRequest instance (for chaining)
  */
 PostsRequest.prototype.types = function() {
 	this._path.action = 'types';
 	this._supportedMethods = [ 'head', 'get' ];
+
 	return this;
 };
 
@@ -157,21 +167,25 @@ PostsRequest.prototype.types = function() {
  * Specify that we are requesting the revisions for a specific post
  *
  * @method revisions
+ * @chainable
  * @return {PostsRequest} The PostsRequest instance (for chaining)
  */
 PostsRequest.prototype.revisions = function() {
 	this._path.action = 'revisions';
 	this._supportedMethods = [ 'head', 'get' ];
+
 	return this;
 };
 
 /**
  * @method statuses
+ * @chainable
  * @return {PostsRequest} The PostsRequest instance (for chaining)
  */
 PostsRequest.prototype.statuses = function() {
 	this._path.action = 'statuses';
 	this._supportedMethods = [ 'head', 'get' ];
+
 	return this;
 };
 

--- a/tests/lib/posts.js
+++ b/tests/lib/posts.js
@@ -134,8 +134,13 @@ describe( 'wp.posts', function() {
 		});
 
 		it( 'should create the URL for retrieving a specific comment', function() {
-			var path = posts.id( 1337 ).comments().id( 9001 )._renderURI();
+			var path = posts.id( 1337 ).comments().comment( 9001 )._renderURI();
 			expect( path ).to.equal( '/wp-json/posts/1337/comments/9001' );
+		});
+
+		it( 'should force the "comments" action when comment() is called', function() {
+			var path = posts.id( 2501 ).comment( 9 )._renderURI();
+			expect( path ).to.equal( '/wp-json/posts/2501/comments/9' );
 		});
 
 		it( 'should create the URL for retrieving the revisions for a specific post', function() {


### PR DESCRIPTION
`.id()` is now used exclusively for setting the ID of a post.
