### PR TITLE
Implement pagination parsing for collection responses (ref #76)

### DIFF
--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -9,6 +9,8 @@
 var Promise = require( 'bluebird' );
 var agent = require( 'superagent' );
 var Route = require( 'route-parser' );
+var parseLinkHeader = require( 'li' ).parse;
+var url = require( 'url' );
 
 /**
  * WPRequest is the base API request object constructor
@@ -114,13 +116,19 @@ function invokeAndPromisify( request, callback, transform ) {
 }
 
 /**
- * Extract and return the body property from a superagent response object
+ * Return the body of the request, augmented with pagination information if the
+ * result is a paged collection.
  *
- * @param {Object} result The results from the HTTP request
- * @return {Object} The "body" property of the result
+ * @method returnBody
+ * @private
+ * @param result {Object} The results from the HTTP request
+ * @return {Object} The "body" property of the result, conditionally augmented with
+ *                  pagination information if the result is a partial collection.
  */
 function returnBody( result ) {
-	return result.body;
+	/* jshint validthis:true */
+	var endpoint = this._options.endpoint;
+	return paginateResponse( result, endpoint ).body;
 }
 
 /**
@@ -162,6 +170,86 @@ function validatePath( pathValues, validators ) {
 
 	// If validation passed, return the pathValues object
 	return pathValues;
+}
+
+// Pagination-Related Helpers
+// ==========================
+
+/**
+ * Combine the API endpoint root URI and link URI into a valid request URL.
+ * Endpoints are generally a full path to the JSON API's root endpoint, such
+ * as `website.com/wp-json`: the link headers, however, are returned as root-
+ * relative paths. Concatenating these would generate a URL such as
+ * `website.com/wp-json/wp-json/posts?page=2`: we must intelligently merge the
+ * URI strings in order to generate a valid new request URL.
+ *
+ * @param endpoint {String} The endpoint URL for the REST API root
+ * @param linkPath {String} A root-relative link path to an API request
+ * @returns {String} The full URL path to the provided link
+ */
+function mergeUrl( endpoint, linkPath ) {
+	var request = url.parse( endpoint );
+	linkPath = url.parse( linkPath, true );
+
+	// Overwrite relevant request URL object properties with the link's values
+	request.query = linkPath.query;
+	request.pathname = linkPath.pathname;
+
+	// Reassemble and return the merged URL
+	return url.format(request);
+}
+
+/**
+ * If the response is not paged, return the body as-is. If pagination
+ * information is present in the response headers, parse those headers into
+ * a custom `_paging` property on the response body. `_paging` contains links
+ * to the previous and next pages in the collection, as well as metadata
+ * about the size and number of pages in the collection.
+ *
+ * The structure of the `_paging` property is as follows:
+ *
+ * - `total` {Integer} The total number of records in the collection
+ * - `totalPages` {Integer} The number of pages available
+ * - `links` {Object} The parsed "links" headers, separated into individual URI strings
+ * - `next` {WPRequest} A WPRequest object bound to the "next" page (if page exists)
+ * - `prev` {WPRequest} A WPRequest object bound to the "previous" page (if page exists)
+ *
+ * @param result {Object} The response object from the HTTP request
+ * @param endpoint {String} The base URL of the requested API endpoint
+ * @returns {Object} The body of the HTTP request, conditionally augmented with
+ *                   pagination metadata
+ */
+function paginateResponse( result, endpoint ) {
+	if ( ! result.headers || ! result.headers['x-wp-totalpages'] ) {
+		// No paging: return as-is
+		return result;
+	}
+
+	// Decode the link header object
+	var links = parseLinkHeader( result.headers.link );
+
+	// Store pagination data from response headers on the response collection
+	result.body._paging = {
+		total: result.headers['x-wp-total'],
+		totalPages: result.headers['x-wp-totalpages'],
+		links: links
+	};
+
+	// Create a WPRequest instance pre-bound to the "next" page, if available
+	if ( links.next ) {
+		result.body._paging.next = new WPRequest({
+			endpoint: mergeUrl( endpoint, links.next )
+		});
+	}
+
+	// Create a WPRequest instance pre-bound to the "prev" page, if available
+	if ( links.prev ) {
+		result.body._paging.prev = new WPRequest({
+			endpoint: mergeUrl( endpoint, links.prev )
+		});
+	}
+
+	return result;
 }
 
 // Prototype Methods
@@ -302,7 +390,7 @@ WPRequest.prototype.get = function( callback ) {
 
 	var request = this._auth( agent.get( url ) );
 
-	return invokeAndPromisify( request, callback, returnBody );
+	return invokeAndPromisify( request, callback, returnBody.bind( this ) );
 };
 
 /**
@@ -321,7 +409,7 @@ WPRequest.prototype.post = function( data, callback ) {
 
 	var request = this._auth( agent.post( url ), true ).send( data );
 
-	return invokeAndPromisify( request, callback, returnBody );
+	return invokeAndPromisify( request, callback, returnBody.bind( this ) );
 };
 
 /**
@@ -340,7 +428,7 @@ WPRequest.prototype.put = function( data, callback ) {
 
 	var request = this._auth( agent.put( url ), true ).send( data );
 
-	return invokeAndPromisify( request, callback, returnBody );
+	return invokeAndPromisify( request, callback, returnBody.bind( this ) );
 };
 
 /**
@@ -356,7 +444,7 @@ WPRequest.prototype.delete = function( callback ) {
 	var url = this._renderURI();
 	var request = this._auth( agent.del( url ), true );
 
-	return invokeAndPromisify( request, callback, returnBody );
+	return invokeAndPromisify( request, callback, returnBody.bind( this ) );
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "bluebird": "^2.1.3",
+    "li": "^1.0.0",
     "lodash": "^2.4.1",
     "node.extend": "^1.0.10",
     "route-parser": "0.0.2",


### PR DESCRIPTION
This implementation follows the structure outlined in the discussion of #76: parse the header information, and use it to augment the response collection. The presence or absence of `._paging` can therefore be used to quickly assess whether the response collection is complete, or just one page's worth.

I ended up not taking the approach of implementing this as a drop-in method to mutate the response data, as I needed pagination handling now and we have more discussion to do before we go forward with the response collection augmentation interface. There was also a question of whether that interface would be exposed pre-returnBody, or after it; if we went with the latter, there would be no way to access header information.

We've opened a conversation with @rmccue about how Pagination may evolve within the ReST API plugin; this solution will evolve along with the plugin itself, at least up until the API hits core.
