### PR TITLE
Add a build process to create a bundle for browser use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ index.html
 
 # Webstorm config folder
 .idea
+
+# Built files (for use in browser)
+browser/

--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -7,7 +7,7 @@
 'use strict';
 
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
-var Promise = require( 'bluebird' );
+var Promise = require( 'es6-promise' ).Promise;
 var agent = require( 'superagent' );
 var parseLinkHeader = require( 'parse-link-header' );
 

--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -11,11 +11,13 @@ var agent = require( 'superagent' );
 var parseLinkHeader = require( 'li' ).parse;
 var url = require( 'url' );
 var qs = require( 'qs' );
-var _ = require( 'lodash' );
+var _reduce = require( 'lodash.reduce' );
+var _union = require( 'lodash.union' );
+var _unique = require( 'lodash.uniq' );
 var extend = require( 'node.extend' );
 
-// TODO: reorganize library so that this has a better home
 var alphaNumericSort = require( '../util/alphanumeric-sort' );
+var keyValToObj = require( '../util/key-val-to-obj' );
 
 /**
  * WPRequest is the base API request object constructor
@@ -172,13 +174,13 @@ function prepareTaxonomies( taxonomyFilters ) {
 		return {};
 	}
 
-	return _.reduce( taxonomyFilters, function( result, terms, key ) {
+	return _reduce( taxonomyFilters, function( result, terms, key ) {
 		// Trim whitespace and concatenate multiple terms with +
 		result[ key ] = terms.map(function( term ) {
 			// Coerce term into a string so that trim() won't fail
-			term = term + '';
-			return term.trim().toLowerCase();
+			return ( term + '' ).trim().toLowerCase();
 		}).join( '+' );
+
 		return result;
 	}, {});
 }
@@ -204,7 +206,7 @@ function populated( obj ) {
 	}
 	return Object.keys( obj ).reduce(function( values, key ) {
 		var val = obj[ key ];
-		if ( ! _.isUndefined( val ) && ! _.isNull( val ) && val !== '' ) {
+		if ( val !== undefined && val !== null && val !== '' ) {
 			values[ key ] = val;
 		}
 		return values;
@@ -464,15 +466,15 @@ WPRequest.prototype.validatePath = function() {
 WPRequest.prototype.param = function( props, value, merge ) {
 	merge = merge || false;
 
-	if ( ! props || _.isString( props ) && typeof value === 'undefined' ) {
+	if ( ! props || typeof props === 'string' && value === undefined ) {
 		// We have no property to set, or no value to set for that property
 		return this;
 	}
 
 	// We can use the same iterator function below to handle explicit key-value
 	// pairs if we convert them into to an object we can iterate over:
-	if ( _.isString( props ) ) {
-		props = _.zipObject([[ props, value ]]);
+	if ( typeof props === 'string' ) {
+		props = keyValToObj( props, value );
 	}
 
 	// Iterate through the properties
@@ -484,8 +486,8 @@ WPRequest.prototype.param = function( props, value, merge ) {
 		if ( ! currentVal || ! merge ) {
 
 			// Arrays should be de-duped and sorted
-			if ( _.isArray( value ) ) {
-				value = _.unique( value ).sort( alphaNumericSort );
+			if ( Array.isArray( value ) ) {
+				value = _unique( value ).sort( alphaNumericSort );
 			}
 
 			// Set the value
@@ -496,16 +498,16 @@ WPRequest.prototype.param = function( props, value, merge ) {
 		}
 
 		// value and currentVal must both be arrays in order to merge
-		if ( ! _.isArray( currentVal ) ) {
+		if ( ! Array.isArray( currentVal ) ) {
 			currentVal = [ currentVal ];
 		}
 
-		if ( ! _.isArray( value ) ) {
+		if ( ! Array.isArray( value ) ) {
 			value = [ value ];
 		}
 
 		// Concat the new values onto the old (and sort)
-		this._params[ key ] = _.union( currentVal, value ).sort( alphaNumericSort );
+		this._params[ key ] = _union( currentVal, value ).sort( alphaNumericSort );
 	}.bind( this ));
 
 	return this;

--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -204,8 +204,7 @@ function populated( obj ) {
 	if ( ! obj ) {
 		return obj;
 	}
-	return Object.keys( obj ).reduce(function( values, key ) {
-		var val = obj[ key ];
+	return _reduce( obj, function( values, val, key ) {
 		if ( val !== undefined && val !== null && val !== '' ) {
 			values[ key ] = val;
 		}

--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -6,7 +6,7 @@
  */
 
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
-var Promise = require( 'bluebird' );
+var Promise = require( 'es6-promise' ).Promise;
 var agent = require( 'superagent' );
 var parseLinkHeader = require( 'li' ).parse;
 var url = require( 'url' );
