### PR TITLE
Promote _renderURI to a public api & rename to toString

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ wp.posts().then(function( data ) {
     // handle error
 });
 ```
-The `wp` object will have endpoint handler methods for every endpoint that ships with the default WordPress REST API plugin.
+The `wp` object has endpoint handler methods for every endpoint that ships with the default WordPress REST API plugin.
+
+Once you have used the chaining methods to describe a resource, you may call `.create()`, `.get()`, `.update()` or `.delete()`  to send the API request to create, read, update or delete content within WordPress. These methods are documented in further detail below.
 
 ### Self-signed (Insecure) HTTPS Certificates
 
@@ -284,6 +286,16 @@ Additional querying methods provided, by endpoint:
     - `wp.media().id( n )`: get media object with ID *n*
 
 For security reasons, methods like `.revisions()` and `.users()` require the request to be authenticated.
+
+#### toString()
+
+To get the URI of the resource _without_ making a request, call `.toString()` at the end of a query chain:
+
+```js
+var uriString = wp.posts().id( 7 ).embed().toString();
+```
+
+As the name implies `.toString()` is not a chaining method, and will return a string containing the full URI; this can then be used with alternative HTTP transports like `request`, Node's native `http`, `fetch`, or even jQuery.
 
 ### Filtering Collections
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ To get the URI of the resource _without_ making a request, call `.toString()` at
 var uriString = wp.posts().id( 7 ).embed().toString();
 ```
 
-As the name implies `.toString()` is not a chaining method, and will return a string containing the full URI; this can then be used with alternative HTTP transports like `request`, Node's native `http`, `fetch`, or even jQuery.
+As the name implies `.toString()` is not a chaining method, and will return a string containing the full URI; this can then be used with alternative HTTP transports like `request`, Node's native `http`, `fetch`, or jQuery.
 
 ### Filtering Collections
 

--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -608,24 +608,6 @@ WPRequest.prototype._renderPath = function() {
 };
 
 /**
- * Parse the request's instance properties into a WordPress API request URI
- *
- * @private
- *
- * @method _renderURI
- * @return {String} The URI for the HTTP request to be sent
- */
-WPRequest.prototype._renderURI = function() {
-	// Render the path to a string
-	var path = this._renderPath();
-
-	// Render the query string
-	var queryStr = this._renderQuery();
-
-	return this._options.endpoint + path + queryStr;
-};
-
-/**
  * Conditionally set basic authentication on a server request object
  *
  * @method _auth
@@ -658,6 +640,28 @@ WPRequest.prototype._auth = function( request, forceAuthentication ) {
 	// Can authenticate: set basic auth parameters on the request
 	return request.auth( username, password );
 };
+
+// Non-chaining public methods
+// ===========================
+
+/**
+ * Parse the request into a WordPress API request URI string
+ *
+ * @method toString
+ * @return {String} The URI for the HTTP request to be sent
+ */
+WPRequest.prototype.toString = function() {
+	// Render the path to a string
+	var path = this._renderPath();
+
+	// Render the query string
+	var queryStr = this._renderQuery();
+
+	return this._options.endpoint + path + queryStr;
+};
+
+/** @deprecated Use .toString() */
+WPRequest.prototype._renderURI = WPRequest.prototype.toString;
 
 // Chaining methods
 // ================
