### PR TITLE
Allow endpoints containing queries.

### DIFF
--- a/lib/constructors/wp-request.js
+++ b/lib/constructors/wp-request.js
@@ -232,8 +232,11 @@ WPRequest.prototype._renderQuery = function() {
 		.sort()
 		.join( '&' );
 
-	// Prepend a "?" if a query is present, and return
-	return ( queryString === '' ) ? '' : '?' + queryString;
+	// Check if the endpoint contains a previous query and set the query character accordingly.
+	var queryCharacter = /\?/.test(this._options.endpoint) ? '&' : '?';
+
+	// Prepend a "?" (or a "&") if a query is present, and return.
+	return ( queryString === '' ) ? '' : queryCharacter + queryString;
 };
 
 /**

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -95,6 +95,14 @@ describe( 'WPRequest', function() {
 			expect( query ).to.equal( '?filter%5Bcat%5D=7%2B10&filter%5Bname%5D=some-slug' );
 		});
 
+		it( 'uses the correct query character if the endpoint already contains a query', function() {
+			request._filters = { name: 'some-slug' };
+			request._options = { endpoint: 'https://example.org?rest_route=' };
+			var query = request._renderQuery();
+			expect( query ).to
+				.equal( '&filter%5Bname%5D=some-slug' );
+		});
+
 	});
 
 	describe( '.checkMethodSupport()', function() {


### PR DESCRIPTION
We need to support wp sites without permalinks. If we use `http://example.org?rest_route=` it works fine, but when we add a query it returns `http://example.org?rest_route=/wp/v2/posts?params` instead of `http://example.org?rest_route=/wp/v2/posts&params`.

This PR checks if the endpoint has a previous query and if it does, it uses `&` instead of `?`.

I've added a unit test. The other tests pass fine as well.