### PR TITLE
Test & document .settings() route handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A WPAPI instance object provides the following basic request methods:
 * `wp.statuses()...`: Get resources within the `/statuses` endpoints
 * `wp.users()...`: Get resources within the `/users` endpoints
 * `wp.media()...`: Get Media collections and objects from the `/media` endpoints
+* `wp.settings()...`: Read or update site settings from the `/settings` endpoint (always requires authentication)
 
 All of these methods return a customizable request object. The request object can be further refined with chaining methods, and/or sent to the server via `.get()`, `.create()`, `.update()`, `.delete()`, `.headers()`, or `.then()`. (Not all endpoints support all methods; for example, you cannot POST or PUT records on `/types`, as these are defined in WordPress plugin or theme code.)
 
@@ -282,14 +283,16 @@ Additional querying methods provided, by endpoint:
     - `wp.statuses()`: get a collection of all registered public post statuses (if the query is authenticated&mdash;will just display "published" if unauthenticated)
     - `wp.statuses().status( 'slug' )`: get the object for the status with the slug *slug*
 * **users**
-    - `wp.users()`: get a collection of registered users
+    - `wp.users()`: get a collection of users (will show only users with published content if request is not authenticated)
     - `wp.users().id( n )`: get the user with ID *n* (does not require authentication if that user is a published author within the blog)
     - `wp.users().me()`: get the authenticated user's record
 * **media**
     - `wp.media()`: get a collection of media objects (attachments)
     - `wp.media().id( n )`: get media object with ID *n*
+* **settings**
+    - `wp.settings()`: get or update one or many site settings
 
-For security reasons, methods like `.revisions()` and `.users()` require the request to be authenticated.
+For security reasons, methods like `.revisions()` and `.settings()` require the request to be authenticated, and others such as `.users()` and `.posts()` will return only a subset of their information without authentication.
 
 #### toString()
 

--- a/tests/integration/settings.js
+++ b/tests/integration/settings.js
@@ -1,0 +1,110 @@
+'use strict';
+var chai = require( 'chai' );
+// Variable to use as our "success token" in promise assertions
+var SUCCESS = 'success';
+// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
+// used to ensure that the assertions running within the promise chains are
+// actually run.
+chai.use( require( 'chai-as-promised' ) );
+var expect = chai.expect;
+
+var WPAPI = require( '../../' );
+
+var credentials = require( './helpers/constants' ).credentials;
+
+describe( 'integration: settings()', function() {
+	var wp;
+	var authenticated;
+
+	beforeEach(function() {
+		wp = new WPAPI({
+			endpoint: 'http://wpapi.loc/wp-json'
+		});
+		authenticated = new WPAPI({
+			endpoint: 'http://wpapi.loc/wp-json'
+		}).auth( credentials );
+	});
+
+	it( 'cannot be used to retrieve site settings unless authenticated', function() {
+		var prom = wp.settings()
+			.get()
+			.catch(function( err ) {
+				expect( err.code ).to.equal( 'rest_forbidden' );
+				expect( err.data ).to.deep.equal({
+					status: 403
+				});
+				return SUCCESS;
+			});
+		return expect( prom ).to.eventually.equal( SUCCESS );
+	});
+
+	it( 'can be used to retrieve a list of site settings when authenticated', function() {
+		var prom = authenticated.settings()
+			.get()
+			.then(function( settings ) {
+				expect( settings ).to.be.an( 'object' );
+
+				// Validate existence of all expected keys
+				expect( Object.keys( settings ).sort() ).to.deep.equal([
+					'date_format',
+					'default_category',
+					'default_comment_status',
+					'default_ping_status',
+					'default_post_format',
+					'description',
+					'email',
+					'language',
+					'posts_per_page',
+					'start_of_week',
+					'time_format',
+					'timezone',
+					'title',
+					'url',
+					'use_smilies'
+				]);
+
+				// Spot check specific values
+				expect( settings.title ).to.equal( 'WP-API Testbed' );
+				expect( settings.description ).to.equal( 'Just another WordPress site' );
+				expect( settings.language ).to.equal( 'en_US' );
+				expect( settings.posts_per_page ).to.equal( 10 );
+
+				return SUCCESS;
+			});
+		return expect( prom ).to.eventually.equal( SUCCESS );
+	});
+
+	it( 'can be used to update settings', function() {
+		var prom = authenticated.settings()
+			.get()
+			.then(function( settings ) {
+				expect( settings.description ).to.equal( 'Just another WordPress site' );
+				return authenticated.settings()
+					.update({
+						description: 'It\'s amazing what you\'ll find face to face'
+					});
+			})
+			.then(function() {
+				// Initialize new request to see if changes persisted
+				return authenticated.settings().get();
+			})
+			.then(function( settings ) {
+				expect( settings.description ).to.equal( 'It&#039;s amazing what you&#039;ll find face to face' );
+				// Reset to original value
+				return authenticated.settings()
+					.update({
+						description: 'Just another WordPress site'
+					});
+			})
+			.then(function() {
+				// Request one final time to validate value has been set back
+				return authenticated.settings().get();
+			})
+			.then(function( settings ) {
+				expect( settings.description ).to.equal( 'Just another WordPress site' );
+				return SUCCESS;
+			});
+		return expect( prom ).to.eventually.equal( SUCCESS );
+	});
+
+});


### PR DESCRIPTION
Adds documentation and integration tests to ensure that `.settings()` can be used to read and write site settings when authenticated.

Fixes #263