### PR TITLE
Release v0.11.0 "Super"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "url": "http://www.kadamwhite.com"
   },
   "name": "wpapi",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A client for interacting with the WordPress REST API",
   "main": "wpapi.js",
   "repository": {


### PR DESCRIPTION
The theme for v0.11 is better parameter handling. Several parameters are now supported that apply to all default content routes, and this release also features a [complete overhaul][a] of the handling for registering mixins and custom query parameter setters with `.registerRoute()`.

**Parameter convenience methods**

`.order()`, `.orderby()`, `.offset()`, `.exclude()`, `.include()`, `.page()`, `.perPage()` and `.slug()` are now supported for _all_ request handlers generated by this library, not just for some resources.

**Setting Parameters on Custom Routes**

The `.param( name, val )` method is always available for custom route handler instances, but the convenience of `.filter` and other overloaded setters was not available to custom routes without some sleuthing through the code for this library (#203). To remedy this situation, a `params` array can now be provided on the `registerRoute` configuration object. If a method is available for a parameter (such as `filter`), it will be used; if no method exists, a setter for that property will be created:

```js
site.handler = site.registerRoute( 'myplugin/v1', 'collection/(?P<id>)', {
    params: [
      // Listing any of the parameters with built-in handlers will
      // assign that built-in chaining method to the route handler:
      'filter',
      'author',
      // `.customparam()` will be created as well, as a shortcut
      // for `.param( 'customparam', val )
      'customparam'
    ]
});
```

**Parameter convenience methods for Beta 14+ & beyond**

If you are running the bleeding-edge `develop` branch of the API, there is now a `.sticky( [boolean] )` method to support the new sticky posts handling recently added to the REST API.

If you are actually running the REST API plugin _in the future_, this library now also provides a `.password()` method for use in setting the password needed to access the content for a password-protected post. (The PR for adding that parameter should land later this week.)

This release is named for the Pet Shop Boys' latest album [_Super_][b].

Closes #231 by releasing the results of #178

[a]: https://github.com/WP-API/node-wpapi#custom-routes
[b]: http://whatissuper.co/