### PR TITLE
Implement basic objectReduce() function to replace lodash.reduce

### DIFF
--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -6,7 +6,6 @@
  */
 
 var qs = require( 'qs' );
-var _reduce = require( 'lodash.reduce' );
 var _union = require( 'lodash.union' );
 var _unique = require( 'lodash.uniq' );
 var extend = require( 'node.extend' );
@@ -14,6 +13,7 @@ var extend = require( 'node.extend' );
 var alphaNumericSort = require( '../util/alphanumeric-sort' );
 var keyValToObj = require( '../util/key-val-to-obj' );
 var paramSetter = require( '../util/parameter-setter' );
+var objectReduce = require( '../util/object-reduce' );
 
 /**
  * WPRequest is the base API request object constructor
@@ -127,7 +127,7 @@ function prepareTaxonomies( taxonomyFilters ) {
 		return {};
 	}
 
-	return _reduce( taxonomyFilters, function( result, terms, key ) {
+	return objectReduce( taxonomyFilters, function( result, terms, key ) {
 		// Trim whitespace and concatenate multiple terms with +
 		result[ key ] = terms.map(function( term ) {
 			// Coerce term into a string so that trim() won't fail
@@ -157,7 +157,7 @@ function populated( obj ) {
 	if ( ! obj ) {
 		return obj;
 	}
-	return _reduce( obj, function( values, val, key ) {
+	return objectReduce( obj, function( values, val, key ) {
 		if ( val !== undefined && val !== null && val !== '' ) {
 			values[ key ] = val;
 		}

--- a/lib/data/simplify-object.js
+++ b/lib/data/simplify-object.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _reduce = require( 'lodash.reduce' );
+var objectReduce = require( '../util/object-reduce' );
 
 /**
  * Walk through the keys and values of a provided object, removing any properties
@@ -27,7 +27,7 @@ function simplifyObject( obj ) {
 
 	// Reduce through objects to run each property through simplifyObject
 	if ( typeof obj === 'object' ) {
-		return _reduce( obj, function( newObj, val, key ) {
+		return objectReduce( obj, function( newObj, val, key ) {
 			// Omit _links objects entirely
 			if ( key === '_links' ) {
 				return newObj;
@@ -36,7 +36,7 @@ function simplifyObject( obj ) {
 			// If the key is "args", omit all keys of second-level descendants
 			// other than "required"
 			if ( key === 'args' ) {
-				newObj.args = _reduce( val, function( slimArgs, argVal, argKey ) {
+				newObj.args = objectReduce( val, function( slimArgs, argVal, argKey ) {
 					slimArgs[ argKey ] = {
 						required: argVal.required
 					};

--- a/lib/endpoint-factories.js
+++ b/lib/endpoint-factories.js
@@ -4,10 +4,10 @@
  * @module parseRouteString
  */
 
-var _reduce = require( 'lodash.reduce' );
 var extend = require( 'node.extend' );
 var createResourceHandlerSpec = require( './resource-handler-spec' ).create;
 var createEndpointRequest = require( './endpoint-request' ).create;