@@ -75,22 +75,9 @@ function WPRequest( options ) {
 // Private helper methods
 // ======================
 
-/** No-op function for use within ensureFunction() */
-function noop() {}
-
 /** Identity function for use within invokeAndPromisify() */
 function identity( value ) {
 	return value;
-}
-
-/**
- * If fn is a function, return it; else, return a no-op function
- *
- * @param {Function|undefined} fn A WPRequest request callback
- * @return {Function} The provided callback function or a no-op
- */
-function ensureFunction( fn ) {
-	return ( typeof fn === 'function' ) ? fn : noop;
 }
 
 /**
@@ -103,7 +90,6 @@ function ensureFunction( fn ) {
  * @return {Promise} A promise to the superagent request
  */
 function invokeAndPromisify( request, callback, transform ) {
-	callback = ensureFunction( callback );
 
 	return new Promise(function( resolve, reject ) {
 		// Fire off the result
@@ -116,7 +102,22 @@ function invokeAndPromisify( request, callback, transform ) {
 				resolve( result );
 			}
 		});
-	}).then( transform ).nodeify( callback );
+	}).then( transform ).then(function( result ) {
+		// If a node-style callback was provided, call it, but also return the
+		// result value for use via the returned Promise
+		if ( callback && typeof callback === 'function' ) {
+			callback( null, result );
+		}
+		return result;
+	}, function( err ) {
+		// If a callback was provided, ensure it is called with the error; otherwise
+		// re-throw the error so that it can be handled by a Promise .catch or .then
+		if ( callback && typeof callback === 'function' ) {
+			callback( err );
+		} else {
+			throw err;
+		}
+	});
 }
 
 /**

--- a/lib/data/simplify-object.js
+++ b/lib/data/simplify-object.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _reduce = require( 'lodash.reduce' );
+
 /**
  * Walk through the keys and values of a provided object, removing any properties
  * which would be inessential to the generation of the route tree used to deduce
@@ -25,7 +27,7 @@ function simplifyObject( obj ) {
 
 	// Reduce through objects to run each property through simplifyObject
 	if ( typeof obj === 'object' ) {
-		return Object.keys( obj ).reduce(function( newObj, key ) {
+		return _reduce( obj, function( newObj, val, key ) {
 			// Omit _links objects entirely
 			if ( key === '_links' ) {
 				return newObj;
@@ -34,9 +36,9 @@ function simplifyObject( obj ) {
 			// If the key is "args", omit all keys of second-level descendants
 			// other than "required"
 			if ( key === 'args' ) {
-				newObj.args = Object.keys( obj.args ).reduce(function( slimArgs, arg ) {
-					slimArgs[ arg ] = {
-						required: obj.args[ arg ].required
+				newObj.args = _reduce( val, function( slimArgs, argVal, argKey ) {
+					slimArgs[ argKey ] = {
+						required: argVal.required
 					};
 					return slimArgs;
 				}, {});

--- a/lib/endpoint-factories.js
+++ b/lib/endpoint-factories.js
@@ -4,6 +4,7 @@
  * @module parseRouteString
  */
 
+var _reduce = require( 'lodash.reduce' );
 var extend = require( 'node.extend' );
 var createResourceHandlerSpec = require( './resource-handler-spec' ).create;
 var createEndpointRequest = require( './endpoint-request' ).create;
