### PR TITLE
Implement `.transport()` prototype method & document transport customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is a client for the [WordPress REST API](http://v2.wp-api.org/). It is **un
   - [Custom Routes](#custom-routes)
 - [Embedding Data](#embedding-data)
 - [Paginated Collections](#working-with-paged-response-data)
+- [Customizing HTTP Request Behavior](#customizing-http-request-behavior)
 - [Authentication](#authentication)
 - [API Documentation](#api-documentation)
 - [Issues](#issues)
@@ -538,6 +539,58 @@ You can also use a `.page(pagenumber)` method on calls that support pagination t
 ```js
 wp.posts().perPage( 5 ).page( 3 ).then(/* ... */);
 ```
+
+## Customizing HTTP Request Behavior
+
+By default `node-wpapi` uses the [superagent](https://www.npmjs.com/package/superagent) library internally to make HTTP requests against the API endpoints. Superagent is a flexible tool that works on both the client and the browser, but you may want to use a different HTTP library, or to get data from a cache when available instead of making an HTTP request. To facilitate this, `node-wpapi` lets you supply a `transport` object when instantiating a site client to specify custom functions to use for one (or all) of GET, POST, PUT, DELETE & HEAD requests.
+
+**This is advanced behavior; you will only need to utilize this functionality if your application has very specific HTTP handling or caching requirements.**
+
+In order to maintain consistency with the rest of the API, custom transport methods should take in a WordPress API route handler query object (_e.g._ the result of calling `wp.posts()...` or any of the other chaining resource handlers), a `data` object (for POST, PUT and DELETE requests), and an optional callback function (as `node-wpapi` transport methods both return Promise objects _and_ support traditional `function( err, response )` callbacks).
+
+The default HTTP transport methods are available as `WP.transport` (a property of the constructor object) and may be called within your transports if you wish to extend the existing behavior, as in the example below.
+
+**Example:** Cache requests in a simple dictionary object, keyed by request URI. If a request's response is already available, serve from the cache; if not, use the default GET transport method to retrieve the data, save it in the cache, and return it to the consumer:
+
+```js
+var site = new WP({
+  endpoint: 'http://my-site.com/wp-json',
+  transport: {
+    // Only override the transport for the GET method, in this example
+    // Transport methods should take a wpquery object and a callback:
+    get: function( wpquery, cb ) {
+      var result = cache[ wpquery ];
+      // If a cache hit is found, return it via the same callback/promise
+      // signature as the default transport method:
+      if ( result ) {
+        if ( cb && typeof cb === 'function' ) {
+          // Invoke the callback function, if one was provided
+          cb( null, result );
+        }
+        // Return the data as a promise
+        return Promise.resolve( result );
+      }
+
+      // Delegate to default transport if no cached data was found
+      return WP.transport.get( wpquery, cb ).then(function( result ) {
+        cache[ wpquery ] = result;
+        return result;
+      });
+    }
+  }
+});
+```
+
+You may set one or many custom HTTP transport methods on an existing WP site client instance (for example one returned through [Auto-discovery](#auto-discovery) by calling the `.transport()` method on the site client instance and passing an object of handler functions:
+
+```js
+site.transport({
+    get: function( wpquery, callbackFn ) { /* ... */},
+    put: function( wpquery, callbackFn ) { /* ... */}
+});
+```
+
+Note that these transport methods are the internal methods used by `create` and `.update`, so the names of these methods therefore map to the HTTP verbs "get", "post", "put", "head" and "delete"; name your transport methods accordingly or they will not be used.
 
 ## Authentication
 

--- a/tests/unit/wp.js
+++ b/tests/unit/wp.js
@@ -406,6 +406,50 @@ describe( 'wp', function() {
 
 		});
 
+		describe( '.transport()', function() {
+
+			it( 'is defined', function() {
+				expect( site ).to.have.property( 'transport' );
+			});
+
+			it( 'is a function', function() {
+				expect( site.transport ).to.be.a( 'function' );
+			});
+
+			it( 'is chainable', function() {
+				expect( site.transport() ).to.equal( site );
+			});
+
+			it( 'sets transport methods on the instance', function() {
+				sinon.stub( httpTransport, 'get' );
+				var customGet = sinon.stub();
+				site.transport({
+					get: customGet
+				});
+				function cb() {}
+				var query = site.root( '' );
+				query.get( cb );
+				expect( httpTransport.get ).not.to.have.been.called;
+				expect( customGet ).to.have.been.calledWith( query, cb );
+				httpTransport.get.restore();
+			});
+
+			it( 'does not impact or overwrite unspecified transport methods', function() {
+				var originalMethods = Object.assign( {}, site._options.transport );
+				site.transport({
+					get: function() {},
+					put: function() {}
+				});
+				var newMethods = Object.assign( {}, site._options.transport );
+				expect( newMethods.delete ).to.equal( originalMethods.delete );
+				expect( newMethods.post ).to.equal( originalMethods.post );
+
+				expect( newMethods.get ).not.to.equal( originalMethods.get );
+				expect( newMethods.put ).not.to.equal( originalMethods.put );
+			});
+
+		});
+
 		describe( '.url()', function() {
 
 			it( 'is defined', function() {


### PR DESCRIPTION
This follows #220 by providing a method by which transport functions can be set on a preexisting `WP` instance object, such as one returned through the auto-discovery flow. Documentation around HTTP behavior customization and extension has been added to the README.