### PR TITLE
Only pass API errors through; return transport-level errors as-is

### DIFF
--- a/lib/http-transport.js
+++ b/lib/http-transport.js
@@ -173,7 +173,11 @@ function invokeAndPromisify( request, callback, transform ) {
 		}
 		return result;
 	}, function( err ) {
-		if ( err.response && err.response.body ) {
+		// If the API provided an error object, it will be available within the
+		// superagent response object as response.body (containing the response
+		// JSON). If that object exists, it will have a .code property if it is
+		// truly an API error (non-API errors will not have a .code).
+		if ( err.response && err.response.body && err.response.body.code ) {
 			// Forward API error response JSON on to the calling method: omit
 			// all transport-specific (superagent-specific) properties
 			err = err.response.body;

--- a/tests/integration/error-states.js
+++ b/tests/integration/error-states.js
@@ -1,0 +1,28 @@
+'use strict';
+var chai = require( 'chai' );
+// Variable to use as our "success token" in promise assertions
+var SUCCESS = 'success';
+// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
+// used to ensure that the assertions running within the promise chains are
+// actually run.
+chai.use( require( 'chai-as-promised' ) );
+var expect = chai.expect;
+
+var WPAPI = require( '../../' );
+
+describe( 'error states:', function() {
+
+	it( 'invalid root endpoint causes a transport-level (superagent) 404 error', function() {
+		var wp = WPAPI.site( 'http://wpapi.loc/wrong-root-endpoint' );
+		var prom = wp.posts()
+			.get()
+			.catch(function( err ) {
+				expect( err ).to.be.an.instanceOf( Error );
+				expect( err ).to.have.property( 'status' );
+				expect( err.status ).to.equal( 404 );
+				return SUCCESS;
+			});
+		return expect( prom ).to.eventually.equal( SUCCESS );
+	});
+
+});


### PR DESCRIPTION
Fixes #266