### PR TITLE
Update generated API documentation for 0.2.2

### DIFF
--- a/docs/classes/CollectionRequest.html
+++ b/docs/classes/CollectionRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -1012,7 +1012,7 @@ This is used to store the query values for Type, Page &amp; Context</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -1142,7 +1142,7 @@ This is used to store the query values for Type, Page &amp; Context</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -1242,7 +1242,7 @@ This is used to store the query values for Type, Page &amp; Context</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1401,7 +1401,7 @@ This is used to store the query values for Type, Page &amp; Context</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1495,7 +1495,7 @@ This is used to store the query values for Type, Page &amp; Context</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -1985,7 +1985,7 @@ object, by setting the context to &quot;edit&quot;.</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -2369,7 +2369,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -2513,7 +2513,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -3057,7 +3057,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -3223,7 +3223,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -3869,7 +3869,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/classes/MediaRequest.html
+++ b/docs/classes/MediaRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -1130,7 +1130,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -1260,7 +1260,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -1360,7 +1360,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1516,7 +1516,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1610,7 +1610,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -2091,7 +2091,7 @@ object, by setting the context to &quot;edit&quot;.</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -2469,7 +2469,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -2613,7 +2613,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -3262,7 +3262,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -3428,7 +3428,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -4062,7 +4062,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/classes/PagesRequest.html
+++ b/docs/classes/PagesRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -1218,7 +1218,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -1348,7 +1348,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -1448,7 +1448,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1604,7 +1604,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1698,7 +1698,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -2374,7 +2374,7 @@ object, by setting the context to &quot;edit&quot;.</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -2752,7 +2752,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -2896,7 +2896,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -3627,7 +3627,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -3793,7 +3793,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -4508,7 +4508,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/classes/PostsRequest.html
+++ b/docs/classes/PostsRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -1221,7 +1221,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -1351,7 +1351,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -1451,7 +1451,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1607,7 +1607,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1701,7 +1701,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -2377,7 +2377,7 @@ object, by setting the context to &quot;edit&quot;.</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -2755,7 +2755,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -2899,7 +2899,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -3549,7 +3549,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -3715,7 +3715,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -4510,7 +4510,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/classes/TaxonomiesRequest.html
+++ b/docs/classes/TaxonomiesRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -1134,7 +1134,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -1264,7 +1264,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -1364,7 +1364,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1520,7 +1520,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1614,7 +1614,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -2095,7 +2095,7 @@ object, by setting the context to &quot;edit&quot;.</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -2473,7 +2473,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -2617,7 +2617,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -3152,7 +3152,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -3318,7 +3318,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -4129,7 +4129,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/classes/TypesRequest.html
+++ b/docs/classes/TypesRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -1013,7 +1013,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -1143,7 +1143,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -1243,7 +1243,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1399,7 +1399,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1493,7 +1493,7 @@
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -1974,7 +1974,7 @@ object, by setting the context to &quot;edit&quot;.</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -2352,7 +2352,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -2496,7 +2496,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -3031,7 +3031,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -3197,7 +3197,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -3831,7 +3831,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/classes/UsersRequest.html
+++ b/docs/classes/UsersRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -1135,7 +1135,7 @@ endpoint responds with a 401 error without authentication, so <code>users()</cod
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -1265,7 +1265,7 @@ endpoint responds with a 401 error without authentication, so <code>users()</cod
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -1365,7 +1365,7 @@ endpoint responds with a 401 error without authentication, so <code>users()</cod
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1521,7 +1521,7 @@ endpoint responds with a 401 error without authentication, so <code>users()</cod
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1615,7 +1615,7 @@ endpoint responds with a 401 error without authentication, so <code>users()</cod
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -2096,7 +2096,7 @@ object, by setting the context to &quot;edit&quot;.</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -2474,7 +2474,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -2618,7 +2618,7 @@ wp.filter( &#39;post_status&#39;, &#39;publish&#39; ).filter( &#39;category_name
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -3347,7 +3347,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -3513,7 +3513,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -4147,7 +4147,7 @@ retrieved from the response&#39;s .)</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/classes/WP.html
+++ b/docs/classes/WP.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/classes/WPRequest.html
+++ b/docs/classes/WPRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -741,7 +741,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l226"><code>lib&#x2F;shared&#x2F;wp-request.js:226</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l223"><code>lib&#x2F;shared&#x2F;wp-request.js:223</code></a>
         
         </p>
 
@@ -874,7 +874,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l173"><code>lib&#x2F;shared&#x2F;wp-request.js:173</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l170"><code>lib&#x2F;shared&#x2F;wp-request.js:170</code></a>
         
         </p>
 
@@ -977,7 +977,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l193"><code>lib&#x2F;shared&#x2F;wp-request.js:193</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l190"><code>lib&#x2F;shared&#x2F;wp-request.js:190</code></a>
         
         </p>
 
@@ -1058,7 +1058,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l208"><code>lib&#x2F;shared&#x2F;wp-request.js:208</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l205"><code>lib&#x2F;shared&#x2F;wp-request.js:205</code></a>
         
         </p>
 
@@ -1155,7 +1155,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l257"><code>lib&#x2F;shared&#x2F;wp-request.js:257</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l254"><code>lib&#x2F;shared&#x2F;wp-request.js:254</code></a>
         
         </p>
 
@@ -1301,7 +1301,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l349"><code>lib&#x2F;shared&#x2F;wp-request.js:349</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l346"><code>lib&#x2F;shared&#x2F;wp-request.js:346</code></a>
         
         </p>
 
@@ -1448,7 +1448,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l294"><code>lib&#x2F;shared&#x2F;wp-request.js:294</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l291"><code>lib&#x2F;shared&#x2F;wp-request.js:291</code></a>
         
         </p>
 
@@ -1595,7 +1595,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l365"><code>lib&#x2F;shared&#x2F;wp-request.js:365</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l362"><code>lib&#x2F;shared&#x2F;wp-request.js:362</code></a>
         
         </p>
 
@@ -1748,7 +1748,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l311"><code>lib&#x2F;shared&#x2F;wp-request.js:311</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l308"><code>lib&#x2F;shared&#x2F;wp-request.js:308</code></a>
         
         </p>
 
@@ -1917,7 +1917,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l330"><code>lib&#x2F;shared&#x2F;wp-request.js:330</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l327"><code>lib&#x2F;shared&#x2F;wp-request.js:327</code></a>
         
         </p>
 
@@ -2086,7 +2086,7 @@ Individual endpoint handlers specify their own subset of supported methods</p>
             
         
         
-        <a href="../files/lib_shared_wp-request.js.html#l381"><code>lib&#x2F;shared&#x2F;wp-request.js:381</code></a>
+        <a href="../files/lib_shared_wp-request.js.html#l378"><code>lib&#x2F;shared&#x2F;wp-request.js:378</code></a>
         
         </p>
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -2,7 +2,7 @@
     "project": {
         "name": "wordpress-rest-api",
         "description": "A client for interacting with the WordPress REST API",
-        "version": "0.2.1",
+        "version": "0.2.2",
         "url": "https://github.com/kadamwhite/wordpress-rest-api"
     },
     "files": {
@@ -1313,7 +1313,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 119,
+            "line": 116,
             "description": "Extract and return the body property from a superagent response object",
             "params": [
                 {
@@ -1332,7 +1332,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 129,
+            "line": 126,
             "description": "Extract and return the headers property from a superagent response object",
             "params": [
                 {
@@ -1351,7 +1351,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 139,
+            "line": 136,
             "description": "Check path parameter values against validation regular expressions",
             "params": [
                 {
@@ -1375,7 +1375,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 173,
+            "line": 170,
             "description": "Verify that the current request object supports a given HTTP verb",
             "access": "private",
             "tagname": "",
@@ -1397,7 +1397,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 193,
+            "line": 190,
             "description": "Validate & assemble a path string from the request object's _path",
             "access": "private",
             "tagname": "",
@@ -1413,7 +1413,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 208,
+            "line": 205,
             "description": "Parse the request's instance properties into a WordPress API request URI",
             "access": "private",
             "tagname": "",
@@ -1429,7 +1429,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 226,
+            "line": 223,
             "description": "Conditionally set basic authentication on a server request object",
             "itemtype": "method",
             "name": "_auth",
@@ -1458,7 +1458,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 257,
+            "line": 254,
             "description": "Set a requst to use authentication, and optionally provide auth credentials",
             "example": [
                 "\nIf auth credentials were already specified when the WP instance was created, calling\n`.auth` on the request chain will set that request to use the existing credentials:\n\n    request.auth().get...\n\nAlternatively, a username & password can be explicitly passed into `.auth`:\n\n    request.auth( 'username', 'password' ).get..."
@@ -1490,7 +1490,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 294,
+            "line": 291,
             "itemtype": "method",
             "name": "get",
             "async": 1,
@@ -1524,7 +1524,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 311,
+            "line": 308,
             "itemtype": "method",
             "name": "post",
             "async": 1,
@@ -1563,7 +1563,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 330,
+            "line": 327,
             "itemtype": "method",
             "name": "put",
             "async": 1,
@@ -1602,7 +1602,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 349,
+            "line": 346,
             "itemtype": "method",
             "name": "delete",
             "async": 1,
@@ -1636,7 +1636,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 365,
+            "line": 362,
             "itemtype": "method",
             "name": "head",
             "async": 1,
@@ -1670,7 +1670,7 @@
         },
         {
             "file": "lib/shared/wp-request.js",
-            "line": 381,
+            "line": 378,
             "description": "Calling .then on a query chain will invoke the query as a GET and return a promise",
             "itemtype": "method",
             "name": "then",
@@ -3055,15 +3055,15 @@
         },
         {
             "message": "Missing item type\nExtract and return the body property from a superagent response object",
-            "line": " lib/shared/wp-request.js:119"
+            "line": " lib/shared/wp-request.js:116"
         },
         {
             "message": "Missing item type\nExtract and return the headers property from a superagent response object",
-            "line": " lib/shared/wp-request.js:129"
+            "line": " lib/shared/wp-request.js:126"
         },
         {
             "message": "Missing item type\nCheck path parameter values against validation regular expressions",
-            "line": " lib/shared/wp-request.js:139"
+            "line": " lib/shared/wp-request.js:136"
         },
         {
             "message": "Missing item type\nSorted list of private WP_Query variables, requiring authentication\nThis may be used for a whitelist soon, but at present please consider it\nto be simply documentation.\n\nDocumentation:\n\n- WP_Query parameters: http://codex.wordpress.org/Class_Reference/WP_Query\n- Privat query variables: WordPress core, wp-includes/class-wp.php\n\nNote: posts_per_page is a private query varaible within WordPress, but is\nexplicitly exposed for public querying within the WP API so it exists in\nthe list within public-query-vars.js",

--- a/docs/files/lib_media.js.html
+++ b/docs/files/lib_media.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_pages.js.html
+++ b/docs/files/lib_pages.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_posts.js.html
+++ b/docs/files/lib_posts.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_shared_collection-request.js.html
+++ b/docs/files/lib_shared_collection-request.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_shared_wp-request.js.html
+++ b/docs/files/lib_shared_wp-request.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>
@@ -203,17 +203,14 @@ function invokeAndPromisify( request, callback, transform ) {
 		// Fire off the result
 		request.end(function( err, result ) {
 
-			// Invoke the callback (if provided), to conform to standard Node pattern
-			callback( err, transform( result ) );
-
 			// Return the results as a promise
 			if ( err || result.error ) {
 				reject( err || result.error );
 			} else {
-				resolve( transform( result ) );
+				resolve( result );
 			}
 		});
-	});
+	}).then(transform).nodeify(callback);
 }
 
 /**

--- a/docs/files/lib_taxonomies.js.html
+++ b/docs/files/lib_taxonomies.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_types.js.html
+++ b/docs/files/lib_types.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_users.js.html
+++ b/docs/files/lib_users.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_var_private-query-vars.js.html
+++ b/docs/files/lib_var_private-query-vars.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/lib_var_public-query-vars.js.html
+++ b/docs/files/lib_var_public-query-vars.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/files/wp.js.html
+++ b/docs/files/wp.js.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/CollectionRequest.html
+++ b/docs/modules/CollectionRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/MediaRequest.html
+++ b/docs/modules/MediaRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/PagesRequest.html
+++ b/docs/modules/PagesRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/PostsRequest.html
+++ b/docs/modules/PostsRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/TaxonomiesRequest.html
+++ b/docs/modules/TaxonomiesRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/TypesRequest.html
+++ b/docs/modules/TypesRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/UsersRequest.html
+++ b/docs/modules/UsersRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/WP.html
+++ b/docs/modules/WP.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>

--- a/docs/modules/WPRequest.html
+++ b/docs/modules/WPRequest.html
@@ -16,7 +16,7 @@
             <div class="project-title">
                 
                 
-                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.1</span>
+                    <h1 class="project-name">wordpress-rest-api</h1> <span class="project-version">0.2.2</span>
                 
                 
                     <p class="description">A client for interacting with the WordPress REST API</p>


### PR DESCRIPTION
No API changed, but we should keep the version numbers consistent between the gh-pages docs branch and the core library
