### PR TITLE
Add parameter setter for .sticky()

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,16 @@ wp.categories().search( 'news' )...
 wp.posts().before( '2013-04-01T00:00:00.000Z' ).after( new Date( 'March 01, 2013' ) )...
 ```
 
+If you are using the **latest development branch** of the API plugin, there are a few more new query parameter methods you may take advantage of:
+
+```js
+// Return ONLY sticky posts
+wp.posts().sticky( true )...
+
+// Return NO sticky posts
+wp.posts().sticky( false )...
+```
+
 #### Paging & Sorting
 
 Convenience methods are also available to set paging & sorting properties like `page`, `per_page` (available as `.perPage()`), `offset`, `order` and `orderby`:

--- a/lib/mixins/parameters.js
+++ b/lib/mixins/parameters.js
@@ -8,6 +8,7 @@
  *
  * @module filters
  */
+var paramSetter = require( '../util/parameter-setter' );
 
 var parameterMixins = {};
 
@@ -86,10 +87,18 @@ parameterMixins.parent = function( parentId ) {
  * @param {String|Number} post The ID of the post for which to retrieve terms
  * @return The request instance (for chaining)
  */
-parameterMixins.forPost = function( postId ) {
-	/* jshint validthis:true */
-	return this.param( 'post', postId );
-};
+parameterMixins.forPost = paramSetter( 'post' );
+
+/**
+ * Specify whether to return only, or to completely exclude, sticky posts
+ *
+ * @method sticky
+ * @chainable
+ * @param {boolean} sticky A boolean value for whether ONLY sticky posts (true) or
+ *                         NO sticky posts (false) should be returned in the query
+ * @returns The request instance (for chaining)
+ */
+parameterMixins.sticky = paramSetter( 'sticky' );
 
 // Date Methods
 // ============

--- a/tests/unit/lib/mixins/parameters.js
+++ b/tests/unit/lib/mixins/parameters.js
@@ -248,4 +248,39 @@ describe( 'mixins: parameters', function() {
 
 	});
 
+	describe( 'sticky', function() {
+
+		beforeEach(function() {
+			Req.prototype.sticky = parameterMixins.sticky;
+		});
+
+		it( 'mixin method is defined', function() {
+			expect( parameterMixins ).to.have.property( 'sticky' );
+		});
+
+		it( 'is a function', function() {
+			expect( parameterMixins.sticky ).to.be.a( 'function' );
+		});
+
+		it( 'supports chaining', function() {
+			expect( req.sticky() ).to.equal( req );
+		});
+
+		it( 'has no effect when called with no argument', function() {
+			var result = req.sticky();
+			expect( getQueryStr( result ) ).to.equal( '' );
+		});
+
+		it( 'sets the "sticky" query parameter when provided a value', function() {
+			var result = req.sticky( true );
+			expect( getQueryStr( result ) ).to.equal( 'sticky=true' );
+		});
+
+		it( 'overwrites previously-set values on subsequent calls', function() {
+			var result = req.sticky( 1 ).sticky( 0 );
+			expect( getQueryStr( result ) ).to.equal( 'sticky=0' );
+		});
+
+	});
+
 });


### PR DESCRIPTION
This is an anticipatory change for compatibility with the latest develop branch of the REST API plugin, which added support for a "sticky" param used to either return only, or else no, sticky posts, depending on what boolean value is passed.

See WP-API/WP-API#2708