### PR TITLE
Add wp.root() method to query custom endpoints

### DIFF
--- a/tests/wp.js
+++ b/tests/wp.js
@@ -9,6 +9,7 @@ var PostsRequest = require( '../lib/posts' );
 var TaxonomiesRequest = require( '../lib/taxonomies' );
 var TypesRequest = require( '../lib/types' );
 var UsersRequest = require( '../lib/users' );
+var CollectionRequest = require( '../lib/shared/collection-request' );
 var WPRequest = require( '../lib/shared/wp-request' );
 
 describe( 'wp', function() {
@@ -131,6 +132,53 @@ describe( 'wp', function() {
 			expect( request._options.endpoint ).to.equal( 'http://new-endpoint.com/' );
 			expect( request._options ).to.have.property( 'identifier' );
 			expect( request._options.identifier ).to.equal( 'some unique value' );
+		});
+
+	});
+
+	describe( '.root()', function() {
+
+		it( 'is defined', function() {
+			expect( site ).to.have.property( 'root' );
+			expect( site.root ).to.be.a( 'function' );
+		});
+
+		it( 'creates a get request against the root endpoint', function() {
+			site._options.endpoint = 'http://my.site.com/wp-json/';
+			var request = site.root();
+			expect( request._renderURI() ).to.equal( 'http://my.site.com/wp-json/' );
+		});
+
+		it( 'takes a "path" property to query a root-relative path', function() {
+			site._options.endpoint = 'http://my.site.com/wp-json/';
+			var request = site.root( 'custom/endpoint' );
+			expect( request._renderURI() ).to.equal( 'http://my.site.com/wp-json/custom/endpoint' );
+		});
+
+		it( 'creates a basic WPRequest if "collection" is unspecified or "false"', function() {
+			var pathRequest = site.root( 'some/relative/root' );
+			expect( pathRequest._template ).to.equal( 'some/relative/root' );
+			expect( pathRequest instanceof WPRequest ).to.be.true;
+			expect( pathRequest instanceof CollectionRequest ).to.be.false;
+		});
+
+		it( 'creates a CollectionRequest object if "collection" is "true"', function() {
+			var pathRequest = site.root( 'some/collection/endpoint', true );
+			expect( pathRequest._template ).to.equal( 'some/collection/endpoint' );
+			expect( pathRequest instanceof WPRequest ).to.be.true;
+			expect( pathRequest instanceof CollectionRequest ).to.be.true;
+		});
+
+		it( 'inherits options from the parent WP instance', function() {
+			var wp = new WP({
+				endpoint: 'http://cat.website.com/',
+				customOption: 'best method ever'
+			});
+			var request = wp.root( 'custom-path' );
+			expect( request._options ).to.have.property( 'endpoint' );
+			expect( request._options.endpoint ).to.equal( 'http://cat.website.com/' );
+			expect( request._options ).to.have.property( 'customOption' );
+			expect( request._options.customOption ).to.equal( 'best method ever' );
 		});
 
 	});

--- a/wp.js
+++ b/wp.js
@@ -28,6 +28,7 @@ var PostsRequest = require( './lib/posts' );
 var TaxonomiesRequest = require( './lib/taxonomies' );
 var TypesRequest = require( './lib/types' );
 var UsersRequest = require( './lib/users' );
+var CollectionRequest = require( './lib/shared/collection-request' );
 var WPRequest = require( './lib/shared/wp-request' );
 
 /**
@@ -194,6 +195,28 @@ WP.prototype.url = function( url ) {
 		endpoint: url
 	});
 	return new WPRequest( options );
+};
+
+/**
+ * Generate a query against an arbitrary path on the current endpoint. This is useful for
+ * requesting resources at custom WP-API endpoints, such as WooCommerce's `/products`.
+ *
+ * @method root
+ * @param {String} [relativePath] An endpoint-relative path to which to bind the request
+ * @param {Boolean} [collection] Whether to return a CollectionRequest or a vanilla WPRequest
+ * @return {CollectionRequest|WPRequest} A request object
+ */
+WP.prototype.root = function( relativePath, collection ) {
+	relativePath = relativePath || '';
+	collection = collection || false;
+	var options = extend( {}, this._options );
+	// Request should be
+	var request = collection ? new CollectionRequest( options ) : new WPRequest( options );
+
+	// Set the path template to the string passed in
+	request._template = relativePath;
+
+	return request;
 };
 
 module.exports = WP;


### PR DESCRIPTION
This is the first stab at defining behavior for #51; it's a little early to be adding this sort of behavior, but given that this library is unstable I feel that iterating on the idea quickly while it's top of mind will give us the best long-term results.

Usage for `wp.root`:

Create a basic `WPRequest` which, if submitted with `.get()`, would send a GET request to the URI `http://my.website.com/wp-json/custom/endpoint`:

``` javascript
var wp = new WP({ endpoint: 'http://my.website.com/wp-json' });
var request = wp.root( 'custom/endpoint' );
```

Create a `request` with all of the filtering methods of `CollectionRequest`, which would send a GET to `http://another-website.com/api/collection/endpoint`:

``` javascript
var wp = new WP({ 'http://another-website.com/api' });
var request = wp.root( 'collection/endpoint', true );
```

I am open to bikeshedding this syntax, but let's keep more theoretical discussion about how we want to handle custom endpoints long-term over in #51.
