### PR TITLE
Update superagent

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "parse-link-header": "^0.4.1",
     "qs": "^6.2.0",
     "route-parser": "0.0.4",
-    "superagent": "^1.8.3"
+    "superagent": "^3.3.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Superagent has this awsome bug where it fails and tells you to upgrade. When I would try and run a command it would just output `superagent: double callback bug. Upgrade to v3.2+ to fix this`. So I decided to upgrade supragent and everything seems to work.

This would require droping support for node 0.x as Superagent dropped support for it in 3.0.0

There are other breaking changes in superagent, but all unit tests pass and all of my real world testing shows that it works.