### PR TITLE
Add method to attach a file when creating a media object

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a client for the [WordPress REST API](http://wp-api.org/). It is **under
   - [Updating Posts](#updating-posts)
   - [Requesting Different Resources](#requesting-different-resources)
   - [Filtering Collections](#filtering-collections)
+  - [Uploading Media](#uploading-media)
   - [Custom Routes](#custom-routes)
   - [Embedding Data](#embedding-data)
   - [Paginated Collections](#working-with-paged-response-data)
@@ -309,6 +310,43 @@ The following methods are shortcuts for filtering the requested collection down 
 * `.year( year )`: find items published in the specified year
 * `.month( month )`: find items published in the specified month, designated by the month index (1&ndash;12) or name (*e.g.* "February")
 * `.day( day )`: find items published on the specified day
+
+### Uploading Media
+
+Files may be uploaded to the WordPress media library by creating a media record using the `.media()` collection handler.
+
+If you wish to associate a newly-uploaded media record to a specific post, you must use two calls: one to first upload the file, then another to associate it with a post. Example code:
+
+```js
+wp.media()
+    // Specify a path to the file you want to upload
+    .file( '/path/to/the/image.jpg' )
+    .create({
+        title: 'My awesome image',
+        alt_text: 'an image of something awesome',
+        caption: 'This is the caption text',
+        description: 'More explanatory information'
+    })
+    .then(function( response ) {
+        // Your media is now uploaded: let's associate it with a post
+        var newImageId = response.id;
+        return wp.media().id( newImageId ).update({
+            post: associatedPostId
+        });
+    })
+    .then(function( response ) {
+        console.log( 'Media ID #' + response.id );
+        console.log( 'is now associated with Post ID #' + response.post );
+    });
+```
+
+If you are uploading media from the client side, you can pass a reference to a file input's file list entry in place of the file path:
+
+```js
+wp.media()
+    .file( document.getElementById( 'file-input' ).files[0] )
+    .create()...
+```
 
 ### Custom Routes
 

--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -724,6 +724,38 @@ WPRequest.prototype.auth = function( usrOrObj, password ) {
 	return this;
 };
 
+/**
+ * Specify a file or a file buffer to attach to the request, for use when
+ * creating a new Media item
+ *
+ * @example within a server context
+ *
+ *     wp.media()
+ *       // Pass .file() the file system path to a file to upload
+ *       .file( '/path/to/file.jpg' )
+ *       .create({})...
+ *
+ * @example within a browser context
+ *
+ *     wp.media()
+ *       // Pass .file() the file reference from an HTML file input
+ *       .file( document.querySelector( 'input[type="file"]' ).files[0] )
+ *       .create({})...
+ *
+ * @method file
+ * @param {string|object} file   A path to a file (in Node) or an file object
+ *                               (Node or Browser) to attach to the request
+ * @param {string}        [name] An (optional) filename to use for the file
+ * @returns {[type]} [description]
+ */
+WPRequest.prototype.file = function( file, name ) {
+	this._attachment = file;
+	// Explicitly set to undefined if not provided, to override any previously-
+	// set attachment name property that might exist from a prior `.file()` call
+	this._attachmentName = name ? name : undefined;
+	return this;
+};
+
 // HTTP Methods: Private HTTP-verb versions
 // ========================================
 
@@ -756,8 +788,16 @@ WPRequest.prototype._httpPost = function( data, callback ) {
 	this._checkMethodSupport( 'post' );
 	var url = this._renderURI();
 	data = data || {};
+	var request = this._auth( agent.post( url ), true );
 
-	var request = this._auth( agent.post( url ), true ).send( data );
+	if ( this._attachment ) {
+		// Data must be form-encoded alongside image attachment
+		request = _reduce( data, function( req, value, key ) {
+			return req.field( key, value );
+		}, request.attach( 'file', this._attachment, this._attachmentName ) );
+	} else {
+		request = request.send( data );
+	}
 
 	return invokeAndPromisify( request, callback, returnBody.bind( this ) );
 };


### PR DESCRIPTION
This adds a `.file` method which may be chained onto a `.media()` handler to upload a file attachment when `.create`ing a new media record. Documentation for this method has been added to the README and inline docs; still needs tests.

For #116, #153, #185