### PR TITLE
Update code style build task dependency: package was renamed

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-yuidoc": "^0.5.2",
-    "grunt-jscs-checker": "^0.5.1",
+    "grunt-jscs": "^1.0.0",
     "grunt-newer": "^0.7.0",
     "grunt-simple-mocha": "^0.4.0",
     "jscs-stylish": "^0.3.0",


### PR DESCRIPTION
This suppresses a warning on `npm install`
