### PR TITLE
Handle case where JSON response is returned as content-type text/html

### DIFF
--- a/lib/http-transport.js
+++ b/lib/http-transport.js
@@ -13,6 +13,7 @@ var url = require( 'url' );
 var WPRequest = require( './constructors/wp-request' );
 var checkMethodSupport = require( './util/check-method-support' );
 var objectReduce = require( './util/object-reduce' );
+var isEmptyObject = require( './util/is-empty-object' );
 
 /**
  * Conditionally set basic authentication on a server request object
@@ -79,6 +80,29 @@ function mergeUrl( endpoint, linkPath ) {
 }
 
 /**
+ * Extract the body property from the superagent response, or else try to parse
+ * the response text to get a JSON object.
+ *
+ * @param {Object} response      The response object from the HTTP request
+ * @param {String} response.text The response content as text
+ * @param {Object} response.body The response content as a JS object
+ * @returns {Object} The response content as a JS object
+ */
+function extractResponseBody( response ) {
+	var responseBody = response.body;
+	if ( isEmptyObject( responseBody ) && response.type === 'text/html' ) {
+		// Response may have come back as HTML due to caching plugin; try to parse
+		// the response text into JSON
+		try {
+			responseBody = JSON.parse( response.text );
+		} catch ( e ) {
+			// Swallow errors, it's OK to fall back to returning the body
+		}
+	}
+	return responseBody;
+}
+
+/**
  * If the response is not paged, return the body as-is. If pagination
  * information is present in the response headers, parse those headers into
  * a custom `_paging` property on the response body. `_paging` contains links
@@ -98,24 +122,26 @@ function mergeUrl( endpoint, linkPath ) {
  * @returns {Object} The body of the HTTP request, conditionally augmented with
  *                   pagination metadata
  */
