### PR TITLE
Make requests using HTTP transport during auto-discovery process

### DIFF
--- a/lib/autodiscovery.js
+++ b/lib/autodiscovery.js
@@ -1,68 +1,20 @@
 /**
- * Utility methods used to query a site in order to discover its available
+ * Utility methods used when querying a site in order to discover its available
  * API endpoints
  *
  * @module autodiscovery
  */
 'use strict';
 
-/*jshint -W079 */// Suppress warning about redefiniton of `Promise`
-var Promise = require( 'es6-promise' ).Promise;
-var agent = require( 'superagent' );
 var parseLinkHeader = require( 'parse-link-header' );
 
-function resolveAsPromise( superagentReq ) {
-	return new Promise(function( resolve, reject ) {
-		superagentReq.end(function( err, res ) {
-			if ( err ) {
-				// If err.response is present, the request succeeded but we got an
-				// error from the server: surface & return that error
-				if ( err.response && err.response.error ) {
-					return reject( err.response.error );
-				}
-				// If err.response is not present, the request could not connect
-				return reject( err );
-			}
-			resolve( res );
-		});
-	});
-}
-
-/**
- * Fetch the headers for a URL and inspect them to attempt to locate an API
- * endpoint header. Return a promise that will be resolved with a string, or
- * rejected if no such header can be located.
- *
- * @param {string}  url      An arbitrary URL within an API-enabled WordPress site
- * @param {boolean} [useGET] Whether to use GET or HEAD to read the URL, to enable
- *                           the method to upgrade to a full GET request if a HEAD
- *                           request initially fails.
- * @returns {Promise} A promise to the string containing the API endpoint URL
- */
-function getAPIRootFromURL( url, useGET ) {
-
-	// If useGET is specified and truthy, .get the url; otherwise use .head
-	// because we only care about the HTTP headers, not the response body.
-	var request = useGET ? agent.get( url ) : agent.head( url );
-
-	return resolveAsPromise( request )
-		.catch(function( err ) {
-			// If this wasn't already a GET request, then on the hypothesis that an
-			// error arises from an unaccepted HEAD request, try again using GET
-			if ( ! useGET ) {
-				return getAPIRootFromURL( url, true );
-			}
-
-			// Otherwise re-throw the error
-			throw err;
-		});
-}
-
 function locateAPIRootHeader( response ) {
+	// Define the expected link rel value per http://v2.wp-api.org/guide/discovery/
 	var rel = 'https://api.w.org/';
 
 	// Extract & parse the response link headers
-	var headers = parseLinkHeader( response.headers.link );
+	var link = response.link || ( response.headers && response.headers.link );
+	var headers = parseLinkHeader( link );
 	var apiHeader = headers && headers[ rel ];
 
 	if ( apiHeader && apiHeader.url ) {
@@ -72,22 +24,6 @@ function locateAPIRootHeader( response ) {
 	throw new Error( 'No header link found with rel="https://api.w.org/"' );
 }
 
-/**
- * Function to be called with the API url, once we have found one
- *
- * @param  {String} linkUrl The href of the <link> pointing to the API root
- * @return {Promise} Promise that resolves once the API root has been inspected
- */
-function getRootResponseJSON( apiRootURL ) {
-	return resolveAsPromise( agent.get( apiRootURL ).set( 'Accept', 'application/json' ) )
-		.then(function( response ) {
-			return response.body;
-		});
-}
-
 module.exports = {
-	resolveAsPromise: resolveAsPromise,
-	getAPIRootFromURL: getAPIRootFromURL,
-	locateAPIRootHeader: locateAPIRootHeader,
-	getRootResponseJSON: getRootResponseJSON
+	locateAPIRootHeader: locateAPIRootHeader
 };

--- a/tests/integration/autodiscovery.js
+++ b/tests/integration/autodiscovery.js
@@ -15,7 +15,6 @@ var Promise = require( 'es6-promise' ).Promise;
 
 var WPAPI = require( '../../' );
 var WPRequest = require( '../../lib/constructors/wp-request.js' );
-var autodiscovery = require( '../../lib/autodiscovery' );
 
 // Inspecting the titles of the returned posts arrays is an easy way to
 // validate that the right page of results was returned
@@ -110,107 +109,6 @@ describe( 'integration: discover()', function() {
 				.then(function( user ) {
 					expect( user ).to.be.an( 'object' );
 					expect( user.slug ).to.equal( credentials.username );
-					return SUCCESS;
-				});
-			return expect( prom ).to.eventually.equal( SUCCESS );
-		});
-
-	});
-
-	describe( 'rejection states', function() {
-
-		beforeEach(function() {
-			sinon.stub( autodiscovery, 'getAPIRootFromURL' );
-			sinon.stub( autodiscovery, 'locateAPIRootHeader' );
-			sinon.stub( autodiscovery, 'getRootResponseJSON' );
-		});
-
-		afterEach(function() {
-			autodiscovery.getAPIRootFromURL.restore();
-			autodiscovery.locateAPIRootHeader.restore();
-			autodiscovery.getRootResponseJSON.restore();
-		});
-
-		it( 'resolves even if no endpoint is found', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.reject() );
-			var prom = WPAPI.discover( 'http://we.made.it/to/mozarts/house' );
-			return expect( prom ).to.eventually.be.fulfilled;
-		});
-
-		it( 'resolves to null if no endpoint is found', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.resolve() );
-			var prom = WPAPI.discover( 'http://we.made.it/to/mozarts/house' )
-				.then(function( result ) {
-					expect( result ).to.equal( null );
-					return SUCCESS;
-				});
-			return expect( prom ).to.eventually.equal( SUCCESS );
-		});
-
-		it( 'logs a console error if no endpoint is found', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.reject() );
-			var prom = WPAPI.discover( 'http://we.made.it/to/mozarts/house' )
-				.then(function() {
-					expect( console.error ).to.have.been.calledWith( 'Autodiscovery failed' );
-					return SUCCESS;
-				});
-			return expect( prom ).to.eventually.equal( SUCCESS );
-		});
-
-		it( 'does not display any warnings if no endpoint is found', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.reject() );
-			var prom = WPAPI.discover( 'http://we.made.it/to/mozarts/house' )
-				.then(function() {
-					expect( console.warn ).not.to.have.been.called;
-					return SUCCESS;
-				});
-			return expect( prom ).to.eventually.equal( SUCCESS );
-		});
-
-		it( 'resolves to a WPAPI instance if an endpoint is found but route autodiscovery fails', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.resolve() );
-			autodiscovery.locateAPIRootHeader.returns( 'http://we.made.it/to/mozarts/house' );
-			autodiscovery.getRootResponseJSON.throws();
-			var prom = WPAPI.discover()
-				.then(function( result ) {
-					expect( result ).to.be.an.instanceOf( WPAPI );
-					return SUCCESS;
-				});
-			return expect( prom ).to.eventually.equal( SUCCESS );
-		});
-
-		it( 'binds returned instance to the provided endpoint even if route autodiscovery fails', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.resolve() );
-			autodiscovery.locateAPIRootHeader.returns( 'http://we.made.it/to/mozarts/house' );
-			autodiscovery.getRootResponseJSON.throws();
-			var prom = WPAPI.discover()
-				.then(function( result ) {
-					expect( result.root( '' ).toString() ).to.equal( 'http://we.made.it/to/mozarts/house/' );
-					return SUCCESS;
-				});
-			return expect( prom ).to.eventually.equal( SUCCESS );
-		});
-
-		it( 'logs a console error if an endpoint is found but route autodiscovery fails', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.resolve() );
-			autodiscovery.locateAPIRootHeader.returns( 'http://we.made.it/to/mozarts/house' );
-			autodiscovery.getRootResponseJSON.throws();
-			var prom = WPAPI.discover()
-				.then(function() {
-					expect( console.error ).to.have.been.calledWith( 'Autodiscovery failed' );
-					return SUCCESS;
-				});
-			return expect( prom ).to.eventually.equal( SUCCESS );
-		});
-
-		it( 'displays a warning if an endpoint is detected but route autodiscovery fails', function() {
-			autodiscovery.getAPIRootFromURL.returns( Promise.resolve() );
-			autodiscovery.locateAPIRootHeader.returns( 'http://we.made.it/to/mozarts/house' );
-			autodiscovery.getRootResponseJSON.throws();
-			var prom = WPAPI.discover()
-				.then(function() {
-					expect( console.warn ).to.have.been.calledWith( 'Endpoint detected, proceeding despite error...' );
-					expect( console.warn ).to.have.been.calledWith( 'Binding to http://we.made.it/to/mozarts/house and assuming default routes' );
 					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );

--- a/tests/unit/lib/autodiscovery.js
+++ b/tests/unit/lib/autodiscovery.js
@@ -1,67 +1,9 @@
 'use strict';
-var chai = require( 'chai' );
-var expect = chai.expect;
-chai.use( require( 'chai-as-promised' ) );
-
-/*jshint -W079 */// Suppress warning about redefiniton of `Promise`
-var Promise = require( 'es6-promise' ).Promise;
+var expect = require( 'chai' ).expect;
 
 var autodiscovery = require( '../../../lib/autodiscovery' );
 
-describe( 'autodiscovery methods', function() {
-
-	describe( '.resolveAsPromise()', function() {
-		var resolveAsPromise;
-		var err;
-		var res;
-		var mockAgent;
-
-		beforeEach(function() {
-			resolveAsPromise = autodiscovery.resolveAsPromise;
-
-			// Default return values for the mock agent
-			err = null;
-			res = 'Response';
-
-			// Mock superagent
-			mockAgent = {
-				end: function( cb ) {
-					cb( err, res );
-				}
-			};
-		});
-
-		it( 'is a function', function() {
-			expect( resolveAsPromise ).to.be.a( 'function' );
-		});
-
-		it( 'returns a promise', function() {
-			var prom = resolveAsPromise( mockAgent );
-			expect( prom ).to.be.an.instanceOf( Promise );
-		});
-
-		it( 'resolves the promise with the response from the agent end method', function() {
-			var prom = resolveAsPromise( mockAgent );
-			return expect( prom ).to.eventually.equal( 'Response' );
-		});
-
-		it( 'rejects if the agent end method is called with an error', function() {
-			err = 'Some error';
-			var prom = resolveAsPromise( mockAgent );
-			return expect( prom ).to.eventually.be.rejectedWith( 'Some error' );
-		});
-
-		it( 'rejects with the error\'s response.error property when available', function() {
-			err = {
-				response: {
-					error: '404 yo'
-				}
-			};
-			var prom = resolveAsPromise( mockAgent );
-			return expect( prom ).to.eventually.be.rejectedWith( '404 yo' );
-		});
-
-	});
+describe( 'autodiscovery helper methods', function() {
 
 	describe( '.locateAPIRootHeader()', function() {
 		var locateAPIRootHeader;

--- a/tests/unit/lib/mixins/filters.js
+++ b/tests/unit/lib/mixins/filters.js
@@ -249,6 +249,31 @@ describe( 'mixins: filter', function() {
 
 	});
 
+	describe( '.path()', function() {
+
+		beforeEach(function() {
+			Req.prototype.path = filterMixins.path;
+		});
+
+		it( 'mixin is defined', function() {
+			expect( filterMixins ).to.have.property( 'path' );
+		});
+
+		it( 'is a function', function() {
+			expect( filterMixins.path ).to.be.a( 'function' );
+		});
+
+		it( 'supports chaining', function() {
+			expect( req.path( 'tag', 'foo' ) ).to.equal( req );
+		});
+
+		it( 'should create the URL for retrieving a post by path', function() {
+			var path = req.path( 'nested/page' );
+			expect( getQueryStr( path ) ).to.equal( 'filter[pagename]=nested/page' );
+		});
+
+	});
+
 	describe( 'date filters', function() {
 
 		describe( 'year()', function() {


### PR DESCRIPTION
In #181 auto-discovery was added that permits a consumer of this library to automatically locate the API root for a given WordPress site (specified by URL), and in most cases to automatically detect & initialize specific route handlers for the API routes available on that site.

However, these methods were never updated to account for #221, which added the ability to replace the default HTTP transport (superagent) with a custom implementation or a wrapper. This meant that even if the consumer had specified their own transport, for example jQuery, there would still be a dependency on superagent should they wish to use the auto-discovery capabilities of the library.

This PR updates the auto-discovery logic to use the same HTTP transport layer as the rest of the client, which has the added benefit of removing a number of duplicative logic that existed in the auto-discovery module.