### PR TITLE
Allow authentication credentials to be set after autodiscovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ apiPromise.then(function( site ) {
 });
 ```
 
+#### Authenticating with Auto-Discovery
+
+While using `WP.discover( url )` to generate the handler for your site gets you up and running quickly, it does not provide the same level of customization as instantiating your own `new WP` object. In order to specify authentication configuration when using autodiscovery, chain a `.then` onto the initial discovery query to call the `.auth` method on the returned site object with the relevant credentials (username & password, nonce, etc):
+
+```js
+var apiPromise = WP.discover( 'http://my-site.com' ).then(function( site ) {
+    return site.auth({
+        username: 'admin',
+        password: 'always use secure passwords'
+    });
+});
+apiPromise.then(function( site ) {
+    // site is now configured to use authentication
+})
+```
+
 ### Bootstrapping
 
 If you are building an application designed to interface with a specific site, it is possible to sidestep the additional asynchronous HTTP calls that are needed to bootstrap the client through auto-discovery. You can download the root API response, *i.e.* the JSON response when you hit the root endpoint such as `your-site.com/wp-json`, and save that JSON file locally; then, in

--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -678,39 +678,58 @@ WPRequest.prototype.namespace = function( namespace ) {
 };
 
 /**
- * Set a requst to use authentication, and optionally provide auth credentials
+ * Set a request to use authentication, and optionally provide auth credentials
  *
- * @example
+ * Note: the `.auth( username, password )` signature is _deprecated_, use an object
+ * with username and password properties instead as in the below example.
+ *
  * If auth credentials were already specified when the WP instance was created, calling
  * `.auth` on the request chain will set that request to use the existing credentials:
  *
+ * @example use existing credentials
+ *
  *     request.auth().get...
  *
- * Alternatively, a username & password can be explicitly passed into `.auth`:
+ * Alternatively, a username & password (or nonce) can be explicitly passed into `.auth`:
  *
- *     request.auth( 'username', 'password' ).get...
+ * @example use explicit basic authentication credentials
+ *
+ *     request.auth({
+ *       username: 'admin',
+ *       password: 'super secure'
+ *     }).get...
+ *
+ * @example use a nonce for cookie authentication
+ *
+ *     request.auth({
+ *       nonce: 'somenonce'
+ *     })...
  *
  * @method auth
  * @chainable
- * @param {String|Object} [usrOrObj] A username string for basic authentication,
- *                                   or an object with 'username' and 'password'
- *                                   string properties
- * @param {String}        [password] A user password string for basic authentication
- *                                   (ignored if usrOrObj is an object)
+ * @param {Object} credentials            An object with 'username' and 'password' string
+ *                                        properties, or else a 'nonce' property
+ * @param {String} [credentials.username] A WP-API Basic HTTP Authentication username
+ * @param {String} [credentials.password] A WP-API Basic HTTP Authentication password
+ * @param {String} [credentials.nonce]    A WP nonce for use with cookie authentication
  * @return {WPRequest} The WPRequest instance (for chaining)
  */
-WPRequest.prototype.auth = function( usrOrObj, password ) {
-	if ( typeof usrOrObj === 'object' ) {
-		if ( typeof usrOrObj.username === 'string' ) {
-			this._options.username = usrOrObj.username;
+WPRequest.prototype.auth = function( credentials, password ) {
+	if ( typeof credentials === 'object' ) {
+		if ( typeof credentials.username === 'string' ) {
+			this._options.username = credentials.username;
 		}
 
-		if ( typeof usrOrObj.password === 'string' ) {
-			this._options.password = usrOrObj.password;
+		if ( typeof credentials.password === 'string' ) {
+			this._options.password = credentials.password;
+		}
+
+		if ( credentials.nonce ) {
+			this._options.nonce = credentials.nonce;
 		}
 	} else {
-		if ( typeof usrOrObj === 'string' ) {
-			this._options.username = usrOrObj;
+		if ( typeof credentials === 'string' ) {
+			this._options.username = credentials;
 		}
 
 		if ( typeof password === 'string' ) {

--- a/tests/integration/autodiscovery.js
+++ b/tests/integration/autodiscovery.js
@@ -31,6 +31,11 @@ function getTitles( posts ) {
 	});
 }
 
+var credentials = {
+	username: 'apiuser',
+	password: 'password'
+};
+
 describe( 'integration: discover()', function() {
 	var apiPromise;
 	var sinonSandbox;
@@ -79,6 +84,34 @@ describe( 'integration: discover()', function() {
 			return SUCCESS;
 		});
 		return expect( prom ).to.eventually.equal( SUCCESS );
+	});
+
+	describe( 'can authenticate', function() {
+
+		it( 'requests against the detected and bound site', function() {
+			var prom = apiPromise.then(function( site ) {
+				return site.auth( credentials );
+			}).then(function( site ) {
+				return site.users().me();
+			}).then(function( user ) {
+				expect( user ).to.be.an( 'object' );
+				expect( user.slug ).to.equal( credentials.username );
+				return SUCCESS;
+			});
+			return expect( prom ).to.eventually.equal( SUCCESS );
+		});
+
+		it( 'one-off requests against the detected and bound site', function() {
+			var prom = apiPromise.then(function( site ) {
+				return site.users().auth( credentials ).me();
+			}).then(function( user ) {
+				expect( user ).to.be.an( 'object' );
+				expect( user.slug ).to.equal( credentials.username );
+				return SUCCESS;
+			});
+			return expect( prom ).to.eventually.equal( SUCCESS );
+		});
+
 	});
 
 	describe( 'rejection states', function() {

--- a/tests/unit/wp.js
+++ b/tests/unit/wp.js
@@ -330,6 +330,44 @@ describe( 'wp', function() {
 			expect( site._options.auth ).to.be.true;
 		});
 
+		it( 'can update previously-set usernames and passwords', function() {
+			site.auth({
+				username: 'user1',
+				password: 'pass1'
+			}).auth({
+				username: 'admin',
+				password: 'sandwich'
+			});
+			expect( site._options ).to.have.property( 'username' );
+			expect( site._options ).to.have.property( 'password' );
+			expect( site._options.username ).to.equal( 'admin' );
+			expect( site._options.password ).to.equal( 'sandwich' );
+			expect( site._options ).to.have.property( 'auth' );
+			expect( site._options.auth ).to.be.true;
+		});
+
+		it( 'sets the nonce when provided in an object', function() {
+			site.auth({
+				nonce: 'somenonce'
+			});
+			expect( site._options ).to.have.property( 'nonce' );
+			expect( site._options.nonce ).to.equal( 'somenonce' );
+			expect( site._options ).to.have.property( 'auth' );
+			expect( site._options.auth ).to.be.true;
+		});
+
+		it( 'can update nonce credentials', function() {
+			site.auth({
+				nonce: 'somenonce'
+			}).auth({
+				nonce: 'refreshednonce'
+			});
+			expect( site._options ).to.have.property( 'nonce' );
+			expect( site._options.nonce ).to.equal( 'refreshednonce' );
+			expect( site._options ).to.have.property( 'auth' );
+			expect( site._options.auth ).to.be.true;
+		});
+
 		it( 'passes authentication status to all subsequently-instantiated handlers', function() {
 			site.auth({
 				username: 'user',

--- a/wp.js
+++ b/wp.js
@@ -161,6 +161,33 @@ WP.prototype.root = function( relativePath ) {
 	return request;
 };
 
+/**
+ * Set the authentication to use for a WP site handler instance. Accepts basic
+ * HTTP authentication credentials (string username & password) or a Nonce (for
+ * cookie authentication) by default; may be overloaded to accept OAuth credentials
+ * in the future.
+ *
+ * @example Basic Authentication
+ *
+ *     site.auth({
+ *       username: 'admin',
+ *       password: 'securepass55'
+ *     })...
+ *
+ * @example Cookie/Nonce Authentication
+ *
+ *     site.auth({
+ *       nonce: 'somenonce'
+ *     })...
+ *
+ * @method auth
+ * @chainable
+ * @param {Object} credentials            An authentication credentials object
+ * @param {String} [credentials.username] A WP-API Basic HTTP Authentication username
+ * @param {String} [credentials.password] A WP-API Basic HTTP Authentication password
+ * @param {String} [credentials.nonce]    A WP nonce for use with cookie authentication
+ * @return {WP} The WP site handler instance, for chaining
+ */
 WP.prototype.auth = WPRequest.prototype.auth;
 
 // Apply the registerRoute method to the prototype


### PR DESCRIPTION
As noted in #216, the process of authenticating after autodiscovery is not obvious: it is technically possible, but the manner documented uses

```js
WP.discover( 'http://my-site.com' ).then(function( site ) {
  // Call .auth method on individual query
  return site.users().auth( credentials ).me();
}).then(function( user ) { /* ... */ });
```

which is verbose and not obvious in the way that instantiating a WP instance with authentication "baked in" can be.

To resolve the issue, this PR exposes & documents the (existing) `.auth` method on the WP site instances themselves: this method is identical to WPRequest's `.auth`, but sets the provided options on the WP site client instance itself so that they will apply to _all_ subsequently-generated API requests.

The easiest way to use authentication with the new system becomes:

```js
WP.discover( 'http://my-site.com' ).then(function( site ) {
  site.auth( credentials );
  // site is now authenticated as normal
});
```

This approach will work with both currently-supported forms of authentication, Basic HTTP Auth & Cookie/Nonce Auth.

This PR also **deprecates** the `.auth( 'username', 'password' )` signature for the auth method, because explicitly-labeled keys will likely be critical for distinguishing between OAuth and basic auth usage.

Closes #216