@@ -787,7 +791,7 @@ WPRequest.prototype.file = function( file, name ) {
  */
 WPRequest.prototype._httpGet = function( callback ) {
 	this._checkMethodSupport( 'get' );
-	var url = this._renderURI();
+	var url = this.toString();
 
 	var request = this._auth( agent.get( url ) );
 
@@ -805,7 +809,7 @@ WPRequest.prototype._httpGet = function( callback ) {
  */
 WPRequest.prototype._httpPost = function( data, callback ) {
 	this._checkMethodSupport( 'post' );
-	var url = this._renderURI();
+	var url = this.toString();
 	data = data || {};
 	var request = this._auth( agent.post( url ), true );
 
@@ -831,7 +835,7 @@ WPRequest.prototype._httpPost = function( data, callback ) {
  */
 WPRequest.prototype._httpPut = function( data, callback ) {
 	this._checkMethodSupport( 'put' );
-	var url = this._renderURI();
+	var url = this.toString();
 	data = data || {};
 
 	var request = this._auth( agent.put( url ), true ).send( data );
@@ -853,7 +857,7 @@ WPRequest.prototype._httpDelete = function( data, callback ) {
 		data = null;
 	}
 	this._checkMethodSupport( 'delete' );
-	var url = this._renderURI();
+	var url = this.toString();
 	var request = this._auth( agent.del( url ), true ).send( data );
 
 	return invokeAndPromisify( request, callback, returnBody.bind( this ) );
@@ -868,7 +872,7 @@ WPRequest.prototype._httpDelete = function( data, callback ) {
  */
 WPRequest.prototype._httpHead = function( callback ) {
 	this._checkMethodSupport( 'head' );
-	var url = this._renderURI();
+	var url = this.toString();
 	var request = this._auth( agent.head( url ) );
 
 	return invokeAndPromisify( request, callback, returnHeaders );

--- a/tests/integration/autodiscovery.js
+++ b/tests/integration/autodiscovery.js
@@ -64,7 +64,7 @@ describe( 'integration: discover()', function() {
 	it( 'auto-binds to the detected endpoint on the provided site', function() {
 		var prom = apiPromise
 			.then(function( site ) {
-				expect( site.posts()._renderURI() ).to.equal( 'http://wpapi.loc/wp-json/wp/v2/posts' );
+				expect( site.posts().toString() ).to.equal( 'http://wpapi.loc/wp-json/wp/v2/posts' );
 				return SUCCESS;
 			});
 		return expect( prom ).to.eventually.equal( SUCCESS );
@@ -185,7 +185,7 @@ describe( 'integration: discover()', function() {
 			autodiscovery.getRootResponseJSON.throws();
 			var prom = WP.discover()
 				.then(function( result ) {
-					expect( result.root( '' )._renderURI() ).to.equal( 'http://we.made.it/to/mozarts/house/' );
+					expect( result.root( '' ).toString() ).to.equal( 'http://we.made.it/to/mozarts/house/' );
 					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -237,12 +237,12 @@ describe( 'WPRequest', function() {
 			});
 
 			it( 'should map to the "context=VALUE" query parameter', function() {
-				var path = request.context( 'edit' )._renderURI();
+				var path = request.context( 'edit' ).toString();
 				expect( path ).to.equal( '/?context=edit' );
 			});
 
 			it( 'should replace values when called multiple times', function() {
-				var path = request.context( 'edit' ).context( 'view' )._renderURI();
+				var path = request.context( 'edit' ).context( 'view' ).toString();
 				expect( path ).to.equal( '/?context=view' );
 			});
 
@@ -250,7 +250,7 @@ describe( 'WPRequest', function() {
 				sinon.spy( request, 'context' );
 				request.edit();
 				expect( request.context ).to.have.been.calledWith( 'edit' );
-				expect( request._renderURI() ).to.equal( '/?context=edit' );
+				expect( request.toString() ).to.equal( '/?context=edit' );
 			});
 
 			it( 'should force authentication when called with "edit"', function() {
@@ -437,6 +437,26 @@ describe( 'WPRequest', function() {
 		it( 'will clear out previously-set name if called again without a name', function() {
 			request.file( '/some/file.jpg', 'cat_picture.jpg' ).file( '/some/other/file.jpg' );
 			expect( request._attachmentName ).to.be.undefined;
+		});
+
+	});
+
+	describe( 'toString()', function() {
+
+		beforeEach(function() {
+			request = new WPRequest({
+				endpoint: 'http://blogoblog.com/wp-json'
+			});
+		});
+
+		it( 'renders the URL to a string', function() {
+			var str = request.param( 'a', 7 ).param( 'b', [ 1, 2 ] ).toString();
+			expect( str ).to.equal( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
+		});
+
+		it( 'exhibits normal toString() behavior via coercion', function() {
+			var str = '' + request.param( 'a', 7 ).param( 'b', [ 1, 2 ] );
+			expect( str ).to.equal( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
 		});
 
 	});

--- a/tests/unit/lib/mixins/filters.js
+++ b/tests/unit/lib/mixins/filters.js
@@ -400,12 +400,12 @@ describe( 'mixins: filter', function() {
 			});
 
 			it( 'returns without setting any filter if an invalid month string is provided', function() {
-				var result = req.month( 'Not a month' )._renderURI();
+				var result = req.month( 'Not a month' ).toString();
 				expect( result.match( /filter/ ) ).to.equal( null );
 			});
 
 			it( 'returns without setting any filter if an invalid argument is provided', function() {
-				var result = req.month( [ 'arrrr', 'i', 'be', 'an', 'array!' ] )._renderURI();
+				var result = req.month( [ 'arrrr', 'i', 'be', 'an', 'array!' ] ).toString();
 				expect( result.match( /filter/ ) ).to.equal( null );
 			});
 

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -42,11 +42,11 @@ describe( 'wp.registerRoute', function() {
 		});
 
 		it( 'renders a route prefixed with the provided namespace', function() {
-			expect( handler._renderURI().match( /myplugin\/v1/ ) ).to.be.ok;
+			expect( handler.toString().match( /myplugin\/v1/ ) ).to.be.ok;
 		});
 
 		it( 'sets the /authors/ path part automatically', function() {
-			expect( handler._renderURI() ).to.equal( '/myplugin/v1/author' );
+			expect( handler.toString() ).to.equal( '/myplugin/v1/author' );
 		});
 
 		describe( '.id() method', function() {
@@ -60,7 +60,7 @@ describe( 'wp.registerRoute', function() {
 			});
 
 			it( 'sets the ID component of the path', function() {
-				expect( handler.id( 3263827 )._renderURI() ).to.equal( '/myplugin/v1/author/3263827' );
+				expect( handler.id( 3263827 ).toString() ).to.equal( '/myplugin/v1/author/3263827' );
 			});
 
 		});
@@ -115,8 +115,8 @@ describe( 'wp.registerRoute', function() {
 
 		it( 'does not overwrite preexisting methods', function() {
 			expect( handler.param ).to.equal( WPRequest.prototype.param );
-			expect( handler.param( 'foo', 'bar' )._renderURI() ).to.equal( '/ns/route?foo=bar' );
-			expect( handler.param( 'foo', 'bar' )._renderURI() ).not.to.equal( '/ns/route/foo' );
+			expect( handler.param( 'foo', 'bar' ).toString() ).to.equal( '/ns/route?foo=bar' );
+			expect( handler.param( 'foo', 'bar' ).toString() ).not.to.equal( '/ns/route/foo' );
 		});
 
 	});
@@ -142,7 +142,7 @@ describe( 'wp.registerRoute', function() {
 			});
 
 			it( 'sets the part1 component of the path', function() {
-				expect( handler.part1( 12 )._renderURI() ).to.equal( '/ns/resource/12' );
+				expect( handler.part1( 12 ).toString() ).to.equal( '/ns/resource/12' );
 			});
 
 		});
@@ -158,7 +158,7 @@ describe( 'wp.registerRoute', function() {
 			});
 
 			it( 'sets the part2 component of the path', function() {
-				expect( handler.part1( 12 ).part2( 34 )._renderURI() ).to.equal( '/ns/resource/12/34' );
+				expect( handler.part1( 12 ).part2( 34 ).toString() ).to.equal( '/ns/resource/12/34' );
 			});
 
 		});
@@ -194,11 +194,11 @@ describe( 'wp.registerRoute', function() {
 		});
 
 		it( 'can set URL query parameters', function() {
-			expect( handler.foo()._renderURI() ).to.equal( '/myplugin/v1/author?foo=true' );
+			expect( handler.foo().toString() ).to.equal( '/myplugin/v1/author?foo=true' );
 		});
 
 		it( 'can set dynamic URL query parameter values', function() {
-			expect( handler.bar( '1138' )._renderURI() ).to.equal( '/myplugin/v1/author?bar=1138' );
+			expect( handler.bar( '1138' ).toString() ).to.equal( '/myplugin/v1/author?bar=1138' );
 		});
 
 		it( 'will not overwrite existing endpoint handler prototype methods', function() {
@@ -211,7 +211,7 @@ describe( 'wp.registerRoute', function() {
 			});
 			var result = factory({
 				endpoint: '/'
-			}).id( 7 )._renderURI();
+			}).id( 7 ).toString();
 			expect( result ).not.to.equal( '/myplugin/v1/author?id=as_a_param' );
 			expect( result ).to.equal( '/myplugin/v1/author/7' );
 		});
@@ -229,24 +229,24 @@ describe( 'wp.registerRoute', function() {
 		});
 
 		it( 'sets the first static level of the route automatically', function() {
-			expect( handler._renderURI() ).to.equal( '/wp/v2/pages' );
+			expect( handler.toString() ).to.equal( '/wp/v2/pages' );
 		});
 
 		it( 'permits the first dynamic level of the route to be set with .parent', function() {
-			expect( handler.parent( 79 )._renderURI() ).to.equal( '/wp/v2/pages/79' );
+			expect( handler.parent( 79 ).toString() ).to.equal( '/wp/v2/pages/79' );
 		});
 
 		it( 'permits the second static level of the route to be set with .revisions', function() {
-			expect( handler.parent( 79 ).revisions()._renderURI() ).to.equal( '/wp/v2/pages/79/revisions' );
+			expect( handler.parent( 79 ).revisions().toString() ).to.equal( '/wp/v2/pages/79/revisions' );
 		});
 
 		it( 'permits the second dynamic level of the route to be set with .id', function() {
-			expect( handler.parent( 79 ).revisions().id( 97 )._renderURI() ).to.equal( '/wp/v2/pages/79/revisions/97' );
+			expect( handler.parent( 79 ).revisions().id( 97 ).toString() ).to.equal( '/wp/v2/pages/79/revisions/97' );
 		});
 
 		it( 'throws an error if the parts of the route provided are not contiguous', function() {
 			expect(function() {
-				handler.parent( 101 ).id( 102 )._renderURI();
+				handler.parent( 101 ).id( 102 ).toString();
 			}).to.throw();
 		});
 
@@ -261,9 +261,9 @@ describe( 'wp.registerRoute', function() {
 				endpoint: '/'
 			});
 			expect(function() {
-				handler.a( 'foo' )._renderURI();
+				handler.a( 'foo' ).toString();
 			}).to.throw;
-			expect( handler.a( 'foo_100' )._renderURI() ).to.equal( '/myplugin/one/foo_100' );
+			expect( handler.a( 'foo_100' ).toString() ).to.equal( '/myplugin/one/foo_100' );
 		});
 
 		it( 'can be bypassed if no regex is provided for a capture group', function() {
@@ -272,9 +272,9 @@ describe( 'wp.registerRoute', function() {
 				endpoint: '/'
 			});
 			expect(function() {
-				handler.a( 'foo' ).two().b( 1000 )._renderURI();
+				handler.a( 'foo' ).two().b( 1000 ).toString();
 			}).not.to.throw;
-			expect( handler.a( 'foo' ).two( 1000 )._renderURI() ).to.equal( '/myplugin/one/foo/two/1000' );
+			expect( handler.a( 'foo' ).two( 1000 ).toString() ).to.equal( '/myplugin/one/foo/two/1000' );
 		});
 
 	});
@@ -384,7 +384,7 @@ describe( 'wp.registerRoute', function() {
 
 		it( 'can be passed in to the factory method', function() {
 			var factory = registerRoute( 'myplugin', 'myroute' );
-			expect( factory({ endpoint: '/wp-yaml/' })._renderURI() ).to.equal( '/wp-yaml/myplugin/myroute' );
+			expect( factory({ endpoint: '/wp-yaml/' }).toString() ).to.equal( '/wp-yaml/myplugin/myroute' );
 		});
 
 		it( 'correctly defaults to the containing object\'s _options, if present', function() {
@@ -394,7 +394,7 @@ describe( 'wp.registerRoute', function() {
 					endpoint: '/foo/'
 				}
 			};
-			expect( obj.factory()._renderURI() ).to.equal( '/foo/myplugin/myroute' );
+			expect( obj.factory().toString() ).to.equal( '/foo/myplugin/myroute' );
 		});
 
 	});

--- a/tests/unit/route-handlers/comments.js
+++ b/tests/unit/route-handlers/comments.js
@@ -37,7 +37,7 @@ describe( 'wp.comments', function() {
 		});
 
 		it( 'should initialize the base path component', function() {
-			expect( comments._renderURI() ).to.equal( '/wp-json/wp/v2/comments' );
+			expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments' );
 		});
 
 		it( 'should set a default _supportedMethods array', function() {
@@ -62,12 +62,12 @@ describe( 'wp.comments', function() {
 
 			it( 'should set the ID value in the path', function() {
 				comments.id( 314159 );
-				expect( comments._renderURI() ).to.equal( '/wp-json/wp/v2/comments/314159' );
+				expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/314159' );
 			});
 
 			it( 'accepts ID parameters as strings', function() {
 				comments.id( '8' );
-				expect( comments._renderURI() ).to.equal( '/wp-json/wp/v2/comments/8' );
+				expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/8' );
 			});
 
 			it( 'should update the supported methods when setting ID', function() {
@@ -83,12 +83,12 @@ describe( 'wp.comments', function() {
 	describe( 'URL Generation', function() {
 
 		it( 'should create the URL for retrieving all comments', function() {
-			var path = comments._renderURI();
+			var path = comments.toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/comments' );
 		});
 
 		it( 'should create the URL for retrieving a specific comment', function() {
-			var path = comments.id( 1337 )._renderURI();
+			var path = comments.id( 1337 ).toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/comments/1337' );
 		});
 
@@ -123,8 +123,8 @@ describe( 'wp.comments', function() {
 		it( 'should restrict path changes to a single instance', function() {
 			comments.id( 2 );
 			var newComments = site.comments().id( 3 );
-			expect( comments._renderURI() ).to.equal( '/wp-json/wp/v2/comments/2' );
-			expect( newComments._renderURI() ).to.equal( '/wp-json/wp/v2/comments/3' );
+			expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/2' );
+			expect( newComments.toString() ).to.equal( '/wp-json/wp/v2/comments/3' );
 		});
 
 	});

--- a/tests/unit/route-handlers/media.js
+++ b/tests/unit/route-handlers/media.js
@@ -37,7 +37,7 @@ describe( 'wp.media', function() {
 		});
 
 		it( 'should initialize the base path component', function() {
-			expect( media._renderURI() ).to.equal( '/wp-json/wp/v2/media' );
+			expect( media.toString() ).to.equal( '/wp-json/wp/v2/media' );
 		});
 
 		it( 'should set a default _supportedMethods array', function() {
@@ -60,7 +60,7 @@ describe( 'wp.media', function() {
 
 		it( 'should set the ID value in the path', function() {
 			media.id( 8 );
-			expect( media._renderURI() ).to.equal( '/wp-json/wp/v2/media/8' );
+			expect( media.toString() ).to.equal( '/wp-json/wp/v2/media/8' );
 		});
 
 		it( 'should update the supported methods', function() {
@@ -98,17 +98,17 @@ describe( 'wp.media', function() {
 	describe( 'url generation', function() {
 
 		it( 'should create the URL for the media collection', function() {
-			var uri = media._renderURI();
+			var uri = media.toString();
 			expect( uri ).to.equal( '/wp-json/wp/v2/media' );
 		});
 
 		it( 'can paginate the media collection responses', function() {
-			var uri = media.page( 4 )._renderURI();
+			var uri = media.page( 4 ).toString();
 			expect( uri ).to.equal( '/wp-json/wp/v2/media?page=4' );
 		});
 
 		it( 'should create the URL for a specific media object', function() {
-			var uri = media.id( 1492 )._renderURI();
+			var uri = media.id( 1492 ).toString();
 			expect( uri ).to.equal( '/wp-json/wp/v2/media/1492' );
 		});
 

--- a/tests/unit/route-handlers/pages.js
+++ b/tests/unit/route-handlers/pages.js
@@ -37,7 +37,7 @@ describe( 'wp.pages', function() {
 		});
 
 		it( 'should initialize the base path component', function() {
-			expect( pages._renderURI() ).to.equal( '/wp-json/wp/v2/pages' );
+			expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages' );
 		});
 
 		it( 'should set a default _supportedMethods array', function() {
@@ -56,20 +56,20 @@ describe( 'wp.pages', function() {
 		it( 'should restrict path changes to a single instance', function() {
 			pages.id( 2 );
 			var newPages = site.pages().id( 3 ).revisions();
-			expect( pages._renderURI() ).to.equal( '/wp-json/wp/v2/pages/2' );
-			expect( newPages._renderURI() ).to.equal( '/wp-json/wp/v2/pages/3/revisions' );
+			expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages/2' );
+			expect( newPages.toString() ).to.equal( '/wp-json/wp/v2/pages/3/revisions' );
 		});
 
 		describe( 'page collections', function() {
 
 			it( 'should create the URL for retrieving all pages', function() {
-				expect( pages._renderURI() ).to.equal( '/wp-json/wp/v2/pages' );
+				expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages' );
 			});
 
 			it( 'should provide filtering methods', function() {
 				expect( pages ).to.have.property( 'filter' );
 				expect( pages.filter ).to.be.a( 'function' );
-				var path = pages.filter( 'name', 'some-slug' )._renderURI();
+				var path = pages.filter( 'name', 'some-slug' ).toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages?filter%5Bname%5D=some-slug' );
 			});
 
@@ -83,7 +83,7 @@ describe( 'wp.pages', function() {
 			});
 
 			it( 'should create the URL for retrieving a specific post', function() {
-				var path = pages.id( 1337 )._renderURI();
+				var path = pages.id( 1337 ).toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337' );
 			});
 
@@ -103,7 +103,7 @@ describe( 'wp.pages', function() {
 			});
 
 			it( 'should create the URL for retrieving a post by path', function() {
-				var path = pages.path( 'nested/page' )._renderURI();
+				var path = pages.path( 'nested/page' ).toString();
 				expect( path ).to
 					.equal( '/wp-json/wp/v2/pages?filter%5Bpagename%5D=nested%2Fpage' );
 			});
@@ -124,7 +124,7 @@ describe( 'wp.pages', function() {
 			});
 
 			it( 'should create the URL for a page\'s comments collection', function() {
-				var path = pages.id( 1337 ).comments()._renderURI();
+				var path = pages.id( 1337 ).comments().toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/comments' );
 			});
 
@@ -135,7 +135,7 @@ describe( 'wp.pages', function() {
 			});
 
 			it( 'should create the URL for retrieving a specific comment', function() {
-				var path = pages.id( 1337 ).comments().comment( 9001 )._renderURI();
+				var path = pages.id( 1337 ).comments().comment( 9001 ).toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/comments/9001' );
 			});
 
@@ -146,7 +146,7 @@ describe( 'wp.pages', function() {
 			});
 
 			it( 'should force action "comments" when calling .comment()', function() {
-				var path = pages.id( 1337 ).comment( 9002 )._renderURI();
+				var path = pages.id( 1337 ).comment( 9002 ).toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/comments/9002' );
 			});
 
@@ -160,7 +160,7 @@ describe( 'wp.pages', function() {
 			});
 
 			it( 'should create the URL for retrieving the revisions for a specific post', function() {
-				var path = pages.id( 1337 ).revisions()._renderURI();
+				var path = pages.id( 1337 ).revisions().toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/revisions' );
 			});
 

--- a/tests/unit/route-handlers/posts.js
+++ b/tests/unit/route-handlers/posts.js
@@ -37,7 +37,7 @@ describe( 'wp.posts', function() {
 		});
 
 		it( 'should initialize the base path component', function() {
-			expect( posts._renderURI() ).to.equal( '/wp-json/wp/v2/posts' );
+			expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts' );
 		});
 
 		it( 'should set a default _supportedMethods array', function() {
@@ -62,12 +62,12 @@ describe( 'wp.posts', function() {
 
 			it( 'should set the ID value in the path', function() {
 				posts.id( 314159 );
-				expect( posts._renderURI() ).to.equal( '/wp-json/wp/v2/posts/314159' );
+				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/314159' );
 			});
 
 			it( 'accepts ID parameters as strings', function() {
 				posts.id( '8' );
-				expect( posts._renderURI() ).to.equal( '/wp-json/wp/v2/posts/8' );
+				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/8' );
 			});
 
 			it( 'should update the supported methods when setting ID', function() {
@@ -87,7 +87,7 @@ describe( 'wp.posts', function() {
 
 			it( 'provides a method to get the meta values for a post', function() {
 				posts.id( 3 ).meta();
-				expect( posts._renderURI() ).to.equal( '/wp-json/wp/v2/posts/3/meta' );
+				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/3/meta' );
 			});
 
 			it( 'should force authentication when querying posts/id/meta', function() {
@@ -104,7 +104,7 @@ describe( 'wp.posts', function() {
 
 			it( 'provides a method to get specific post meta objects by ID', function() {
 				posts.id( 3 ).meta( 5 );
-				expect( posts._renderURI() ).to.equal( '/wp-json/wp/v2/posts/3/meta/5' );
+				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/3/meta/5' );
 			});
 
 			it( 'should force authentication when querying posts/id/meta/:id', function() {
@@ -126,12 +126,12 @@ describe( 'wp.posts', function() {
 	describe( 'URL Generation', function() {
 
 		it( 'should create the URL for retrieving all posts', function() {
-			var path = posts._renderURI();
+			var path = posts.toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts' );
 		});
 
 		it( 'should create the URL for retrieving a specific post', function() {
-			var path = posts.id( 1337 )._renderURI();
+			var path = posts.id( 1337 ).toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337' );
 		});
 
@@ -164,30 +164,30 @@ describe( 'wp.posts', function() {
 		});
 
 		it.skip( 'should create the URL for retrieving all meta for a specific post', function() {
-			var path = posts.id( 1337 ).meta()._renderURI();
+			var path = posts.id( 1337 ).meta().toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/meta' );
 		});
 
 		it.skip( 'should create the URL for retrieving a specific meta item', function() {
-			var path = posts.id( 1337 ).meta( 2001 )._renderURI();
+			var path = posts.id( 1337 ).meta( 2001 ).toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/meta/2001' );
 		});
 
 		it( 'should create the URL for retrieving the revisions for a specific post', function() {
-			var path = posts.id( 1337 ).revisions()._renderURI();
+			var path = posts.id( 1337 ).revisions().toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/revisions' );
 		});
 
 		it( 'should create the URL for retrieving a specific revision item', function() {
-			var path = posts.id( 1337 ).revisions( 2001 )._renderURI();
+			var path = posts.id( 1337 ).revisions( 2001 ).toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/revisions/2001' );
 		});
 
 		it( 'should restrict path changes to a single instance', function() {
 			posts.id( 2 );
 			var newPosts = site.posts().id( 3 ).revisions();
-			expect( posts._renderURI() ).to.equal( '/wp-json/wp/v2/posts/2' );
-			expect( newPosts._renderURI() ).to.equal( '/wp-json/wp/v2/posts/3/revisions' );
+			expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/2' );
+			expect( newPosts.toString() ).to.equal( '/wp-json/wp/v2/posts/3/revisions' );
 		});
 
 	});

--- a/tests/unit/route-handlers/taxonomies.js
+++ b/tests/unit/route-handlers/taxonomies.js
@@ -37,7 +37,7 @@ describe( 'wp.taxonomies', function() {
 		});
 
 		it( 'should initialize the base path component', function() {
-			expect( taxonomies._renderURI() ).to.equal( '/wp-json/wp/v2/taxonomies' );
+			expect( taxonomies.toString() ).to.equal( '/wp-json/wp/v2/taxonomies' );
 		});
 
 		it( 'should set a default _supportedMethods array', function() {
@@ -67,12 +67,12 @@ describe( 'wp.taxonomies', function() {
 	describe( 'URL Generation', function() {
 
 		it( 'should create the URL for retrieving all taxonomies', function() {
-			var url = taxonomies._renderURI();
+			var url = taxonomies.toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies' );
 		});
 
 		it( 'should create the URL for retrieving a specific taxonomy', function() {
-			var url = taxonomies.taxonomy( 'category' )._renderURI();
+			var url = taxonomies.taxonomy( 'category' ).toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies/category' );
 		});
 

--- a/tests/unit/route-handlers/types.js
+++ b/tests/unit/route-handlers/types.js
@@ -37,7 +37,7 @@ describe( 'wp.types', function() {
 		});
 
 		it( 'should initialize the base path component', function() {
-			expect( types._renderURI() ).to.equal( '/wp-json/wp/v2/types' );
+			expect( types.toString() ).to.equal( '/wp-json/wp/v2/types' );
 		});
 
 		it( 'should set a default _supportedMethods array', function() {
@@ -54,12 +54,12 @@ describe( 'wp.types', function() {
 	describe( 'URL Generation', function() {
 
 		it( 'should create the URL for retrieving all types', function() {
-			var url = types._renderURI();
+			var url = types.toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/types' );
 		});
 
 		it( 'should create the URL for retrieving a specific term', function() {
-			var url = types.type( 'some_type' )._renderURI();
+			var url = types.type( 'some_type' ).toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/types/some_type' );
 		});
 

--- a/tests/unit/route-handlers/users.js
+++ b/tests/unit/route-handlers/users.js
@@ -37,7 +37,7 @@ describe( 'wp.users', function() {
 		});
 
 		it( 'should initialize the base path component', function() {
-			expect( users._renderURI() ).to.equal( '/wp-json/wp/v2/users' );
+			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users' );
 		});
 
 		it( 'should set a default _supportedMethods array', function() {
@@ -55,7 +55,7 @@ describe( 'wp.users', function() {
 
 		it( 'sets the path to users/me', function() {
 			users.me();
-			expect( users._renderURI() ).to.equal( '/wp-json/wp/v2/users/me' );
+			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users/me' );
 		});
 
 	});
@@ -69,25 +69,25 @@ describe( 'wp.users', function() {
 
 		it( 'sets the path ID to the passed-in value', function() {
 			users.id( 2501 );
-			expect( users._renderURI() ).to.equal( '/wp-json/wp/v2/users/2501' );
+			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users/2501' );
 		});
 
 	});
 
-	describe( 'prototype._renderURI', function() {
+	describe( 'prototype.toString', function() {
 
 		it( 'should create the URL for retrieving all users', function() {
-			var url = users._renderURI();
+			var url = users.toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/users' );
 		});
 
 		it( 'should create the URL for retrieving the current user', function() {
-			var url = users.me()._renderURI();
+			var url = users.me().toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/users/me' );
 		});
 
 		it( 'should create the URL for retrieving a specific user by ID', function() {
-			var url = users.id( 1337 )._renderURI();
+			var url = users.id( 1337 ).toString();
 			var _supportedMethods = users._supportedMethods.sort().join( '|' );
 			expect( url ).to.equal( '/wp-json/wp/v2/users/1337' );
 			expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );

--- a/tests/unit/wp.js
+++ b/tests/unit/wp.js
@@ -88,7 +88,7 @@ describe( 'wp', function() {
 			expect( site ).not.to.have.property( 'comments' );
 			expect( site.posts() ).not.to.have.property( 'id' );
 			expect( site.posts().filter ).to.be.a( 'function' );
-			expect( site.posts()._renderURI() ).to.equal( 'endpoint/url/wp/v2/posts' );
+			expect( site.posts().toString() ).to.equal( 'endpoint/url/wp/v2/posts' );
 		});
 
 	});
@@ -194,7 +194,7 @@ describe( 'wp', function() {
 			var thingHandler = site.customendpoint();
 			expect( thingHandler ).to.have.property( 'thing' );
 			expect( thingHandler.thing ).to.be.a( 'function' );
-			expect( thingHandler.thing( 'foobar' )._renderURI() ).to.equal( 'endpoint/url/wp/v2/customendpoint/foobar' );
+			expect( thingHandler.thing( 'foobar' ).toString() ).to.equal( 'endpoint/url/wp/v2/customendpoint/foobar' );
 		});
 
 		it( 'assigns any mixins for detected GET arguments for custom namespace handlers', function() {
@@ -231,7 +231,7 @@ describe( 'wp', function() {
 
 		it( 'maps requests directly onto the provided URL', function() {
 			var request = site.url( 'http://some.url.com/wp-json?filter[name]=some-slug' );
-			var path = request._renderURI();
+			var path = request.toString();
 			expect( path ).to.equal( 'http://some.url.com/wp-json?filter[name]=some-slug' );
 		});
 
@@ -262,12 +262,12 @@ describe( 'wp', function() {
 
 		it( 'creates a get request against the root endpoint', function() {
 			var request = site.root();
-			expect( request._renderURI() ).to.equal( 'http://my.site.com/wp-json/' );
+			expect( request.toString() ).to.equal( 'http://my.site.com/wp-json/' );
 		});
 
 		it( 'takes a "path" argument to query a root-relative path', function() {
 			var request = site.root( 'custom/endpoint' );
-			expect( request._renderURI() ).to.equal( 'http://my.site.com/wp-json/custom/endpoint' );
+			expect( request.toString() ).to.equal( 'http://my.site.com/wp-json/custom/endpoint' );
 		});
 
 		it( 'creates a WPRequest object', function() {


### PR DESCRIPTION
`._renderURI` is arguably the most important single method this library provides; it would be possible (and should eventually be easy) to use the query builder interface independently of any specific HTTP library like superagent, _e.g._ if you wanted to use jQuery or `fetch` to send requests, so long as you have the ability to get at the full, rendered URI for the API query you need to execute.

As such, having this be exclusively "private" (or as private as `_methods` ever can be) functionality has proved confusing. Exposing `_renderURI` as `.toString` makes it a first-class public citizen of the library, and makes it more obvious how the query methods lead to the generation of a URI that is then converted into an HTTP request action by one of the HTTP terminator methods.

`_requestURI` is now deprecated and will be removed in the next release (along with the deprecated "http verb" versions of the request terminators)