### PR TITLE
Return API error body, not full superagent response

### DIFF
--- a/lib/http-transport.js
+++ b/lib/http-transport.js
@@ -173,6 +173,11 @@ function invokeAndPromisify( request, callback, transform ) {
 		}
 		return result;
 	}, function( err ) {
+		if ( err.response && err.response.body ) {
+			// Forward API error response JSON on to the calling method: omit
+			// all transport-specific (superagent-specific) properties
+			err = err.response.body;
+		}
 		// If a callback was provided, ensure it is called with the error; otherwise
 		// re-throw the error so that it can be handled by a Promise .catch or .then
 		if ( callback && typeof callback === 'function' ) {

--- a/tests/integration/media.js
+++ b/tests/integration/media.js
@@ -221,9 +221,10 @@ describe( 'integration: media()', function() {
 				})
 				.catch(function( err ) {
 					httpTestUtils.rethrowIfChaiError( err );
-					expect( err ).to.be.an.instanceOf( Error );
-					expect( err ).to.have.property( 'status' );
-					expect( err.status ).to.equal( 401 );
+					expect( err.code ).to.equal( 'rest_cannot_create' );
+					expect( err.data ).to.deep.equal({
+						status: 401
+					});
 					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
@@ -243,9 +244,10 @@ describe( 'integration: media()', function() {
 				})
 				.catch(function( err ) {
 					httpTestUtils.rethrowIfChaiError( err );
-					expect( err ).to.be.an.instanceOf( Error );
-					expect( err ).to.have.property( 'status' );
-					expect( err.status ).to.equal( 401 );
+					expect( err.code ).to.equal( 'rest_cannot_edit' );
+					expect( err.data ).to.deep.equal({
+						status: 401
+					});
 					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
@@ -263,9 +265,10 @@ describe( 'integration: media()', function() {
 				})
 				.catch(function( err ) {
 					httpTestUtils.rethrowIfChaiError( err );
-					expect( err ).to.be.an.instanceOf( Error );
-					expect( err ).to.have.property( 'status' );
-					expect( err.status ).to.equal( 401 );
+					expect( err.code ).to.equal( 'rest_cannot_delete' );
+					expect( err.data ).to.deep.equal({
+						status: 401
+					});
 					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
@@ -337,9 +340,10 @@ describe( 'integration: media()', function() {
 			})
 			.catch(function( error ) {
 				httpTestUtils.rethrowIfChaiError( error );
-				expect( error ).to.be.an.instanceOf( Error );
-				expect( error ).to.have.property( 'status' );
-				expect( error.status ).to.equal( 501 );
+				expect( error.code ).to.equal( 'rest_trash_not_supported' );
+				expect( error.data ).to.deep.equal({
+					status: 501
+				});
 				// Now permanently delete this media
 				return authenticated.media()
 					.id( id )
@@ -357,9 +361,10 @@ describe( 'integration: media()', function() {
 			})
 			.catch(function( error ) {
 				httpTestUtils.rethrowIfChaiError( error );
-				expect( error ).to.be.an.instanceOf( Error );
-				expect( error ).to.have.property( 'status' );
-				expect( error.status ).to.equal( 404 );
+				expect( error.code ).to.equal( 'rest_post_invalid_id' );
+				expect( error.data ).to.deep.equal({
+					status: 404
+				});
 			})
 			// Validate image file has been removed
 			.then(function() {


### PR DESCRIPTION
This simplifies the returned object coming back from the API when an API error is encountered during a request: rather than returning the full superagent object, only the API error body is returned. This makes it easier for a consuming client to check the response against the expected codes without caring about the structure of the HTTP transport object.

The most important implication of this is that now, if a consumer defines their own transport, they have but to return the error body and responses from their transport will be functionally identical to responses from other transports, where before the response object was transport-specific. This is critical in order to make transport substitution minimally impactful to a consuming application.

Closes #124