### PR TITLE
Always use authentication when credentials are available

### DIFF
--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -613,7 +613,7 @@ describe( 'WPRequest', function() {
 			expect( request.auth ).to.be.a( 'function' );
 		});
 
-		it( 'sets the "auth" option to "true"', function() {
+		it( 'activates authentication for the request', function() {
 			expect( request._options ).not.to.have.property( 'auth' );
 			request.auth();
 			expect( request._options ).to.have.property( 'auth' );
@@ -656,6 +656,29 @@ describe( 'WPRequest', function() {
 			});
 			expect( request._options ).not.to.have.property( 'username' );
 			expect( request._options ).not.to.have.property( 'password' );
+			expect( request._options ).to.have.property( 'auth' );
+			expect( request._options.auth ).to.be.true;
+		});
+
+		it( 'sets the nonce when provided in an object', function() {
+			expect( request._options ).not.to.have.property( 'nonce' );
+			request.auth({
+				nonce: 'nonceynonce'
+			});
+			expect( request._options ).to.have.property( 'nonce' );
+			expect( request._options.nonce ).to.equal( 'nonceynonce' );
+			expect( request._options ).to.have.property( 'auth' );
+			expect( request._options.auth ).to.be.true;
+		});
+
+		it( 'can update nonce credentials', function() {
+			request.auth({
+				nonce: 'nonceynonce'
+			}).auth({
+				nonce: 'refreshednonce'
+			});
+			expect( request._options ).to.have.property( 'nonce' );
+			expect( request._options.nonce ).to.equal( 'refreshednonce' );
 			expect( request._options ).to.have.property( 'auth' );
 			expect( request._options.auth ).to.be.true;
 		});

--- a/tests/unit/route-handlers/comments.js
+++ b/tests/unit/route-handlers/comments.js
@@ -27,11 +27,9 @@ describe( 'wp.comments', function() {
 		});
 
 		it( 'should initialize _options to the site defaults', function() {
-			expect( comments._options ).to.deep.equal({
-				endpoint: '/wp-json/',
-				username: 'foouser',
-				password: 'barpass'
-			});
+			expect( comments._options.endpoint ).to.equal( '/wp-json/' );
+			expect( comments._options.username ).to.equal( 'foouser' );
+			expect( comments._options.password ).to.equal( 'barpass' );
 		});
 
 		it( 'should initialize the base path component', function() {

--- a/tests/unit/route-handlers/media.js
+++ b/tests/unit/route-handlers/media.js
@@ -27,11 +27,9 @@ describe( 'wp.media', function() {
 		});
 
 		it( 'should initialize _options to the site defaults', function() {
-			expect( media._options ).to.deep.equal({
-				endpoint: '/wp-json/',
-				username: 'foouser',
-				password: 'barpass'
-			});
+			expect( media._options.endpoint ).to.equal( '/wp-json/' );
+			expect( media._options.username ).to.equal( 'foouser' );
+			expect( media._options.password ).to.equal( 'barpass' );
 		});
 
 		it( 'should initialize the base path component', function() {

--- a/tests/unit/route-handlers/pages.js
+++ b/tests/unit/route-handlers/pages.js
@@ -27,11 +27,9 @@ describe( 'wp.pages', function() {
 		});
 
 		it( 'should initialize _options to the site defaults', function() {
-			expect( pages._options ).to.deep.equal({
-				endpoint: '/wp-json/',
-				username: 'foouser',
-				password: 'barpass'
-			});
+			expect( pages._options.endpoint ).to.equal( '/wp-json/' );
+			expect( pages._options.username ).to.equal( 'foouser' );
+			expect( pages._options.password ).to.equal( 'barpass' );
 		});
 
 		it( 'should initialize the base path component', function() {

--- a/tests/unit/route-handlers/posts.js
+++ b/tests/unit/route-handlers/posts.js
@@ -27,11 +27,9 @@ describe( 'wp.posts', function() {
 		});
 
 		it( 'should initialize _options to the site defaults', function() {
-			expect( posts._options ).to.deep.equal({
-				endpoint: '/wp-json/',
-				username: 'foouser',
-				password: 'barpass'
-			});
+			expect( posts._options.endpoint ).to.equal( '/wp-json/' );
+			expect( posts._options.username ).to.equal( 'foouser' );
+			expect( posts._options.password ).to.equal( 'barpass' );
 		});
 
 		it( 'should initialize the base path component', function() {

--- a/tests/unit/route-handlers/taxonomies.js
+++ b/tests/unit/route-handlers/taxonomies.js
@@ -27,11 +27,9 @@ describe( 'wp.taxonomies', function() {
 		});
 
 		it( 'should initialize _options to the site defaults', function() {
-			expect( taxonomies._options ).to.deep.equal({
-				endpoint: '/wp-json/',
-				username: 'foouser',
-				password: 'barpass'
-			});
+			expect( taxonomies._options.endpoint ).to.equal( '/wp-json/' );
+			expect( taxonomies._options.username ).to.equal( 'foouser' );
+			expect( taxonomies._options.password ).to.equal( 'barpass' );
 		});
 
 		it( 'should initialize the base path component', function() {

--- a/tests/unit/route-handlers/types.js
+++ b/tests/unit/route-handlers/types.js
@@ -27,11 +27,9 @@ describe( 'wp.types', function() {
 		});
 
 		it( 'should initialize _options to the site defaults', function() {
-			expect( types._options ).to.deep.equal({
-				endpoint: '/wp-json/',
-				username: 'foouser',
-				password: 'barpass'
-			});
+			expect( types._options.endpoint ).to.equal( '/wp-json/' );
+			expect( types._options.username ).to.equal( 'foouser' );
+			expect( types._options.password ).to.equal( 'barpass' );
 		});
 
 		it( 'should initialize the base path component', function() {

--- a/tests/unit/route-handlers/users.js
+++ b/tests/unit/route-handlers/users.js
@@ -27,11 +27,9 @@ describe( 'wp.users', function() {
 		});
 
 		it( 'should initialize _options to the site defaults', function() {
-			expect( users._options ).to.deep.equal({
-				endpoint: '/wp-json/',
-				username: 'foouser',
-				password: 'barpass'
-			});
+			expect( users._options.endpoint ).to.equal( '/wp-json/' );
+			expect( users._options.username ).to.equal( 'foouser' );
+			expect( users._options.password ).to.equal( 'barpass' );
 		});
 
 		it( 'should initialize the base path component', function() {

--- a/tests/unit/wpapi.js
+++ b/tests/unit/wpapi.js
@@ -23,10 +23,10 @@ describe( 'wp', function() {
 	describe( 'constructor', function() {
 
 		it( 'enforces new', function() {
-			var wp1 = new WPAPI({ endpoint: '/' });
-			expect( wp1 instanceof WPAPI ).to.be.true;
-			var wp2 = WPAPI({ endpoint: '/' });
-			expect( wp2 instanceof WPAPI ).to.be.true;
+			var site1 = new WPAPI({ endpoint: '/' });
+			expect( site1 instanceof WPAPI ).to.be.true;
+			var site2 = WPAPI({ endpoint: '/' });
+			expect( site2 instanceof WPAPI ).to.be.true;
 		});
 
 		it( 'throws an error if no endpoint is provided', function() {
@@ -51,14 +51,25 @@ describe( 'wp', function() {
 		});
 
 		it( 'sets options on an instance variable', function() {
-			var wp = new WPAPI({
+			var site = new WPAPI({
 				endpoint: 'http://some.url.com/wp-json',
 				username: 'fyodor',
 				password: 'dostoyevsky'
 			});
-			expect( wp._options.endpoint ).to.equal( 'http://some.url.com/wp-json/' );
-			expect( wp._options.username ).to.equal( 'fyodor' );
-			expect( wp._options.password ).to.equal( 'dostoyevsky' );
+			expect( site._options.endpoint ).to.equal( 'http://some.url.com/wp-json/' );
+			expect( site._options.username ).to.equal( 'fyodor' );
+			expect( site._options.password ).to.equal( 'dostoyevsky' );
+		});
+
+		it( 'activates authentication when credentials are provided', function() {
+			var site = new WPAPI({
+				endpoint: 'http://some.url.com/wp-json',
+				username: 'fyodor',
+				password: 'dostoyevsky'
+			});
+			expect( site._options.username ).to.equal( 'fyodor' );
+			expect( site._options.password ).to.equal( 'dostoyevsky' );
+			expect( site._options.auth ).to.be.true;
 		});
 
 		describe( 'assigns default HTTP transport', function() {
@@ -301,7 +312,10 @@ describe( 'wp', function() {
 			});
 
 			it( 'passes options from the parent WPAPI instance to the namespaced handlers', function() {
-				site.auth( 'u', 'p' );
+				site.auth({
+					username: 'u',
+					password: 'p'
+				});
 				var pages = site.namespace( 'wp/v2' ).pages();
 				expect( pages._options ).to.be.an( 'object' );
 				expect( pages._options ).to.have.property( 'username' );
@@ -311,7 +325,10 @@ describe( 'wp', function() {
 			});
 
 			it( 'permits the namespace to be stored in a variable without disrupting options', function() {
-				site.auth( 'u', 'p' );
+				site.auth({
+					username: 'u',
+					password: 'p'
+				});
 				var wpV2 = site.namespace( 'wp/v2' );
 				var pages = wpV2.pages();
 				expect( pages._options ).to.be.an( 'object' );
@@ -470,11 +487,11 @@ describe( 'wp', function() {
 			});
 
 			it( 'inherits whitelisted non-endpoint options from the parent WPAPI instance', function() {
-				var wp = new WPAPI({
+				var site = new WPAPI({
 					endpoint: 'http://website.com/',
 					identifier: 'some unique value'
 				});
-				var request = wp.url( 'http://new-endpoint.com/' );
+				var request = site.url( 'http://new-endpoint.com/' );
 				expect( request._options ).to.have.property( 'endpoint' );
 				expect( request._options.endpoint ).to.equal( 'http://new-endpoint.com/' );
 				expect( request._options ).not.to.have.property( 'identifier' );
@@ -509,10 +526,10 @@ describe( 'wp', function() {
 			});
 
 			it( 'inherits options from the parent WPAPI instance', function() {
-				var wp = new WPAPI({
+				var site = new WPAPI({
 					endpoint: 'http://cat.website.com/'
 				});
-				var request = wp.root( 'custom-path' );
+				var request = site.root( 'custom-path' );
 				expect( request._options ).to.have.property( 'endpoint' );
 				expect( request._options.endpoint ).to.equal( 'http://cat.website.com/' );
 			});
@@ -530,7 +547,7 @@ describe( 'wp', function() {
 				expect( site.auth ).to.be.a( 'function' );
 			});
 
-			it( 'sets the "auth" option to "true"', function() {
+			it( 'activates authentication for the site', function() {
 				expect( site._options ).not.to.have.property( 'auth' );
 				site.auth();
 				expect( site._options ).to.have.property( 'auth' );

--- a/wpapi.js
+++ b/wpapi.js
@@ -29,11 +29,7 @@ var generateEndpointFactories = require( './lib/endpoint-factories' ).generate;
 // is to be bootstrapped with the handlers for all of the built-in routes)
 var defaultEndpointFactories;
 
-var defaults = {
-	username: '',
-	password: ''
-};
-
+// Constant used to detect first-party WordPress REST API routes
 var apiDefaultNamespace = 'wp/v2';
 
 // Pull in autodiscovery methods
@@ -72,17 +68,22 @@ function WPAPI( options ) {
 		return new WPAPI( options );
 	}
 
-	// Dictionary to be filled by handlers for default namespaces
-	this._ns = {};
-
-	this._options = extend( {}, defaults, options );
-
-	if ( typeof this._options.endpoint !== 'string' ) {
+	if ( typeof options.endpoint !== 'string' ) {
 		throw new Error( 'options hash must contain an API endpoint URL string' );
 	}
 
-	// Ensure trailing slash on endpoint URI
-	this._options.endpoint = this._options.endpoint.replace( /\/?$/, '/' );
+	// Dictionary to be filled by handlers for default namespaces
+	this._ns = {};
+
+	this._options = {
+		// Ensure trailing slash on endpoint URI
+		endpoint: options.endpoint.replace(  /\/?$/, '/' )
+	};
+
+	// If any authentication credentials were provided, assign them now
+	if ( options && ( options.username || options.password || options.nonce ) ) {
+		this.auth( options );
+	}
 
 	return this
 		// Configure custom HTTP transport methods, if provided


### PR DESCRIPTION
Up to now, if a username and password (or nonce) were supplied when instantiating a WPAPI instance, those credentials would not be used by default. This meant that these requests would be handled differently in terms of authentication, despite having all the same information:

```js
// Authenticated
site = new WPAPI({
  endpoint: 'some.website.com/wp-json'
}).auth({
  username: 'bananayoshimoto',
  password: 'kitchen'
});
site.posts()...

// NOT Authenticated
site = new WPAPI({
  endpoint: 'some.website.com/wp-json',
  username: 'bananayoshimoto',
  password: 'kitchen'
});
site.posts()...
```

The consumer of the API must have called `.auth()` at some point on the parent WPAPI object or the instantiated request chain in order for authentication to be used on the request.

This is unintuitive and inconsistent, and even as the library author it has been tripping me up. This PR standardizes the behavior so that authentication will always be used if credentials are available.

Pork barrel:

- Standardize on `site` for the identifier for a WPAPI instance in the wpapi mocha test suite
- Update two tests to use the credentials object `.auth()` syntax, not the now-deprecated `.auth( 'username', 'password' )` syntax