### PR TITLE
Breaking: remove deprecated WPRequest `._renderURI()` & `.name()`

### DIFF
--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -290,9 +290,6 @@ WPRequest.prototype.toString = function() {
 	return this._options.endpoint + path + queryStr;
 };
 
-/** @deprecated Use .toString() */
-WPRequest.prototype._renderURI = WPRequest.prototype.toString;
-
 /**
  * Set a component of the resource URL itself (as opposed to a query parameter)
  *
@@ -565,20 +562,6 @@ WPRequest.prototype.exclude = paramSetter( 'exclude' );
  * @return The request instance (for chaining)
  */
 WPRequest.prototype.slug = paramSetter( 'slug' );
-
-/**
- * Alias for .slug()
- *
- * @method name
- * @alias slug
- * @deprecated use .slug()
- * @chainable
- * @param {String} slug A post name (slug), e.g. "hello-world"
- * @return The request instance (for chaining)
- */
-WPRequest.prototype.name = function( slug ) {
-	return this.slug( slug );
-};
 
 // HTTP Transport Prototype Methods
 // ================================

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -571,39 +571,6 @@ describe( 'WPRequest', function() {
 
 		});
 
-		describe( '.name()', function() {
-
-			it( 'is defined', function() {
-				expect( request ).to.have.property( 'name' );
-			});
-
-			it( 'is a function', function() {
-				expect( request.name ).to.be.a( 'function' );
-			});
-
-			it( 'supports chaining', function() {
-				expect( request.name() ).to.equal( request );
-			});
-
-			it( 'has no effect when called with no argument', function() {
-				var result = request.name();
-				expect( getQueryStr( result ) ).to.equal( '' );
-			});
-
-			it( 'is an alias for .slug()', function() {
-				sinon.spy( request, 'slug' );
-				request.name( 'crooked-man' );
-				expect( request.slug ).to.have.been.calledWith( 'crooked-man' );
-				request.slug.restore();
-			});
-
-			it( 'sets the "slug" query parameter when provided a value', function() {
-				var result = request.name( 'bran-van' );
-				expect( getQueryStr( result ) ).to.equal( 'slug=bran-van' );
-			});
-
-		});
-
 	});
 
 	describe( '.auth()', function() {


### PR DESCRIPTION
Deprecated since v0.9.2 & v0.11 respectively

Use `.toString()` and the consistently-named `.slug()` method instead