### PR TITLE
Release v0.10.0 "Abaporu"

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ More robust authentication methods will hopefully be added; we would welcome con
 
 When the library is loaded from the frontend of the WordPress site you are querying against, you can utilize the build in [Cookie authentication](http://wp-api.org/guides/authentication.html) supported by WP REST API.
 
-First localize your scripts with an object with root-url and nonce in your theme's `functions.php` or your plugin::
+First localize your scripts with an object with root-url and nonce in your theme's `functions.php` or your plugin:
 
 ```php
 function my_enqueue_scripts() {

--- a/build/grunt/yuidoc.js
+++ b/build/grunt/yuidoc.js
@@ -9,7 +9,7 @@ module.exports = function( grunt ) {
 			url: '<%= pkg.homepage %>',
 			options: {
 				ignorePaths: [ 'node_modules', 'tests', 'browser' ],
-				exclude: 'browser',
+				exclude: 'browser,bin,build,tests',
 				paths: '.',
 				themedir: './docs-theme',
 				// theme: 'simple',

--- a/documentation/index.html.combyne
+++ b/documentation/index.html.combyne
@@ -15,7 +15,7 @@ layout: default
     <ol class="post-list">
     [{%each readmeSections as section %}]
       <li>
-        <a class="post-link" href="{{ "/<< section.slug >>" | prepend: site.baseurl }}">[{{{
+        <a class="post-link" href="{{ "/[{{ section.slug }}]" | prepend: site.baseurl }}">[{{{
           section.title
         }}}]</a>
         [{%if section.hasSubheadings %}]

--- a/lib/wp-register-route.js
+++ b/lib/wp-register-route.js
@@ -11,7 +11,7 @@ var generateEndpointFactories = require( './endpoint-factories' ).generate;
  * The first two parameters mirror `register_rest_route` in the REST API
  * codebase:
  *
- * @class wp
+ * @class WPAPI
  * @method registerRoute
  * @param {string}   namespace         A namespace string, e.g. 'myplugin/v1'
  * @param {string}   restBase          A REST route string, e.g. '/author/(?P<id>\d+)'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "url": "http://www.kadamwhite.com"
   },
   "name": "wpapi",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "A client for interacting with the WordPress REST API",
   "main": "wpapi.js",
   "repository": {


### PR DESCRIPTION
v0.10 standardizes the name of the constructor exposed by this module as "WPAPI", and creates a seam through which HTTP interactions can be customized or overridden. This release is named for Brazilian DJ Gui Boratto's fourth studio album _Abaporu_ (Kompakt, 2014).

**Module Naming**

The constructor exposed by this module should be referred to as `WPAPI` in all cases. This has been updated across the documentation site, source code, and examples within code comments.

There is remaining inconsistency throughout the docs & test suite between whether an _instance_ of `WPAPI` is referred to as `wp` or as `site`; this will not be addressed at this time, the identifier used to hold the WP site client instance is left up to the library consumer.

**Custom HTTP Transport Behavior**

Custom HTTP transport methods may be provided to inject or short-circuit HTTP behavior for each type of request; methods may be specified via a `.transport` property on the configuration object passed to the `WP` constructor, or by passing an object of transport methods to the `.transport()` method on the instantiated `WP` object.

**Props**

@edygar