### PR TITLE
Do not unnecessarily lowercase path part setter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,24 @@ site.handler = site.registerRoute( 'myplugin/v1', 'collection/(?P<id>)', {
 ```
 This permits a developer to extend an endpoint with arbitrary parameters in the same manner as is done for the automatically-generated built-in route handlers.
 
-Auto-discovery of all available routes will be supported in the near future, as will re-utilizing existing mixins (like `.search()`) on custom routes.
+Re-utilizing existing mixins (like `.search()`) on custom routes will be supported in the near future.
+
+#### Setter method naming for named route components
+
+In the example above, registering the route string `'/author/(?P<id>\\d+)'` results in the creation of an `.id()` method on the resulting resource handler:
+
+```js
+site.myCustomResource().id( 7 ); // => myplugin/v1/author/7
+```
+
+If a named route component (e.g. `(?P<id>\\d+)`, above) is in `snake_case`, then that setter will be converted to camelCase instead, as with `some_part` below:
+
+```js
+site.myCustomResource = site.registerRoute( 'myplugin/v1', '/resource/(?P<some_part>\\d+)' );
+site.myCustomResource().somePart( 7 ); // => myplugin/v1/resource/7
+```
+
+Non-snake_cased route parameter names will be unaffected.
 
 ## Embedding data
 

--- a/lib/resource-handler-spec.js
+++ b/lib/resource-handler-spec.js
@@ -23,9 +23,8 @@ function assignSetterFnForNode( handler, node ) {
 		setterFn = createPathPartSetter( node );
 
 		node.names.forEach(function( name ) {
-			// camel-case the setter name
+			// Convert from snake_case to camelCase
 			var setterFnName = name
-				.toLowerCase()
 				.replace( /_\w/g, function( match ) {
 					return match.replace( '_', '' ).toUpperCase();
 				});

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -7,7 +7,6 @@ var SUCCESS = 'success';
 // actually run.
 chai.use( require( 'chai-as-promised' ) );
 var expect = chai.expect;
-var sinon = require( 'sinon' );
 
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
 var Promise = require( 'es6-promise' ).Promise;

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -67,7 +67,6 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	// custom route example for wp-api.org
 	describe( 'handler for /a/(?P<snake_cased_path_setter>\\d+)', function() {
 		var handler;
 
@@ -86,7 +85,24 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	// custom route example for wp-api.org
+	describe( 'handler for /a/(?P<camelCasedPathSetter>\\d+)', function() {
+		var handler;
+
+		beforeEach(function() {
+			var factory = registerRoute( 'ns', '/a/(?P<camelCasedPathSetter>\\d+)' );
+			handler = factory({
+				endpoint: '/'
+			});
+		});
+
+		it( 'does not mutate the setter name', function() {
+			expect( handler ).not.to.have.property( 'camelcasedpathsetter' );
+			expect( handler ).to.have.property( 'camelCasedPathSetter' );
+			expect( handler.camelCasedPathSetter ).to.be.a( 'function' );
+		});
+
+	});
+
 	describe( 'handler for route with capture group named identically to existing method', function() {
 		var handler;
 
@@ -101,6 +117,50 @@ describe( 'wp.registerRoute', function() {
 			expect( handler.param ).to.equal( WPRequest.prototype.param );
 			expect( handler.param( 'foo', 'bar' )._renderURI() ).to.equal( '/ns/route?foo=bar' );
 			expect( handler.param( 'foo', 'bar' )._renderURI() ).not.to.equal( '/ns/route/foo' );
+		});
+
+	});
+
+	describe( 'handler for consecutive dynamic route segments', function() {
+		var handler;
+
+		beforeEach(function() {
+			var factory = registerRoute( 'ns', '/resource/(?P<part1>\\d+)/(?P<part2>\\d+)' );
+			handler = factory({
+				endpoint: '/'
+			});
+		});
+
+		describe( 'part1 method', function() {
+
+			it( 'is defined', function() {
+				expect( handler ).to.have.property( 'part1' );
+			});
+
+			it( 'is a function', function() {
+				expect( handler.part1 ).to.be.a( 'function' );
+			});
+
+			it( 'sets the part1 component of the path', function() {
+				expect( handler.part1( 12 )._renderURI() ).to.equal( '/ns/resource/12' );
+			});
+
+		});
+
+		describe( 'part2 method', function() {
+
+			it( 'is defined', function() {
+				expect( handler ).to.have.property( 'part2' );
+			});
+
+			it( 'is a function', function() {
+				expect( handler.part2 ).to.be.a( 'function' );
+			});
+
+			it( 'sets the part2 component of the path', function() {
+				expect( handler.part1( 12 ).part2( 34 )._renderURI() ).to.equal( '/ns/resource/12/34' );
+			});
+
 		});
 
 	});


### PR DESCRIPTION
The logic used to create setter names for path parts within a resource handler incorrectly assumed that all path part components should be lowercased before being converted from snake_case to camelCase. If a resource already employed a camelCase component (and it is perfectly valid to do so), then the setter for thatComponent would be created as `thatcomponent`, not `thatComponent`. This is unintuitive behavior (and actually raises the question of whether the token should be mutated at all), so this PR removes the offending `toLowerCase` method and documents the naming conversion logic in the readme.

Fixes #198, props @joneslloyd for the bug report