### PR TITLE
Breaking: Remove deprecated `.auth( 'user', 'pass' )` method signature

### DIFF
--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -604,9 +604,6 @@ WPRequest.prototype.namespace = function( namespace ) {
 /**
  * Set a request to use authentication, and optionally provide auth credentials
  *
- * Note: the `.auth( username, password )` signature is _deprecated_, use an object
- * with username and password properties instead as in the below example.
- *
  * If auth credentials were already specified when the WPAPI instance was created, calling
  * `.auth` on the request chain will set that request to use the existing credentials:
  *
@@ -638,7 +635,7 @@ WPRequest.prototype.namespace = function( namespace ) {
  * @param {String} [credentials.nonce]    A WP nonce for use with cookie authentication
  * @return {WPRequest} The WPRequest instance (for chaining)
  */
-WPRequest.prototype.auth = function( credentials, password ) {
+WPRequest.prototype.auth = function( credentials ) {
 	if ( typeof credentials === 'object' ) {
 		if ( typeof credentials.username === 'string' ) {
 			this._options.username = credentials.username;
@@ -650,14 +647,6 @@ WPRequest.prototype.auth = function( credentials, password ) {
 
 		if ( credentials.nonce ) {
 			this._options.nonce = credentials.nonce;
-		}
-	} else {
-		if ( typeof credentials === 'string' ) {
-			this._options.username = credentials;
-		}
-
-		if ( typeof password === 'string' ) {
-			this._options.password = password;
 		}
 	}
 

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -620,18 +620,6 @@ describe( 'WPRequest', function() {
 			expect( request._options.auth ).to.be.true;
 		});
 
-		it( 'sets the username and password when provided as strings', function() {
-			expect( request._options ).not.to.have.property( 'username' );
-			expect( request._options ).not.to.have.property( 'password' );
-			request.auth( 'user', 'pass' );
-			expect( request._options ).to.have.property( 'username' );
-			expect( request._options ).to.have.property( 'password' );
-			expect( request._options.username ).to.equal( 'user' );
-			expect( request._options.password ).to.equal( 'pass' );
-			expect( request._options ).to.have.property( 'auth' );
-			expect( request._options.auth ).to.be.true;
-		});
-
 		it( 'sets the username and password when provided in an object', function() {
 			expect( request._options ).not.to.have.property( 'username' );
 			expect( request._options ).not.to.have.property( 'password' );

--- a/tests/unit/wpapi.js
+++ b/tests/unit/wpapi.js
@@ -554,16 +554,6 @@ describe( 'wp', function() {
 				expect( site._options.auth ).to.be.true;
 			});
 
-			it( 'sets the username and password when provided as strings', function() {
-				site.auth( 'user1', 'pass1' );
-				expect( site._options ).to.have.property( 'username' );
-				expect( site._options ).to.have.property( 'password' );
-				expect( site._options.username ).to.equal( 'user1' );
-				expect( site._options.password ).to.equal( 'pass1' );
-				expect( site._options ).to.have.property( 'auth' );
-				expect( site._options.auth ).to.be.true;
-			});
-
 			it( 'sets the username and password when provided in an object', function() {
 				site.auth({
 					username: 'user1',


### PR DESCRIPTION
The string username & password signature for the `.auth()` method (both for WPRequest-derived handlers & WPAPI instances itself) has been deprecated for the last release or so because it offers less flexibility vs explicit parameter naming. Were we to add, say, OAuth support, we would want to be able to specify a token and secret value, but would not want them to be confusable with the less-recommended Basic Auth scheme. Removing the signature that uses unnamed strings disambiguates in a future-oriented way.