### PR TITLE
Do not manually encode parameters with array syntax (fixes #89)

### DIFF
--- a/lib/shared/collection-request.js
+++ b/lib/shared/collection-request.js
@@ -9,7 +9,7 @@ var WPRequest = require( './wp-request' );
 var _ = require( 'lodash' );
 var extend = require( 'node.extend' );
 var inherit = require( 'util' ).inherits;
-var formatUrl = require( 'url' ).format;
+var qs = require('qs');
 
 /**
  * CollectionRequest extends WPRequest with properties & methods for filtering collections
@@ -107,13 +107,13 @@ inherit( CollectionRequest, WPRequest );
  * All terms listed in the arrays will be required (AND behavior).
  *
  * @example
- *    prepareTaxonomies({
- *        tag: [ 'tag1 ', 'tag2' ], // by term slug
- *        cat: [ 7 ] // by term ID
- *    }) === {
- *        tag: 'tag1+tag2',
- *        cat: '7'
- *    }
+ *     prepareTaxonomies({
+ *         tag: [ 'tag1 ', 'tag2' ], // by term slug
+ *         cat: [ 7 ] // by term ID
+ *     }) === {
+ *         tag: 'tag1+tag2',
+ *         cat: '7'
+ *     }
  *
  * @param {Object} taxonomyFilters An object of taxonomy term arrays, keyed by taxonomy name
  * @return {Object} An object of prepareFilters-ready query arg and query param value pairs
@@ -132,79 +132,6 @@ function prepareTaxonomies( taxonomyFilters ) {
 		}).join( '+' );
 		return result;
 	}, {});
-}
-
-/**
- * Process the _params object into valid API-ready query parameters.
- *
- * @param {Object} params The _params object to process
- * @return {Object} An object of WP-API non-filter query parameter key-value pairs
- */
-function prepareParameters( params ) {
-	return _.reduce( params, function( result, value, key ) {
-		// No need for array syntax if the value array has only a single member
-		if ( _.isArray( value ) && 1 === value.length ) {
-			value = _.first( value );
-		}
-
-		// If the value was not (or is no longer) an array, set it as-is
-		if ( ! _.isArray( value ) ) {
-			result[ key ] = value;
-		} else {
-			// Use Array-syntax for multiple values (specifically used for the "types" parameter)
-			key = key + '[]';
-			result[ key ] = value;
-		}
-
-		return result;
-	}, {});
-}
-
-/**
- * Process an array of filter keys and values into API-ready query parameter syntax.
- *
- * @example
- *    prepareFilters({
- *        tag: 'tag1+tag2',
- *        category_name: 'news'
- *    }) === {
- *        'filter[tag]': 'tag1+tag2',
- *        'filter[category_name]': 'news'
- *    }
- *
- * @param {Object} filters An object of filter values, keyed by filter parameter name
- * @return {Object} An object of WP-API filter query parameter key-value pairs
- */
-function prepareFilters( filters ) {
-	return _.reduce( filters, function( result, value, key ) {
-		// Filters are specified via query parameter Array syntax
-		key = 'filter[' + key + ']';
-		result[ key ] = value;
-		return result;
-	}, {});
-}
-
-/**
- * Generate a complete query string from the provided array of query parameters.
- *
- * @example
- *     generateQueryString({
- *         'filter[tag]': 'tag1',
- *         'filter[post_status': 'publish',
- *         'type': 'cpt_item'
- *     }) === '?filter%5Btag%5D=tag1&filter%5Bpost_status=publish&type=cpt_item'
- *
- * @param {Object} queryParams A hash of query parameter keys and values
- * @return {String} A complete, rendered query string
- */
-function generateQueryString( queryParams ) {
-	// Sort the object properties by alphabetical order
-	// (consistent property ordering means easier caching of request URIs)
-	var keys = _.keys( queryParams ).sort();
-	queryParams = _.pick( queryParams, keys );
-	return formatUrl({
-		query: queryParams
-	});
 }
 
 /**
@@ -229,6 +156,12 @@ function alphaNumericSort( a, b ) {
 
 /**
  * Process the endpoint query's filter objects into a valid query string.
+ * Nested objects and Array properties are rendered with indexed array syntax.
+ *
+ * @example
+ *     _renderQuery({ p1: 'val1', p2: 'val2' });  // ?p1=val1&p2=val2
+ *     _renderQuery({ obj: { prop: 'val' } });    // ?obj[prop]=val
+ *     _renderQuery({ arr: [ 'val1', 'val2' ] }); // ?arr[0]=val1&arr[1]=val2
  *
  * @private
  *
@@ -236,17 +169,23 @@ function alphaNumericSort( a, b ) {
  * @return {String} A query string representing the specified filter parameters
  */
 CollectionRequest.prototype._renderQuery = function() {
-	// Prepare the taxonomies to be converted into filter values
+	// Build the full query parameters object
+	var queryParams = extend( {}, this._params );
+
+	// Prepare the taxonomies and merge with other filter values
 	var taxonomies = prepareTaxonomies( this._taxonomyFilters );
+	queryParams.filter = extend( {}, this._filters, taxonomies );
 
-	// Format all filter query parameters using the filter array syntax
-	var filters = prepareFilters( extend( {}, this._filters, taxonomies ) );
+	// Parse query parameters object into a query string, sorting the object
+	// properties by alphabetical order (consistent property ordering can make
+	// for easier caching of request URIs)
+	var queryString = qs.stringify( queryParams )
+		.split( '&' )
+		.sort()
+		.join( '&' );
 
-	// Get any non-filter query parameters
-	var parameters = prepareParameters( this._params );
-
-	// Append the non-filter parameters to the object and return a generated query string
-	return generateQueryString( extend( {}, filters, parameters ) );
+	// Prepend a "?" if a query is present, and return
+	return ( queryString === '' ) ? '' : '?' + queryString;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "li": "^1.0.0",
     "lodash": "^2.4.1",
     "node.extend": "^1.0.10",
+    "qs": "^2.3.3",
     "route-parser": "0.0.2",
     "superagent": "^0.18.0"
   },

--- a/tests/lib/posts.js
+++ b/tests/lib/posts.js
@@ -140,7 +140,7 @@ describe( 'wp.posts', function() {
 				'page'
 			]);
 
-			var uri = '/wp-json/posts?type%5B%5D=cpt1&type%5B%5D=cpt2&type%5B%5D=page';
+			var uri = '/wp-json/posts?type%5B0%5D=cpt1&type%5B1%5D=cpt2&type%5B2%5D=page';
 			expect( posts._renderURI() ).to.equal( uri );
 		});
 


### PR DESCRIPTION
superagent was transforming the (already-formatted)

```
type[]=type1&type[]=type2
```

portion of the URL into

```
type[][0]=type1&type[][1]=type2
```

This syntax is invalid, and results in an error on the WP side.

By removing the prepareParameters method, we eliminate all of our custom
handling for array syntax, and trust that superagent will take care of it.

TODO: Add a test suite to verify this integration point.
