### PR TITLE
Add .before and .after parameter mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ The following methods are shortcuts for filtering the requested collection down 
 * `.year( year )`: find items published in the specified year
 * `.month( month )`: find items published in the specified month, designated by the month index (1&ndash;12) or name (*e.g.* "February")
 * `.day( day )`: find items published on the specified day
+* `.before( date )`: find items published before the specified date (string or Date object)
+* `.after( date )`: find items published after the specified date (string or Date object)
 
 ### Uploading Media
 

--- a/lib/mixins/index.js
+++ b/lib/mixins/index.js
@@ -11,7 +11,9 @@ var parameterMixins = require( './parameters' );
 // supported by default in WPRequest, as is the base `.param` method. Any GET
 // argument parameters not covered here must be set directly by using `.param`.
 module.exports = {
+	after: { after: parameterMixins.after },
 	author: { author: parameterMixins.author },
+	before: { before: parameterMixins.before },
 	filter: filterMixins,
 	page: { page: parameterMixins.page },
 	parent: { parent: parameterMixins.parent },

--- a/lib/mixins/parameters.js
+++ b/lib/mixins/parameters.js
@@ -162,4 +162,49 @@ parameterMixins.forPost = function( postId ) {
 	return this.param( 'post', postId );
 };
 
+// Date Methods
+// ============
+
+/**
+ * Retrieve only records published before a specified date
+ *
+ * @example Provide an ISO 8601-compliant date string
+ *
+ *     wp.posts().before('2016-03-22')...
+ *
+ * @example Provide a JavaScript Date object
+ *
+ *     wp.posts().before( new Date( 2016, 03, 22 ) )...
+ *
+ * @method before
+ * @chainable
+ * @param {String|Date} date An ISO 8601-compliant date string, or Date object
+ * @return The request instance (for chaining)
+ */
+parameterMixins.before = function( date ) {
+	/* jshint validthis:true */
+	return this.param( 'before', new Date( date ).toISOString() );
+};
+
+/**
+ * Retrieve only records published after a specified date
+ *
+ * @example Provide an ISO 8601-compliant date string
+ *
+ *     wp.posts().after('1986-03-22')...
+ *
+ * @example Provide a JavaScript Date object
+ *
+ *     wp.posts().after( new Date( 1986, 03, 22 ) )...
+ *
+ * @method after
+ * @chainable
+ * @param {String|Date} date An ISO 8601-compliant date string, or Date object
+ * @return The request instance (for chaining)
+ */
+parameterMixins.after = function( date ) {
+	/* jshint validthis:true */
+	return this.param( 'after', new Date( date ).toISOString() );
+};
+
 module.exports = parameterMixins;

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -270,6 +270,31 @@ describe( 'integration: posts()', function() {
 
 		});
 
+		describe( 'before', function() {
+
+			it( 'can be used to return only posts from before a certain date', function() {
+				var prom = wp.posts().before( '2013-01-08' ).then(function( posts ) {
+					expect( posts[0].title.rendered ).to.equal( 'Markup: Title With Special Characters' );
+					return SUCCESS;
+				});
+				return expect( prom ).to.eventually.equal( SUCCESS );
+			});
+
+		});
+
+		describe( 'after', function() {
+
+			it( 'can be used to return only posts from after a certain date', function() {
+				var prom = wp.posts().after( '2013-01-08' ).then(function( posts ) {
+					expect( posts.length ).to.equal( 3 );
+					expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1.slice( 0, 3 ) );
+					return SUCCESS;
+				});
+				return expect( prom ).to.eventually.equal( SUCCESS );
+			});
+
+		});
+
 	});
 
 	// Post creation, update & deletion suites

--- a/tests/unit/lib/mixins/parameters.js
+++ b/tests/unit/lib/mixins/parameters.js
@@ -101,6 +101,86 @@ describe( 'mixins: parameters', function() {
 
 	});
 
+	describe( 'date parameters', function() {
+
+		describe( '.before()', function() {
+
+			beforeEach(function() {
+				Req.prototype.before = parameterMixins.before;
+			});
+
+			it( 'mixin method is defined', function() {
+				expect( parameterMixins ).to.have.property( 'before' );
+			});
+
+			it( 'is a function', function() {
+				expect( parameterMixins.before ).to.be.a( 'function' );
+			});
+
+			it( 'supports chaining', function() {
+				expect( req.before( '1933-11-01' ) ).to.equal( req );
+			});
+
+			it( 'throws an error when called with a missing or invalid time', function() {
+				expect(function() {
+					req.before();
+				}).to.throw( 'Invalid time value' );
+			});
+
+			it( 'sets the "before" query parameter as an ISO 8601 Date', function() {
+				var result = req.before( '2016-07-01' );
+				expect( getQueryStr( result ) ).to.equal( 'before=2016-07-01T00:00:00.000Z' );
+			});
+
+			it( 'sets the "before" query parameter when provided a Date object', function() {
+				var date = new Date( 1986, 2, 22 );
+				var result = req.before( date );
+				// use .match and regex to avoid time zone-induced false negatives
+				expect( getQueryStr( result ) ).to.match( /^before=1986-03-22T\d{2}:\d{2}:\d{2}.\d{3}Z$/ );
+			});
+
+		});
+
+		describe( '.after()', function() {
+
+			beforeEach(function() {
+				Req.prototype.after = parameterMixins.after;
+			});
+
+			it( 'mixin method is defined', function() {
+				expect( parameterMixins ).to.have.property( 'after' );
+			});
+
+			it( 'is a function', function() {
+				expect( parameterMixins.after ).to.be.a( 'function' );
+			});
+
+			it( 'supports chaining', function() {
+				expect( req.after( '1992-04-22' ) ).to.equal( req );
+			});
+
+			it( 'throws an error when called with a missing or invalid time', function() {
+				expect(function() {
+					req.after();
+				}).to.throw( 'Invalid time value' );
+			});
+
+			it( 'sets the "after" query parameter when provided a value', function() {
+				var result = req.after( '2016-03-22' );
+				expect( getQueryStr( result ) ).to.equal( 'after=2016-03-22T00:00:00.000Z' );
+			});
+
+			it( 'sets the "after" query parameter when provided a Date object', function() {
+				var date = new Date( 1987, 11, 7 );
+				var result = req.after( date );
+				// use .match and regex to avoid time zone-induced false negatives
+				expect( getQueryStr( result ) ).to.match( /^after=1987-12-07T\d{2}:\d{2}:\d{2}.\d{3}Z$/ );
+			});
+
+		});
+
+	});
+
 	describe( 'name parameters', function() {
 
 		describe( '.slug()', function() {


### PR DESCRIPTION
These top-level query parameters are supported by all built-in collections of dated resources (posts, media, comments, etc).

If a Date object is provided, it is converted to a full ISO8601 string before being sent to the API.

Closes #179