### PR TITLE
Add `.status()` query method & fix mixin application bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,12 @@ wp.pages().slug( 'about' )...
 // Find a post authored by the user with ID #42
 wp.posts().author( 42 )...
 
+// Find trashed posts
+wp.posts().status( 'trash' )...
+
+// Find posts in status "future" or "draft"
+wp.posts().status([ 'draft', 'future' ])...
+
 // Find all categories containing the word "news"
 wp.categories().search( 'news' )...
 
@@ -434,6 +440,25 @@ wp.posts().author( 42 ).author( 71 ).get();
 ```
 
 As with categories and tags, the `/users` endpoint may be queried by slug to retrieve the ID to use in this query, if needed.
+
+### Password-Protected posts
+
+The `.password()` method (not to be confused with the password property of `.auth()`!) sets the password to use to view a password-protected post. Any post for which the content is protected will have `protected: true` set on its `content` and `excerpt` properties; `content.rendered` and `excerpt.rendered` will both be `''` until the password is provided by query string.
+
+```js
+wp.posts().id( idOfProtectedPost )
+    .then(function( result ) {
+        console.log( result.content.protected ); // true
+        console.log( result.content.rendered ); // ""
+    });
+
+wp.posts.id( idOfProtectedPost )
+    // Provide the password string with the request
+    .password( 'thepasswordstring' )
+    .then(function( result ) {
+        console.log( result.content.rendered ); // "The post content"
+    });
+```
 
 #### Other Filters
 

--- a/lib/mixins/index.js
+++ b/lib/mixins/index.js
@@ -10,10 +10,12 @@ var parameterMixins = require( './parameters' );
 // `.context`, `.embed`, and `.edit` (a shortcut for `context(edit, true)`) are
 // supported by default in WPRequest, as is the base `.param` method. Any GET
 // argument parameters not covered here must be set directly by using `.param`.
-module.exports = {
-	after: { after: parameterMixins.after },
-	author: { author: parameterMixins.author },
-	before: { before: parameterMixins.before },
+
+// The initial mixins we define are the ones where either a single property
+// accepted by the API endpoint corresponds to multiple individual mixin
+// functions, or where the name we use for the function diverges from that
+// of the query parameter that the mixin sets.
+var mixins = {
 	categories: {
 		categories: parameterMixins.categories,
 		/** @deprecated use .categories() */
@@ -31,10 +33,28 @@ module.exports = {
 		excludeTags: parameterMixins.excludeTags
 	},
 	filter: filterMixins,
-	parent: { parent: parameterMixins.parent },
 	post: {
 		post: parameterMixins.post,
 		/** @deprecated use .post() */
 		forPost: parameterMixins.post
 	}
 };
+
+// All of these parameter mixins use a setter function named identically to the
+// property that the function sets, but they must still be provided in wrapper
+// objects so that the mixin can be `.assign`ed correctly: wrap & assign each
+// setter to the mixins dictionary object.
+[
+	'after',
+	'author',
+	'before',
+	'parent',
+	'password',
+	'status',
+	'sticky'
+].forEach(function( mixinName ) {
+	mixins[ mixinName ] = {};
+	mixins[ mixinName ][ mixinName ] = parameterMixins[ mixinName ];
+});
+
+module.exports = mixins;

--- a/lib/mixins/parameters.js
+++ b/lib/mixins/parameters.js
@@ -106,6 +106,21 @@ parameterMixins.post = paramSetter( 'post' );
 parameterMixins.password = paramSetter( 'password' );
 
 /**
+ * Specify for which post statuses to return posts in a response collection
+ *
+ * See https://codex.wordpress.org/Post_Status -- the default post status
+ * values in WordPress which are most relevant to the API are 'publish',
+ * 'future', 'draft', 'pending', 'private', and 'trash'. This parameter also
+ * supports passing the special value "any" to return all statuses.
+ *
+ * @method status
+ * @chainable
+ * @param {string|string[]} status A status name string or array of strings
+ * @returns The request instance (for chaining)
+ */
+parameterMixins.status = paramSetter( 'status' );
+
+/**
  * Specify whether to return only, or to completely exclude, sticky posts
  *
  * @method sticky

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -230,6 +230,24 @@ describe( 'integration: posts()', function() {
 
 		});
 
+		describe( 'status', function() {
+
+			it( 'can be used to retrieve specific statuses of posts', function() {
+				var prom = authenticated.posts()
+					.status([ 'future', 'draft' ])
+					.get()
+					.then(function( posts ) {
+						expect( getTitles( posts ) ).to.deep.equal([
+							'Scheduled',
+							'Draft'
+						]);
+						return SUCCESS;
+					});
+				return expect( prom ).to.eventually.equal( SUCCESS );
+			});
+
+		});
+
 		describe( 'tags', function() {
 
 			it( 'can be used to return only posts with a provided tag', function() {

--- a/tests/unit/lib/mixins/parameters.js
+++ b/tests/unit/lib/mixins/parameters.js
@@ -283,6 +283,36 @@ describe( 'mixins: parameters', function() {
 
 	});
 
+	describe( '.status()', function() {
+
+		beforeEach(function() {
+			Req.prototype.status = parameterMixins.status;
+		});
+
+		it( 'mixin method is defined', function() {
+			expect( parameterMixins ).to.have.property( 'status' );
+		});
+
+		it( 'is a function', function() {
+			expect( parameterMixins.status ).to.be.a( 'function' );
+		});
+
+		it( 'supports chaining', function() {
+			expect( req.status( 'publish' ) ).to.equal( req );
+		});
+
+		it( 'sets the "status" query parameter when provided a value', function() {
+			var result = req.status( 'future' );
+			expect( getQueryStr( result ) ).to.equal( 'status=future' );
+		});
+
+		it( 'sets an array of "status" query values when provided an array of strings', function() {
+			var result = req.status([ 'future', 'draft' ]);
+			expect( getQueryStr( result ) ).to.equal( 'status[]=draft&status[]=future' );
+		});
+
+	});
+
 	describe( '.sticky()', function() {
 
 		beforeEach(function() {

--- a/tests/unit/route-handlers/posts.js
+++ b/tests/unit/route-handlers/posts.js
@@ -76,6 +76,24 @@ describe( 'wp.posts', function() {
 
 	});
 
+	it( 'provides expected filter methods', function() {
+		[
+			'after',
+			'before',
+			'categories',
+			'include',
+			'order',
+			'page',
+			'slug',
+			'password',
+			'status',
+			'sticky'
+		].forEach(function( methodName ) {
+			expect( posts ).to.have.property( methodName );
+			expect( posts[ methodName ] ).to.be.a( 'function' );
+		});
+	});
+
 	describe( 'URL Generation', function() {
 
 		it( 'should create the URL for retrieving all posts', function() {


### PR DESCRIPTION
This PR adds a `.status()` query method for setting one or more statuses to return for endpoints that differentiate based on status, such as Posts (fixes #264). It also allows the `.password` and `.sticky` mixins to be properly applied; they were not previously auto-set when working with a collection that supports those parameters as they were not included in the mixin index.

All three parameters are now tested consistently, & all are documented in the README file.