### PR TITLE
Alter .path method on pages collections to not use endpoint/posts/<path>

### DIFF
--- a/lib/pages.js
+++ b/lib/pages.js
@@ -186,10 +186,9 @@ PagesRequest.prototype.revisions = function() {
  * @return {PagesRequest} The PagesRequest instance (for chaining)
  */
 PagesRequest.prototype.path = function( path ) {
-	this._path.id = path;
-	this._supportedMethods = [ 'head', 'get', 'put', 'post', 'delete' ];
-
-	return this;
+	return this.filter({
+		pagename: path
+	});
 };
 
 module.exports = PagesRequest;

--- a/tests/lib/pages.js
+++ b/tests/lib/pages.js
@@ -117,8 +117,8 @@ describe( 'wp.pages', function() {
 			});
 
 			it( 'should create the URL for retrieving a post by path', function() {
-				var path = pages.path( 'some/nested/page' )._renderURI();
-				expect( path ).to.equal( '/wp-json/pages/some/nested/page' );
+				var path = pages.path( 'nested/page' )._renderURI();
+				expect( path ).to.equal( '/wp-json/pages?filter%5Bpagename%5D=nested%2Fpage' );
 			});
 
 			it( 'should update the supported methods when setting ID', function() {
@@ -127,10 +127,10 @@ describe( 'wp.pages', function() {
 				expect( _supportedMethods ).to.equal( 'delete|get|head|post|put' );
 			});
 
-			it( 'should update the supported methods when setting Path', function() {
+			it( 'should not update the supported methods when setting Path', function() {
 				pages.path( 'page/path' );
 				var _supportedMethods = pages._supportedMethods.sort().join( '|' );
-				expect( _supportedMethods ).to.equal( 'delete|get|head|post|put' );
+				expect( _supportedMethods ).to.equal( 'get|head|post' );
 			});
 
 		});


### PR DESCRIPTION
The ability for the API to handle arbitrary paths below the posts endpoint is going away: it is an antipattern over filtering the collection by pagename, which is the recommended approach (per nacin). Fixes #73.

Note: the available methods do not change because we're now getting a _collection_ of pages back, rather than a final post object.