@@ -23,13 +24,12 @@ var createEndpointRequest = require( './endpoint-request' ).create;
  */
 function generateEndpointFactories( routesByNamespace ) {
 
-	return Object.keys( routesByNamespace ).reduce(function( namespaces, namespace ) {
-		var routeDefinitions = routesByNamespace[ namespace ];
+	return _reduce( routesByNamespace, function( namespaces, routeDefinitions, namespace ) {
 
 		// Create
-		namespaces[ namespace ] = Object.keys( routeDefinitions ).reduce(function( handlers, resource ) {
+		namespaces[ namespace ] = _reduce( routeDefinitions, function( handlers, routeDef, resource ) {
 
-			var handlerSpec = createResourceHandlerSpec( routeDefinitions[ resource ], resource );
+			var handlerSpec = createResourceHandlerSpec( routeDef, resource );
 
 			var EndpointRequest = createEndpointRequest( handlerSpec, resource, namespace );
 

--- a/lib/mixins/filters.js
+++ b/lib/mixins/filters.js
@@ -7,9 +7,11 @@
  *
  * @module filters
  */
-var _ = require( 'lodash' );
+var _unique = require( 'lodash.uniq' );
 var extend = require( 'node.extend' );
+
 var alphaNumericSort = require( '../util/alphanumeric-sort' );
+var keyValToObj = require( '../util/key-val-to-obj' );
 
 var filterMixins = {};
 
@@ -43,14 +45,14 @@ var filterMixins = {};
 filterMixins.filter = function( props, value ) {
 	/* jshint validthis:true */
 
-	if ( ! props || _.isString( props ) && typeof value === 'undefined' ) {
+	if ( ! props || typeof props === 'string' && value === undefined ) {
 		// We have no filter to set, or no value to set for that filter
 		return this;
 	}
 
 	// convert the property name string `props` and value `value` into an object
-	if ( _.isString( props ) ) {
-		props = _.zipObject([[ props, value ]]);
+	if ( typeof props === 'string' ) {
+		props = keyValToObj( props, value );
 	}
 
 	this._filters = extend( this._filters, props );
@@ -69,17 +71,17 @@ filterMixins.filter = function( props, value ) {
  */
 filterMixins.taxonomy = function( taxonomy, term ) {
 	/* jshint validthis:true */
-	var termIsArray = _.isArray( term );
+	var termIsArray = Array.isArray( term );
 	var termIsNumber = termIsArray ?
 		term.reduce(function( allAreNumbers, term ) {
-			return allAreNumbers && _.isNumber( term );
+			return allAreNumbers && typeof term === 'number';
 		}, true ) :
-		_.isNumber( term );
+		typeof term === 'number';
 	var termIsString = termIsArray ?
 		term.reduce(function( allAreStrings, term ) {
-			return allAreStrings && _.isString( term );
+			return allAreStrings && typeof term === 'string';
 		}, true ) :
-		_.isString( term );
+		typeof term === 'string';
 	var taxonomyTerms;
 
 	if ( ! termIsString && ! termIsNumber ) {
@@ -112,7 +114,7 @@ filterMixins.taxonomy = function( taxonomy, term ) {
 		.sort( alphaNumericSort );
 
 	// De-dupe
-	this._taxonomyFilters[ taxonomy ] = _.unique( taxonomyTerms, true );
+	this._taxonomyFilters[ taxonomy ] = _unique( taxonomyTerms, true );
 
 	return this;
 };
@@ -168,7 +170,7 @@ filterMixins.year = function( year ) {
 filterMixins.month = function( month ) {
 	/* jshint validthis:true */
 	var monthDate;
-	if ( _.isString( month ) ) {
+	if ( typeof month === 'string' ) {
 		// Append a arbitrary day and year to the month to parse the string into a Date
 		monthDate = new Date( Date.parse( month + ' 1, 2012' ) );
 
@@ -182,7 +184,7 @@ filterMixins.month = function( month ) {
 	}
 
 	// If month is a Number, add the monthnum filter to the request
-	if ( _.isNumber( month ) ) {
+	if ( typeof month === 'number' ) {
 		return filterMixins.filter.call( this, 'monthnum', month );
 	}
 

--- a/lib/mixins/parameters.js
+++ b/lib/mixins/parameters.js
@@ -8,7 +8,6 @@
  *
  * @module filters
  */
-var _ = require( 'lodash' );
 
 var parameterMixins = {};
 
@@ -104,14 +103,14 @@ parameterMixins.search = function( searchString ) {
  */
 parameterMixins.author = function( author ) {
 	/* jshint validthis:true */
-	if ( typeof author === 'undefined' ) {
+	if ( author === undefined ) {
 		return this;
 	}
-	if ( _.isString( author ) ) {
+	if ( typeof author === 'string' ) {
 		this.param( 'author', null );
 		return filter.call( this, 'author_name', author );
 	}
-	if ( _.isNumber( author ) ) {
+	if ( typeof author === 'number' ) {
 		filter.call( this, 'author_name', null );
 		return this.param( 'author', author );
 	}

--- a/lib/path-part-setter.js
+++ b/lib/path-part-setter.js
@@ -74,7 +74,7 @@ function createPathPartSetter( node ) {
 			// If this node has exactly one dynamic child, this method may act as
 			// a setter for that child node. `dynamicChildLevel` will be falsy if the
 			// node does not have a child or has multiple children.
-			if ( typeof val !== 'undefined' && dynamicChildLevel ) {
+			if ( val !== undefined && dynamicChildLevel ) {
 				this.setPathPart( dynamicChildLevel, val );
 			}
 			return this;

--- a/lib/route-tree.js
+++ b/lib/route-tree.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _reduce = require( 'lodash.reduce' );
+
 var namedGroupRegexp = require( './util/named-group-regexp' );
 var ensure = require( './util/ensure' );
 
@@ -133,14 +135,13 @@ function reduceRouteComponents( routeObj, topLevel, parentLevel, component, idx,
  *
  * @method _reduceRouteTree
  * @private
- * @param {object[]} routes     An array of route objects (set via .bind partial application)
  * @param {object}   namespaces The memo object that becomes a dictionary mapping API
  *                              namespaces to an object of the namespace's routes
- * @param {string}   route      The string key of a route in `routes`
+ * @param {object}   routeObj   A route definition object
+ * @param {string}   route      The string key of the `routeObj` route object
  * @returns {object} The namespaces dictionary memo object
  */
-function reduceRouteTree( routes, namespaces, route ) {
-	var routeObj = routes[ route ];
+function reduceRouteTree( namespaces, routeObj, route ) {
 	var nsForRoute = routeObj.namespace;
 
 	// Strip the namespace from the route string (all routes should have the
@@ -183,8 +184,16 @@ function reduceRouteTree( routes, namespaces, route ) {
 	return namespaces;
 }
 
+/**
+ * Build a route tree by reducing over a routes definition object from the API
+ * root endpoint response object
+ *
+ * @param {object} routes A dictionary of routes keyed by route regex strings
+ * @returns {object} A dictionary, keyed by namespace, of resource handler
+ * factory methods for each namespace's resources
+ */
 function buildRouteTree( routes ) {
-	return Object.keys( routes ).reduce( reduceRouteTree.bind( null, routes ), {} );
+	return _reduce( routes, reduceRouteTree, {} );
 }
 
 module.exports = {

--- a/lib/util/ensure.js
+++ b/lib/util/ensure.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function( obj, prop, propDefaultValue ) {
-	if ( obj && typeof obj[ prop ] === 'undefined' ) {
+	if ( obj && obj[ prop ] === undefined ) {
 		obj[ prop ] = propDefaultValue;
 	}
 };

--- a/lib/util/key-val-to-obj.js
+++ b/lib/util/key-val-to-obj.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function( key, value ) {
+	var obj = {};
+	obj[ key ] = value;
+	return obj;
+};

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-yuidoc": "^1.0.0",
     "istanbul": "^0.4.4",
-    "jscs": "^3.0.5",
+    "jscs": "^3.0.6",
     "jscs-stylish": "^0.3.1",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   "dependencies": {
     "es6-promise": "^3.2.1",
     "li": "^1.0.1",
-    "lodash": "^2.4.2",
+    "lodash.reduce": "^4.4.0",
+    "lodash.union": "^4.4.0",
+    "lodash.uniq": "^4.3.0",
     "node.extend": "^1.1.5",
     "parse-link-header": "^0.4.1",
     "qs": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "bluebird": "^3.4.1",
+    "es6-promise": "^3.2.1",
     "li": "^1.0.1",
     "lodash": "^2.4.2",
     "node.extend": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -64,11 +64,13 @@
     "jscs-stylish": "^0.3.1",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",
+    "json-loader": "^0.5.4",
     "load-grunt-tasks": "^3.5.0",
     "minimist": "^1.2.0",
     "mocha": "^2.5.3",
     "sandboxed-module": "^2.0.3",
     "sinon": "^1.17.4",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "webpack": "^1.13.1"
   }
 }

--- a/tests/integration/autodiscovery.js
+++ b/tests/integration/autodiscovery.js
@@ -11,7 +11,7 @@ var expect = chai.expect;
 var sinon = require( 'sinon' );
 
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
-var Promise = require( 'bluebird' );
+var Promise = require( 'es6-promise' ).Promise;
 
 var WP = require( '../../' );
 var WPRequest = require( '../../lib/constructors/wp-request.js' );

--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -7,7 +7,6 @@ var SUCCESS = 'success';
 // actually run.
 chai.use( require( 'chai-as-promised' ) );
 var expect = chai.expect;
-var _ = require( 'lodash' );
 
 var WP = require( '../../' );
 var WPRequest = require( '../../lib/constructors/wp-request.js' );
@@ -317,9 +316,9 @@ describe( 'integration: categories()', function() {
 			var prom = wp.posts().perPage( 1 ).embed().get().then(function( posts ) {
 				var post = posts[ 0 ];
 				// Find the categories for this post
-				postCategories = _.findWhere( post._embedded['wp:term'], function( terms ) {
+				post._embedded['wp:term'].forEach(function( terms ) {
 					if ( terms.length && terms[ 0 ].taxonomy === 'category' ) {
-						return true;
+						postCategories = terms;
 					}
 				});
 				var postId = post.id;

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -10,7 +10,7 @@ var expect = chai.expect;
 var sinon = require( 'sinon' );
 
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
-var Promise = require( 'bluebird' );
+var Promise = require( 'es6-promise' ).Promise;
 
 var WP = require( '../../' );
 var WPRequest = require( '../../lib/constructors/wp-request.js' );
@@ -301,15 +301,17 @@ describe( 'integration: posts()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'cannot create (POST) without authentication', function() {
-		var prom = wp.posts().create({
-			title: 'New Post 2501',
-			content: 'Some Content'
-		}).catch(function( err ) {
-			expect( err ).to.be.an.instanceOf( Error );
-			expect( err ).to.have.property( 'status' );
-			expect( err.status ).to.equal( 401 );
-			return SUCCESS;
+	it( 'cannot create (POST) without authentication (also tests callback-mode errors)', function() {
+		var prom = new Promise(function( resolve, reject ) {
+			wp.posts().create({
+				title: 'New Post 2501',
+				content: 'Some Content'
+			}, function( err ) {
+				expect( err ).to.be.an.instanceOf( Error );
+				expect( err ).to.have.property( 'status' );
+				expect( err.status ).to.equal( 401 );
+				resolve( SUCCESS );
+			});
 		});
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});

--- a/tests/unit/lib/autodiscovery.js
+++ b/tests/unit/lib/autodiscovery.js
@@ -4,7 +4,7 @@ var expect = chai.expect;
 chai.use( require( 'chai-as-promised' ) );
 
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
-var Promise = require( 'bluebird' );
+var Promise = require( 'es6-promise' ).Promise;
 
 var autodiscovery = require( '../../../lib/autodiscovery' );
 

--- a/tests/unit/lib/util/key-val-to-obj.js
+++ b/tests/unit/lib/util/key-val-to-obj.js
@@ -1,0 +1,43 @@
+'use strict';
+var expect = require( 'chai' ).expect;
+
+var keyValToObj = require( '../../../../lib/util/key-val-to-obj' );
+
+describe( 'keyValToObj utility', function() {
+	var obj;
+
+	beforeEach(function() {
+		obj = {};
+	});
+
+	it( 'is defined', function() {
+		expect( keyValToObj ).to.exist;
+	});
+
+	it( 'is a function', function() {
+		expect( keyValToObj ).to.be.a( 'function' );
+	});
+
+	it( 'returns an object', function() {
+		expect( keyValToObj() ).to.be.an( 'object' );
+	});
+
+	it( 'sets the specified value at the provided key on the returned object', function() {
+		var result = keyValToObj( 'propName', 123456 );
+		expect( result ).to.have.property( 'propName' );
+		expect( result ).to.deep.equal({
+			propName: 123456
+		});
+	});
+
+	it( 'can be used to set an array, and sets values by reference', function() {
+		var arr = [ 'mimsy', 'borogoves', 'outgrabe' ];
+		var result = keyValToObj( 'words', arr );
+		expect( result ).to.have.property( 'words' );
+		expect( result.words ).to.equal( arr );
+		expect( result ).to.deep.equal({
+			words: [ 'mimsy', 'borogoves', 'outgrabe' ]
+		});
+	});
+
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const path = require( 'path' );
+const outputPath = path.join( __dirname, 'browser' );
+
+module.exports = {
+	entry: './wp.js',
+
+	devtool: 'source-map',
+
+	output: {
+		path: outputPath,
+		filename: 'wpapi.js',
+		library: 'WPAPI',
+		libraryTarget: 'umd'
+	},
+
+	module: {
+		loaders: [
+			{ test: /\.json$/, loader: 'json-loader' }
+		]
+	}
+};

--- a/webpack.config.minified.js
+++ b/webpack.config.minified.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const webpack = require( 'webpack' );
+const config = require( './webpack.config' );
+
+// Re-use normal Webpack build config, just adding minification
+config.output.filename = 'wpapi.min.js';
+config.plugins = config.plugins || [];
+config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+	compress: {
+		warnings: false
+	}
+}));
+
+module.exports = config;

--- a/wp.js
+++ b/wp.js
@@ -16,6 +16,7 @@
  */
 'use strict';
 
+var _reduce = require( 'lodash.reduce' );
 var extend = require( 'node.extend' );
 
 // All valid routes in API v2 beta 11
@@ -203,12 +204,11 @@ WP.prototype.bootstrap = function( routes ) {
 	// client instance and passing a registered namespace string.
 	// Handlers for default (wp/v2) routes will also be assigned to the WP client
 	// instance object itself, for brevity.
-	return Object.keys( endpointFactoriesByNamespace ).reduce(function( wpInstance, namespace ) {
-		var endpointFactories = endpointFactoriesByNamespace[ namespace ];
+	return _reduce( endpointFactoriesByNamespace, function( wpInstance, endpointFactories, namespace ) {
 
 		// Set (or augment) the route handler factories for this namespace.
-		wpInstance._ns[ namespace ] = Object.keys( endpointFactories ).reduce(function( nsHandlers, methodName ) {
-			nsHandlers[ methodName ] = endpointFactories[ methodName ];
+		wpInstance._ns[ namespace ] = _reduce( endpointFactories, function( nsHandlers, handlerFn, methodName ) {
+			nsHandlers[ methodName ] = handlerFn;
 			return nsHandlers;
 		}, wpInstance._ns[ namespace ] || {
 			// Create all namespace dictionaries with a direct reference to the main WP


### PR DESCRIPTION
This PR

- Adds a [Webpack](webpack.github.io) build to bundle the library code into `/browser/wpapi.js`
- Switches from [Bluebird](http://bluebirdjs.com/docs/getting-started.html) to [es6-promise](https://www.npmjs.com/package/es6-promise) for all our Promise-polyfilling needs, to minimize the size of the bundled code
- Switches from using the full Lodash (at an outdated version, no less) to using only the three lodash sub-modules that are needed to make this library's code function (`reduce`, `uniq` and `union`), to minimize the size of the bundled code