-function paginateResponse( result, endpoint, httpTransport ) {
+function createPaginationObject( result, endpoint, httpTransport ) {
+	var _paging = null;
+
 	if ( ! result.headers || ! result.headers[ 'x-wp-totalpages' ] ) {
 		// No headers: return as-is
-		return result;
+		return _paging;
 	}
 
 	var totalPages = result.headers[ 'x-wp-totalpages' ];
 
 	if ( ! totalPages || totalPages === '0' ) {
 		// No paging: return as-is
-		return result;
+		return _paging;
 	}
 
 	// Decode the link header object
 	var links = result.headers.link ? parseLinkHeader( result.headers.link ) : {};
 
 	// Store pagination data from response headers on the response collection
-	result.body._paging = {
+	_paging = {
 		total: result.headers[ 'x-wp-total' ],
 		totalPages: totalPages,
 		links: links
@@ -123,7 +149,7 @@ function paginateResponse( result, endpoint, httpTransport ) {
 
 	// Create a WPRequest instance pre-bound to the "next" page, if available
 	if ( links.next ) {
-		result.body._paging.next = new WPRequest({
+		_paging.next = new WPRequest({
 			transport: httpTransport,
 			endpoint: mergeUrl( endpoint, links.next )
 		});
@@ -131,13 +157,13 @@ function paginateResponse( result, endpoint, httpTransport ) {
 
 	// Create a WPRequest instance pre-bound to the "prev" page, if available
 	if ( links.prev ) {
-		result.body._paging.prev = new WPRequest({
+		_paging.prev = new WPRequest({
 			transport: httpTransport,
 			endpoint: mergeUrl( endpoint, links.prev )
 		});
 	}
 
-	return result;
+	return _paging;
 }
 
 // HTTP-Related Helpers
@@ -153,7 +179,6 @@ function paginateResponse( result, endpoint, httpTransport ) {
  * @return {Promise} A promise to the superagent request
  */
 function invokeAndPromisify( request, callback, transform ) {
-
 	return new Promise(function( resolve, reject ) {
 		// Fire off the result
 		request.end(function( err, result ) {
@@ -206,7 +231,12 @@ function invokeAndPromisify( request, callback, transform ) {
 function returnBody( wpreq, result ) {
 	var endpoint = wpreq._options.endpoint;
 	var httpTransport = wpreq.transport;
-	return paginateResponse( result, endpoint, httpTransport ).body;
+	var body = extractResponseBody( result );
+	var _paging = createPaginationObject( result, endpoint, httpTransport );
+	if ( _paging ) {
+		body._paging = _paging;
+	}
+	return body;
 }
 
 /**

--- a/lib/util/is-empty-object.js
+++ b/lib/util/is-empty-object.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = function( value ) {
+	// If the value is not object-like, then it is certainly not an empty object
+	if ( typeof value !== 'object' ) {
+		return false;
+	}
+
+	// For our purposes an empty array should not be treated as an empty object
+	// (Since this is used to process invalid content-type responses, )
+	if ( Array.isArray( value ) ) {
+		return false;
+	}
+
+	for ( var key in value ) {
+		if ( value.hasOwnProperty( key ) ) {
+			return false;
+		}
+	}
+
+	return true;
+};

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -96,10 +96,33 @@ describe( 'integration: posts()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
+	it( 'properly parses responses returned from server as text/html', function() {
+		var prom = wp.posts()
+			.param( '_wpapi_force_html', true )
+			.get()
+			.then(function( posts ) {
+				expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1 );
+				return SUCCESS;
+			});
+		return expect( prom ).to.eventually.equal( SUCCESS );
+	});
+
 	describe( 'paging properties', function() {
 
 		it( 'are exposed as _paging on the response array', function() {
 			var prom = wp.posts()
+				.get()
+				.then(function( posts ) {
+					expect( posts ).to.have.property( '_paging' );
+					expect( posts._paging ).to.be.an( 'object' );
+					return SUCCESS;
+				});
+			return expect( prom ).to.eventually.equal( SUCCESS );
+		});
+
+		it( 'are exposed as _paging on the response array when response is text/html', function() {
+			var prom = wp.posts()
+				.param( '_wpapi_force_html', true )
 				.get()
 				.then(function( posts ) {
 					expect( posts ).to.have.property( '_paging' );
@@ -164,6 +187,21 @@ describe( 'integration: posts()', function() {
 							// @TODO: re-enable once PPP support is merged
 							// expect( posts.length ).to.equal( 10 );
 							// expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page2 );
+							return SUCCESS;
+						});
+				});
+			return expect( prom ).to.eventually.equal( SUCCESS );
+		});
+
+		it( 'allows access to the next page of results via .next when response is text/html', function() {
+			var prom = wp.posts()
+				.param( '_wpapi_force_html', true )
+				.get()
+				.then(function( posts ) {
+					return posts._paging.next
+						.get()
+						.then(function( posts ) {
+							expect( posts ).to.be.an( 'array' );
 							return SUCCESS;
 						});
 				});

--- a/tests/unit/lib/util/is-empty-object.js
+++ b/tests/unit/lib/util/is-empty-object.js
@@ -1,0 +1,55 @@
+'use strict';
+var expect = require( 'chai' ).expect;
+
+var isEmptyObject = require( '../../../../lib/util/is-empty-object' );
+
+describe( 'isEmptyObject utility', function() {
+
+	it( 'is defined', function() {
+		expect( isEmptyObject ).to.exist;
+	});
+
+	it( 'is a function', function() {
+		expect( isEmptyObject ).to.be.a( 'function' );
+	});
+
+	it( 'returns true if passed an empty object', function() {
+		expect( isEmptyObject( {} ) ).to.equal( true );
+	});
+
+	it( 'returns true if passed a constructed object with no instance properties', function() {
+		function Ctor() {}
+		Ctor.prototype.prop = 'val';
+		expect( isEmptyObject( new Ctor() ) ).to.equal( true );
+	});
+
+	it( 'returns false if passed an object with own properties', function() {
+		expect( isEmptyObject({ prop: 'value' }) ).to.equal( false );
+	});
+
+	it( 'returns false if passed a constructed object with instance properties', function() {
+		function Ctor() {
+			this.prop = 'val';
+		}
+		expect( isEmptyObject( new Ctor() ) ).to.equal( false );
+	});
+
+	it( 'returns false if passed a string', function() {
+		expect( isEmptyObject( '{}' ) ).to.equal( false );
+	});
+
+	it( 'returns false if passed an empty array', function() {
+		expect( isEmptyObject( [] ) ).to.equal( false );
+	});
+
+	it( 'returns false if passed a boolean', function() {
+		expect( isEmptyObject( true ) ).to.equal( false );
+		expect( isEmptyObject( false ) ).to.equal( false );
+	});
+
+	it( 'returns false if passed a number', function() {
+		expect( isEmptyObject( 0 ) ).to.equal( false );
+		expect( isEmptyObject( 1337 ) ).to.equal( false );
+	});
+
+});


### PR DESCRIPTION
As noted in #146, the API response is not properly parsed by superagent when a caching plugin is enabled: the `.body` property of the response ends up null, so an error is thrown when the pagination object is tacked on. This seems to originate from the caching plugin (WP SuperCache) forcing a "text/html" content-type header on the API responses.

The workaround in this PR is to detect for the text/html content type, and to parse the JSON in the response `.text` property should the response body itself end up empty.

Fixes #146