### PR TITLE
Readme: add syntax description for Uploading Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,16 +425,22 @@ If you wish to associate a newly-uploaded media record to a specific post, you m
 wp.media().file(content [, name])
 ```
 
-`content`
-Type: String
+##### `content`
+
+Type: `String`
+
 String with path to image file, e. g. `'/path/to/the/image.jpg'`
 
-`content`
-Type: Buffer
+##### `content`
+
+Type: `Buffer`
+
 Buffer with file content, e. g. `new Buffer()`
 
-`name`
-Type: String
+##### `name`
+
+Type: `String`
+
 String with new file name to upload with, e. g. `image.jpg`. If omitted, it tries to get file name from content.
 
 #### Example usage

--- a/README.md
+++ b/README.md
@@ -420,6 +420,25 @@ Files may be uploaded to the WordPress media library by creating a media record 
 
 If you wish to associate a newly-uploaded media record to a specific post, you must use two calls: one to first upload the file, then another to associate it with a post. Example code:
 
+#### Syntax
+```js
+wp.media().file(content [, name])
+```
+
+`content`
+Type: String
+String with path to image file, e. g. `'/path/to/the/image.jpg'`
+
+`content`
+Type: Buffer
+Buffer with file content, e. g. `new Buffer()`
+
+`name`
+Type: String
+String with new file name to upload with, e. g. `image.jpg`. If omitted, it tries to get file name from content.
+
+#### Example usage
+
 ```js
 wp.media()
     // Specify a path to the file you want to upload


### PR DESCRIPTION
To get it clear that it can use Buffer, not only file path.
Fix #245
