### PR TITLE
Check existence of `options.endpoint` by its type

### DIFF
--- a/wp.js
+++ b/wp.js
@@ -69,7 +69,7 @@ function WP( options ) {
 
 	this._options = extend( {}, defaults, options );
 
-	if ( ! this._options.endpoint ) {
+	if ( typeof this._options.endpoint !== 'string' ) {
 		throw new Error( 'options hash must contain an API endpoint URL string' );
 	}
 


### PR DESCRIPTION
Currently if you pass a non-string value as the `endpoint` you won't receive the nice `'options hash must contain an API endpoint URL string'` warning, but instead the library will throw on attempting to invoke `replace` on whatever that value is.

Small commit to fix this by checking that `endpoint` not only exists, but that it is a string.