### PR TITLE
Fix exception when fetching empty collections

### DIFF
--- a/lib/shared/wp-request.js
+++ b/lib/shared/wp-request.js
@@ -220,7 +220,14 @@ function mergeUrl( endpoint, linkPath ) {
  *                   pagination metadata
  */
 function paginateResponse( result, endpoint ) {
-	if ( ! result.headers || ! result.headers['x-wp-totalpages'] ) {
+	if ( ! result.headers || ! result.headers.link ) {
+		// No headers: return as-is
+		return result;
+	}
+
+	var totalPages = result.headers['x-wp-totalpages'];
+
+	if ( ! totalPages || totalPages === '0' || totalPages === '1' ) {
 		// No paging: return as-is
 		return result;
 	}
@@ -231,7 +238,7 @@ function paginateResponse( result, endpoint ) {
 	// Store pagination data from response headers on the response collection
 	result.body._paging = {
 		total: result.headers['x-wp-total'],
-		totalPages: result.headers['x-wp-totalpages'],
+		totalPages: totalPages,
 		links: links
 	};
 

--- a/tests/lib/shared/wp-request.js
+++ b/tests/lib/shared/wp-request.js
@@ -402,12 +402,36 @@ describe( 'WPRequest', function() {
 				});
 			});
 
-			it( 'passes data through unchanged if no pagination headers are present', function() {
+			it( 'passes data through unchanged if no headers are present', function() {
 				mockAgent._response = {
-					headers: {},
 					body: 'some object'
 				};
-				wpRequest.then(function(parsedResult) {
+				return wpRequest.then(function(parsedResult) {
+					expect( parsedResult ).to.equal( 'some object' );
+					expect( parsedResult ).not.to.have.property( '_paging' );
+				});
+			});
+
+			it( 'passes data through unchanged if header has no link property', function() {
+				mockAgent._response = {
+					headers: {
+						'x-wp-totalpages': '0',
+						'x-wp-total': '0'
+					},
+					body: 'some object'
+				};
+				return wpRequest.then(function(parsedResult) {
+					expect( parsedResult ).to.equal( 'some object' );
+					expect( parsedResult ).not.to.have.property( '_paging' );
+				});
+			});
+
+			it( 'passes data through unchanged if pagination header is unset or empty', function() {
+				mockAgent._response = {
+					headers: { link: '' },
+					body: 'some object'
+				};
+				return wpRequest.then(function(parsedResult) {
 					expect( parsedResult ).to.equal( 'some object' );
 					expect( parsedResult ).not.to.have.property( '_paging' );
 				});


### PR DESCRIPTION
This crops up especially easily with search queries: no results, no paging; `x-wp-totalpages` got set to "0", a string, so the previous null check failed to catch the lack of pagination and an exception occurred when parsing the non-existent link header.

Example error:

```
Possibly unhandled TypeError: Cannot call method 'split' of undefined
    at parse (~/wordpress-rest-api/node_modules/li/lib/index.js:15:33)
    at paginateResponse (~/wordpress-rest-api/lib/shared/wp-request.js:229:14)
    at PostsRequest.returnBody (~/wordpress-rest-api/lib/shared/wp-request.js:131:9)
    [ ... ]
```

This PR breaks the existing no-paging => pass-through tests into three separate tests to validate different scenarios, and adds additional checks to return before the exception would occur.