+var objectReduce = require( './util/object-reduce' );
 
 /**
  * Given an array of route definitions and a specific namespace for those routes,
@@ -24,10 +24,10 @@ var createEndpointRequest = require( './endpoint-request' ).create;
  */
 function generateEndpointFactories( routesByNamespace ) {
 
-	return _reduce( routesByNamespace, function( namespaces, routeDefinitions, namespace ) {
+	return objectReduce( routesByNamespace, function( namespaces, routeDefinitions, namespace ) {
 
 		// Create
-		namespaces[ namespace ] = _reduce( routeDefinitions, function( handlers, routeDef, resource ) {
+		namespaces[ namespace ] = objectReduce( routeDefinitions, function( handlers, routeDef, resource ) {
 
 			var handlerSpec = createResourceHandlerSpec( routeDef, resource );
 

--- a/lib/http-transport.js
+++ b/lib/http-transport.js
@@ -6,13 +6,13 @@
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
 var Promise = require( 'es6-promise' ).Promise;
 
-var _reduce = require( 'lodash.reduce' );
 var agent = require( 'superagent' );
 var parseLinkHeader = require( 'li' ).parse;
 var url = require( 'url' );
 
 var WPRequest = require( './constructors/wp-request' );
 var checkMethodSupport = require( './util/check-method-support' );
+var objectReduce = require( './util/object-reduce' );
 
 /**
  * Conditionally set basic authentication on a server request object
@@ -248,7 +248,7 @@ function _httpPost( wpreq, data, callback ) {
 
 	if ( wpreq._attachment ) {
 		// Data must be form-encoded alongside image attachment
-		request = _reduce( data, function( req, value, key ) {
+		request = objectReduce( data, function( req, value, key ) {
 			return req.field( key, value );
 		}, request.attach( 'file', wpreq._attachment, wpreq._attachmentName ) );
 	} else {

--- a/lib/route-tree.js
+++ b/lib/route-tree.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var _reduce = require( 'lodash.reduce' );
-
 var namedGroupRegexp = require( './util/named-group-regexp' );
 var ensure = require( './util/ensure' );
+var objectReduce = require( './util/object-reduce' );
 
 /**
  * Method to use when reducing route components array.
@@ -193,7 +192,7 @@ function reduceRouteTree( namespaces, routeObj, route ) {
  * factory methods for each namespace's resources
  */
 function buildRouteTree( routes ) {
-	return _reduce( routes, reduceRouteTree, {} );
+	return objectReduce( routes, reduceRouteTree, {} );
 }
 
 module.exports = {

--- a/lib/util/object-reduce.js
+++ b/lib/util/object-reduce.js
@@ -7,6 +7,11 @@
  * but results in ~50kb less size in the resulting bundled code before
  * minification and ~12kb of savings with minification.
  *
+ * Unlike lodash.reduce(), the iterator and initial value properties are NOT
+ * optional: this is done to simplify the code, this module is not intended to
+ * be a full replacement for lodash.reduce and instead prioritizes simplicity
+ * for a specific common case.
+ *
  * @module object-reduce
  * @private
  * @param {Object} obj An object of key-value pairs

--- a/lib/util/object-reduce.js
+++ b/lib/util/object-reduce.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Utility method to permit Array#reduce-like operations over objects
+ *
+ * This is likely to be slightly more inefficient than using lodash.reduce,
+ * but results in ~50kb less size in the resulting bundled code before
+ * minification and ~12kb of savings with minification.
+ *
+ * @module object-reduce
+ * @private
+ * @param {Object} obj An object of key-value pairs
+ * @param {Function} iterator A function to use to reduce the object
+ * @param {*} initialState The initial value to pass to the reducer function
+ * @returns The result of the reduction operation
+ */
+module.exports = function( obj, iterator, initialState ) {
+	return Object.keys( obj ).reduce( function( memo, key ) {
+		return iterator( memo, obj[ key ], key );
+	}, initialState );
+};

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "es6-promise": "^3.2.1",
     "li": "^1.0.1",
-    "lodash.reduce": "^4.4.0",
     "lodash.union": "^4.4.0",
     "lodash.uniq": "^4.3.0",
     "node.extend": "^1.1.5",
@@ -74,6 +73,7 @@
     "json-loader": "^0.5.4",
     "kramed": "^0.5.6",
     "load-grunt-tasks": "^3.5.0",
+    "lodash.reduce": "^4.6.0",
     "minimist": "^1.2.0",
     "mocha": "^2.5.3",
     "prompt": "^1.0.0",

--- a/tests/integration/media.js
+++ b/tests/integration/media.js
@@ -11,8 +11,8 @@ var expect = chai.expect;
 /*jshint -W079 */// Suppress warning about redefiniton of `Promise`
 var Promise = require( 'es6-promise' ).Promise;
 var path = require( 'path' );
-var _reduce = require( 'lodash.reduce' );
 var _unique = require( 'lodash.uniq' );
+var objectReduce = require( '../../lib/util/object-reduce' );
 var httpTestUtils = require( './helpers/http-test-utils' );
 
 var WPAPI = require( '../../' );
@@ -312,7 +312,7 @@ describe( 'integration: media()', function() {
 			// Validate thumbnails were created
 			.then(function( result ) {
 				var sizes = result.media_details.sizes;
-				var sizeURLs = _reduce( sizes, function( urls, size ) {
+				var sizeURLs = objectReduce( sizes, function( urls, size ) {
 					return urls.concat( size.source_url );
 				}, [] );
 				// Expect all sizes to have different URLs

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -749,7 +749,7 @@ describe( 'integration: posts()', function() {
 				return SUCCESS;
 			});
 		return expect( prom ).to.eventually.equal( SUCCESS );
-	});
+	}).timeout( 10000 );
 
 	// Callback context
 

--- a/tests/unit/lib/util/object-reduce.js
+++ b/tests/unit/lib/util/object-reduce.js
@@ -1,0 +1,51 @@
+'use strict';
+var expect = require( 'chai' ).expect;
+
+describe( 'Object reduction tools:', function() {
+	// Ensure parity with the relevant signature & functionality of lodash.reduce
+	[
+		{
+			name: 'lodash.reduce (for API parity verification)',
+			fn: require( 'lodash.reduce' )
+		}, {
+			name: 'objectReduce utility',
+			fn: require( '../../../../lib/util/object-reduce' )
+		}
+	].forEach(function( test ) {
+
+		describe( test.name, function() {
+			var objectReduce = test.fn;
+			var obj;
+
+			beforeEach(function() {
+				obj = {};
+			});
+
+			it( 'is defined', function() {
+				expect( objectReduce ).to.exist;
+			});
+
+			it( 'is a function', function() {
+				expect( objectReduce ).to.be.a( 'function' );
+			});
+
+			it( 'resolves to the provided initial value if called on an empty object', function() {
+				expect( objectReduce( {}, function() {}, 'Sasquatch' ) ).to.equal( 'Sasquatch' );
+			});
+
+			it( 'can be used to reduce over an object', function() {
+				var result = objectReduce({
+					key1: 'val1',
+					key2: 'val2',
+					key3: 'val3'
+				}, function( memo, val, key ) {
+					return memo + val + key;
+				}, 'result:' );
+				expect( result ).to.equal( 'result:val1key1val2key2val3key3' );
+			});
+
+		});
+
+	});
+
+});

--- a/wpapi.js
+++ b/wpapi.js
@@ -16,8 +16,8 @@
  */
 'use strict';
 
-var _reduce = require( 'lodash.reduce' );
 var extend = require( 'node.extend' );
+var objectReduce = require( './lib/util/object-reduce' );
 
 // All valid routes in API v2 beta 11
 var defaultRoutes = require( './lib/data/endpoint-response.json' ).routes;
@@ -328,10 +328,10 @@ WPAPI.prototype.bootstrap = function( routes ) {
 	// client instance and passing a registered namespace string.
 	// Handlers for default (wp/v2) routes will also be assigned to the WPAPI
 	// client instance object itself, for brevity.
-	return _reduce( endpointFactoriesByNamespace, function( wpInstance, endpointFactories, namespace ) {
+	return objectReduce( endpointFactoriesByNamespace, function( wpInstance, endpointFactories, namespace ) {
 
 		// Set (or augment) the route handler factories for this namespace.
-		wpInstance._ns[ namespace ] = _reduce( endpointFactories, function( nsHandlers, handlerFn, methodName ) {
+		wpInstance._ns[ namespace ] = objectReduce( endpointFactories, function( nsHandlers, handlerFn, methodName ) {
 			nsHandlers[ methodName ] = handlerFn;
 			return nsHandlers;
 		}, wpInstance._ns[ namespace ] || {


### PR DESCRIPTION
As identified by [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer), lodash.reduce is the largest single dependency within the wpapi library (390.08kb overall):

![image](https://cloud.githubusercontent.com/assets/442115/20847911/fe26386e-b89d-11e6-8f43-178d1c944a6e.png)

Lodash.reduce is powerful, but has more code and optimizations than are needed for our specific use-case of reducing over an object of key-value pairs in the manner of Array#reduce.

This PR replaces Object.reduce with an API-identical method objectReduce, which handles the simple case of iterating over basic objects containing only own-property key-value pairs. This functionality is sufficient for the needs of node-wpapi, as Array#reduce itself is used for reduction over arrays and we are generally iterating over basic route definition JS objects, not complex instance objects.

![bundle analysis after removing lodash.reduce](https://cloud.githubusercontent.com/assets/442115/20848132/c1823c5e-b89e-11e6-8e50-540c42e22b21.png)

After this change our build drops from 421kb to 355kb unminified, and from 99.4kb to 87.2kb minified.

A unit test suite is added to validate that objectReduce results in identical output to lodash.reduce for the specified use-case.