### PR TITLE
Breaking: Remove deprecated WPRequest `.post`/`.put` methods

### DIFF
--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -691,16 +691,6 @@ WPRequest.prototype.file = function( file, name ) {
 // HTTP Methods: Public Interface
 // ==============================
 
-/** @deprecated Use .create() */
-WPRequest.prototype.post = function() {
-	return this.create.apply( this, arguments );
-};
-
-/** @deprecated Use .update() */
-WPRequest.prototype.put = function() {
-	return this.update.apply( this, arguments );
-};
-
 /**
  * Get (download the data for) the specified resource
  *

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -898,42 +898,4 @@ describe( 'WPRequest', function() {
 
 	});
 
-	describe( 'deprecated request methods', function() {
-
-		describe( '.post()', function() {
-
-			it( 'is a function', function() {
-				expect( request ).to.have.property( 'post' );
-				expect( request.post ).to.be.a( 'function' );
-			});
-
-			it( 'proxies to .create', function() {
-				sinon.stub( request, 'create' );
-				function cb() {}
-				request.create( 'foo', cb );
-				expect( request.create ).to.have.been.calledWith( 'foo', cb );
-				request.create.restore();
-			});
-
-		});
-
-		describe( '.put()', function() {
-
-			it( 'is a function', function() {
-				expect( request ).to.have.property( 'put' );
-				expect( request.put ).to.be.a( 'function' );
-			});
-
-			it( 'proxies to .update', function() {
-				sinon.stub( request, 'update' );
-				function cb() {}
-				request.put( 'foo', cb );
-				expect( request.update ).to.have.been.calledWith( 'foo', cb );
-				request.update.restore();
-			});
-
-		});
-
-	}); // Deprecated request methods
-
 });


### PR DESCRIPTION
Deprecated since v0.8.0: use `.create()` and `.update()` instead