### PR TITLE
Support tax_query filter (added in WP-API/WP-API#2748)

### DIFF
--- a/lib/mixins/filters.js
+++ b/lib/mixins/filters.js
@@ -217,4 +217,37 @@ filterMixins.path = function( path ) {
 	return filterMixins.filter.call( this, 'pagename', path );
 };
 
+/**
+ * Limit results using the tax_query filter
+ *
+ * @method taxQuery
+ * @chainable
+ * @param {Object} queryObj A tax_query configuration object
+ * @returns The request instance (for chaining)
+ */
+filterMixins.taxQuery = function( queryObj ) {
+	if ( ! queryObj ) {
+		return this;
+	}
+	if ( Array.isArray( queryObj ) ) {
+		queryObj = queryObj.reduce(function( obj, item, idx ) {
+			obj[ idx ] = item;
+			return obj;
+		}, {
+			relation: 'OR'
+		} );
+	} else {
+		// If the query object has no relation property or 0 index, but the
+		// query WAS still provided as a non-array object, it is a single
+		// tax_query item and should be wrapped in a numerically-keyed object
+		// so that it is recognized by the API
+		if ( ! ( queryObj.relation || queryObj[ 0 ] ) ) {
+			queryObj = {
+				'0': queryObj
+			};
+		}
+	}
+	return this.filter( 'tax_query', queryObj );
+};
+
 module.exports = filterMixins;


### PR DESCRIPTION
This PR provides a convenience method for setting the `tax_query` filter:

```js
// Return only posts in category 29
site.posts().taxQuery({
  taxonomy: 'category',
  terms: [ 29 ]
})...
```

Note that if a relation is specified, numeric indices must be provided:

```js
// Return posts in (cats 49 or 29) && in tag 79 && NOT in tag 106
const request = site.posts().taxQuery({
  relation: 'AND',
  '0': {
    taxonomy: 'category',
    terms: [ 49, 29 ]
  },
  '1': {
    taxonomy: 'post_tag',
    // field: 'slug',
    terms: [ 79 ]
  },
  '2': {
    taxonomy: 'post_tag',
    terms: [ 106 ],
    operator: 'NOT IN'
  }
});
```

_If_ "OR" can be used as the topmost relation, an array of tax_query objects can be provided to the filter method instead; however, any nested queries must use array indices because the array -> object parsing is not recursive.

```js
// Implicit OR: this query is, all posts with
// (tag #93 && category #49) || (tag #81 && not tag #116)
site.posts().taxQuery([{
  relation: 'AND',
  '0': {
    taxonomy: 'category',
    terms: [49]
  },
  '1': {
    taxonomy: 'post_tag',
    terms: [93]
  }
}, {
  relation: 'AND',
  '0': {
    taxonomy: 'post_tag',
    terms: [81]
  },
  '1': {
    taxonomy: 'post_tag',
    terms: 116,
    operator: 'NOT IN'
  }
}]);
```