### PR TITLE
Do not log a warning when skipping preexisting methods during discovery

### DIFF
--- a/lib/endpoint-request.js
+++ b/lib/endpoint-request.js
@@ -47,10 +47,8 @@ function createEndpointRequest( handlerSpec, resource, namespace ) {
 	}
 
 	Object.keys( handlerSpec._setters ).forEach(function( setterFnName ) {
-		if ( EndpointRequest.prototype[ setterFnName ] ) {
-			console.warn( 'Warning: method .' + setterFnName + '() is already defined!' );
-			console.warn( 'Cannot overwrite .' + resource + '().' + setterFnName + '() method' );
-		} else {
+		// Only assign setter functions if they do not overwrite preexisting methods
+		if ( ! EndpointRequest.prototype[ setterFnName ] ) {
 			EndpointRequest.prototype[ setterFnName ] = handlerSpec._setters[ setterFnName ];
 		}
 	});

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -70,20 +70,11 @@ function getTitles( posts ) {
 
 describe( 'integration: posts()', function() {
 	var wp;
-	var sinonSandbox;
 
 	beforeEach(function() {
-		// Stub warn to suppress notice about overwriting deprecated .post method
-		sinonSandbox = sinon.sandbox.create();
-		sinonSandbox.stub( global.console, 'warn' );
 		wp = new WP({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
-	});
-
-	afterEach(function() {
-		// Restore sandbox
-		sinonSandbox.restore();
 	});
 
 	it( 'can be used to retrieve a list of recent posts', function() {

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -1,8 +1,6 @@
 'use strict';
 var chai = require( 'chai' );
 var expect = chai.expect;
-chai.use( require( 'sinon-chai' ) );
-var sinon = require( 'sinon' );
 
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 var registerRoute = require( '../../../lib/wp-register-route' );
@@ -90,31 +88,19 @@ describe( 'wp.registerRoute', function() {
 
 	// custom route example for wp-api.org
 	describe( 'handler for route with capture group named identically to existing method', function() {
-		var sinonSandbox;
 		var handler;
 
 		beforeEach(function() {
-			// Stub warn BEFORE we call registerRoute()
-			sinonSandbox = sinon.sandbox.create();
-			sinonSandbox.stub( global.console, 'warn' );
-
 			var factory = registerRoute( 'ns', '/route/(?P<param>)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		afterEach(function() {
-			// Restore sandbox
-			sinonSandbox.restore();
-		});
-
-		it( 'overwrites the preexisting method, but logs a warning', function() {
-			// expect( handler.param ).to.equal( WPRequest.prototype.param );
+		it( 'does not overwrite preexisting methods', function() {
+			expect( handler.param ).to.equal( WPRequest.prototype.param );
 			expect( handler.param( 'foo', 'bar' )._renderURI() ).to.equal( '/ns/route?foo=bar' );
 			expect( handler.param( 'foo', 'bar' )._renderURI() ).not.to.equal( '/ns/route/foo' );
-			expect( console.warn ).to.have.been.calledWith( 'Warning: method .param() is already defined!' );
-			expect( console.warn ).to.have.been.calledWith( 'Cannot overwrite .route().param() method' );
 		});
 
 	});


### PR DESCRIPTION
As setters are inferred from the shape of the API routes, there are situations where the names parts of a route will result in setter fn names that conflict with (i.e. are the same as) preexisting methods on the WPRequest object. The `.post` query terminator that triggers a POST request is a good example, as the part of the route indicating post ID for e.g. a revision is named as "post".

In this situation we skip assigning that setter, as in most cases it will not preclude accessing that resource through other means (the .id method will set the post ID in this case, and the revisions method will set the revision ID). Historically, however, we did log a warning when this occurred, to note that certain methods may not be available as expected.

This warning is distracting and causes concern that the library is not functioning as intended. This PR removes the warning, silently skipping any pre-existing methods when assigning setters. This suits the majority use-case without preventing edge-case users from taking advantage of the registerRoute method to craft a custom handler for an arbitrary endpoint.

Closes #199