### PR TITLE
Update outdated custom taxonomy term handler documentation (fixes #251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,14 +268,14 @@ Additional querying methods provided, by endpoint:
 * **taxonomies**
     - `wp.taxonomies()`: retrieve all registered taxonomies
     - `wp.taxonomies().taxonomy( 'taxonomy_name' )`: get a specific taxonomy object with name *taxonomy_name*
-    - `wp.taxonomies().taxonomy( 'taxonomy_name' ).terms()`: get all terms for taxonomy *taxonomy_name*
-    - `wp.taxonomies().taxonomy( 'taxonomy_name' ).term( termIdentifier )`: get the term with slug or ID *termIdentifier* from the taxonomy *taxonomy_name*
 * **categories**
     - `wp.categories()`: retrieve all registered categories
     - `wp.categories().id( n )`: get a specific category object with id *n*
 * **tags**
     - `wp.tags()`: retrieve all registered tags
     - `wp.tags().id( n )`: get a specific tag object with id *n*
+* **custom taxonomy terms**
+    - [Use `registerRoute()`](http://wp-api.org/node-wpapi/custom-routes/) or [route auto-discovery](http://wp-api.org/node-wpapi/using-the-client/#auto-discovery) to query for custom taxonomy terms
 * **types**
     - `wp.types()`: get a collection of all registered public post types
     - `wp.types().type( 'cpt_name' )`: get the object for the custom post type with the name *cpt_name*


### PR DESCRIPTION
Thank you @joaojeronimo for identifying this issue.

The documentation for querying for custom taxonomy terms is outdated. Term collections are now top-level routes on the `/wp/v2` namespace, and are no longer nested within their parent taxonomy. The result of this is that the nesting operators documented in the README are pointing to a route that no longer exists &mdash; for the custom taxonomy "genre", for example, if registered with a `rest_base` argument like so:

```php
register_taxonomy( 'genre', array( 'album' ), array(
  'hierarchical'      => true,
  'show_ui'           => true,
  'show_admin_column' => true,
  'query_var'         => true,
  'rewrite'           => array( 'slug' => 'genre' ),
  'show_in_rest'      => true,
  'rest_base'         => 'genres',
  'rest_controller_class' => 'WP_REST_Terms_Controller',
));
```

then you run `wp.taxonomies().taxonomy('genre')`, it yields this object:

```js
{
  name: 'Genres',
  slug: 'genre',
  description: '',
  types: [ 'album' ],
  hierarchical: true,
  rest_base: 'genres',
  _links: {
    collection: [ { href: 'http://yoursite.com/wp-json/wp/v2/taxonomies' } ],
    'wp:items': [ { href: 'http://yoursite.com/wp-json/wp/v2/genres' } ],
     curies: [ { name: 'wp', href: 'https://api.w.org/{rel}', templated: true } ]
  }
}
```

This object points to the new collection location, `/wp/v2/genres`.

To access this via the API, you have two options. First, autodiscovery should detect and bind to that collection automatically:

```js
WPAPI.discover('http://wpapi.loc')
  .then(function(wp) {
    // client instance now has a "genres" method for that term collection
    return wp.genres();
  });
```

Alternatively, you can make a function to query the genres manually using a [custom route handler](http://wp-api.org/node-wpapi/custom-routes/):

```js
wp.genres = wp.registerRoute( 'wp/v2', '/genres/(?P<id>)' );
```

The documentation update here is minimal, but points to the two ways to make this query using the new API route structure and removes the outdated bullets.