### PR TITLE
Supporting hyphens on endpoints

### DIFF
--- a/lib/resource-handler-spec.js
+++ b/lib/resource-handler-spec.js
@@ -25,8 +25,8 @@ function assignSetterFnForNode( handler, node ) {
 		node.names.forEach(function( name ) {
 			// Convert from snake_case to camelCase
 			var setterFnName = name
-				.replace( /_\w/g, function( match ) {
-					return match.replace( '_', '' ).toUpperCase();
+				.replace( /[_-]+\w/g, function( match ) {
+					return match.replace( /[_-]+/, '' ).toUpperCase();
 				});
 
 			// Don't overwrite previously-set methods


### PR DESCRIPTION
According with https://developer.wordpress.org/reference/functions/register_post_type/#parameters custom post types can have both underscore and hyphens, resulting in endpoints like `my_content `or `my-content`. Current API supports only underscore.

I'm not a WP or a Node developer, but I think this should be either addressed or at least documented.
A temporary workaround is to call the endpoint with `site['my-content'].get()`.

This patch add hyphens supports on routes names replacing.

Ideally the exact regexp should be `[^a-z]+`, in order to cover any future changes and plugins creating weird endpoints. 