### PR TITLE
Rename `.forPost` mixin to just `.post`; deprecate `.forPost`

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ site.handler = site.registerRoute( 'myplugin/v1', 'collection/(?P<id>)', {
     params: [ 'filter', 'before', 'after', 'author', 'parent', 'post' ]
 });
 // yields
-site.handler().forPost( 8 ).author( 92 ).filter( 'etc', 'etera' )...
+site.handler().post( 8 ).author( 92 ).filter( 'etc', 'etera' )...
 ```
 
 If you wish to set custom parameters, for example to query by the custom taxonomy `genre`, you can use the `.param()` method as usual:

--- a/lib/mixins/index.js
+++ b/lib/mixins/index.js
@@ -16,5 +16,9 @@ module.exports = {
 	before: { before: parameterMixins.before },
 	filter: filterMixins,
 	parent: { parent: parameterMixins.parent },
-	post: { forPost: parameterMixins.forPost }
+	post: {
+		post: parameterMixins.post,
+		/** @deprecated use .post() */
+		forPost: parameterMixins.post
+	}
 };

--- a/lib/mixins/parameters.js
+++ b/lib/mixins/parameters.js
@@ -79,15 +79,14 @@ parameterMixins.parent = function( parentId ) {
 
 /**
  * Specify the post for which to retrieve terms (relevant for *e.g.* taxonomy
- * and comment collection endpoints). `forPost` is used to avoid conflicting
- * with the `.post()` method, which corresponds to the HTTP POST action.
+ * and comment collection endpoints).
  *
- * @method forPost
+ * @method post
  * @chainable
  * @param {String|Number} post The ID of the post for which to retrieve terms
  * @return The request instance (for chaining)
  */
-parameterMixins.forPost = paramSetter( 'post' );
+parameterMixins.post = paramSetter( 'post' );
 
 /**
  * Specify the password to use to access the content of a password-protected post

--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -353,7 +353,7 @@ describe( 'integration: categories()', function() {
 
 	});
 
-	describe( 'forPost()', function() {
+	describe( '.post()', function() {
 
 		it( 'can be used to retrieve terms for a specific post', function() {
 			var postCategories;
@@ -370,7 +370,7 @@ describe( 'integration: categories()', function() {
 						}
 					});
 					var postId = post.id;
-					return wp.categories().forPost( postId );
+					return wp.categories().post( postId );
 				})
 				.then(function( categories ) {
 					expect( categories.length ).to.equal( postCategories.length );

--- a/tests/integration/comments.js
+++ b/tests/integration/comments.js
@@ -245,7 +245,7 @@ describe( 'integration: comments()', function() {
 
 	});
 
-	describe( 'forPost() query', function() {
+	describe( '.post() query', function() {
 		var pageComments;
 		var commentProm;
 
@@ -261,7 +261,7 @@ describe( 'integration: comments()', function() {
 						return flatArr.concat( arr );
 					}, [] );
 					return wp.comments()
-						.forPost( pageId )
+						.post( pageId )
 						.get();
 				});
 		});

--- a/tests/unit/lib/mixins/parameters.js
+++ b/tests/unit/lib/mixins/parameters.js
@@ -213,36 +213,36 @@ describe( 'mixins: parameters', function() {
 
 	});
 
-	describe( '.forPost()', function() {
+	describe( '.post()', function() {
 
 		beforeEach(function() {
-			Req.prototype.forPost = parameterMixins.forPost;
+			Req.prototype.post = parameterMixins.post;
 		});
 
 		it( 'mixin method is defined', function() {
-			expect( parameterMixins ).to.have.property( 'forPost' );
+			expect( parameterMixins ).to.have.property( 'post' );
 		});
 
 		it( 'is a function', function() {
-			expect( parameterMixins.forPost ).to.be.a( 'function' );
+			expect( parameterMixins.post ).to.be.a( 'function' );
 		});
 
 		it( 'supports chaining', function() {
-			expect( req.forPost() ).to.equal( req );
+			expect( req.post() ).to.equal( req );
 		});
 
 		it( 'has no effect when called with no argument', function() {
-			var result = req.forPost();
+			var result = req.post();
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
 		it( 'sets the "post" query parameter when provided a value', function() {
-			var result = req.forPost( 3263827 );
+			var result = req.post( 3263827 );
 			expect( getQueryStr( result ) ).to.equal( 'post=3263827' );
 		});
 
 		it( 'overwrites previously-set values on subsequent calls', function() {
-			var result = req.forPost( 1138 ).forPost( 2501 );
+			var result = req.post( 1138 ).post( 2501 );
 			expect( getQueryStr( result ) ).to.equal( 'post=2501' );
 		});
 


### PR DESCRIPTION
Now that WPRequest's `.post` has been removed (in favor of `.create`), we can reinstate the most-obviously-named handler for filtering on the `?post` query parameter.

`.forPost()` is now deprecated and will be removed in a future release