### PR TITLE
Avoid errors when named capture groups contain forward slashes

### DIFF
--- a/lib/route-tree.js
+++ b/lib/route-tree.js
@@ -143,7 +143,9 @@ function reduceRouteTree( namespaces, routeObj, route ) {
 
 	// Strip the namespace from the route string (all routes should have the
 	// format `/namespace/other/stuff`) @TODO: Validate this assumption
-	var routeString = route.replace( '/' + nsForRoute + '/', '' );
+	// Also strip any trailing "/?": the slash is already optional and a single
+	// question mark would break the regex parser
+	var routeString = route.replace( '/' + nsForRoute + '/', '' ).replace( /\/\?$/, '' );
 
 	// Split the routes up into hierarchical route components
 	var routeComponents = splitPath( routeString );

--- a/lib/route-tree.js
+++ b/lib/route-tree.js
@@ -3,7 +3,8 @@
  */
 'use strict';
 
-var namedGroupRegexp = require( './util/named-group-regexp' );
+var namedGroupRE = require( './util/named-group-regexp' ).namedGroupRE;
+var splitPath = require( './util/split-path' );
 var ensure = require( './util/ensure' );
 var objectReduce = require( './util/object-reduce' );
 
@@ -32,7 +33,7 @@ function reduceRouteComponents( routeObj, topLevel, parentLevel, component, idx,
 	//   index: 15,
 	//   input: '/wp/v2/posts/(?P<id>[\\d]+)'
 	// ]
-	var namedGroup = component.match( namedGroupRegexp );
+	var namedGroup = component.match( namedGroupRE );
 	// Pull out references to the relevant indices of the match, for utility:
 	// `null` checking is necessary in case the component did not match the RE,
 	// hence the `namedGroup &&`.
@@ -143,7 +144,9 @@ function reduceRouteTree( namespaces, routeObj, route ) {
 	// Strip the namespace from the route string (all routes should have the
 	// format `/namespace/other/stuff`) @TODO: Validate this assumption
 	var routeString = route.replace( '/' + nsForRoute + '/', '' );
-	var routeComponents = routeString.split( '/' );
+
+	// Split the routes up into hierarchical route components
+	var routeComponents = splitPath( routeString );
 
 	// Do not make a namespace group for the API root
 	// Do not add the namespace root to its own group

--- a/lib/util/named-group-regexp.js
+++ b/lib/util/named-group-regexp.js
@@ -1,15 +1,9 @@
+/**
+ * @module util/named-group-regexp
+ */
 'use strict';
 
-/**
- * Regular Expression to identify a capture group in PCRE formats
- * `(?<name>regex)`, `(?'name'regex)` or `(?P<name>regex)` (see
- * regular-expressions.info/refext.html); RegExp is built as a string
- * to enable more detailed annotation.
- *
- * @module util/named-group-regexp
- * @type {RegExp}
- */
-module.exports = new RegExp([
+var pattern = [
 	// Capture group start
 	'\\(\\?',
 	// Capture group name begins either `P<`, `<` or `'`
@@ -23,4 +17,25 @@ module.exports = new RegExp([
 	'([^\\)]*)',
 	// Capture group end
 	'\\)'
-].join( '' ) );
+].join( '' );
+
+var namedGroupRE = new RegExp( pattern );
+
+module.exports = {
+	/**
+	 * String representation of the exported Regular Expression; we construct this
+	 * RegExp from a string to enable more detailed annotation and permutation
+	 *
+	 * @prop {String} pattern
+	 */
+	pattern: pattern,
+
+	/**
+	 * Regular Expression to identify a capture group in PCRE formats
+	 * `(?<name>regex)`, `(?'name'regex)` or `(?P<name>regex)` (see
+	 * regular-expressions.info/refext.html)
+	 *
+	 * @prop {RegExp} namedGroupRE
+	 */
+	namedGroupRE: namedGroupRE
+};

--- a/lib/util/split-path.js
+++ b/lib/util/split-path.js
@@ -47,8 +47,6 @@ module.exports = function( pathStr ) {
 		}
 
 		// Split the part on / and filter out empty strings
-		return components.concat( part.split( '/' ).filter(function( str ) {
-			return str;
-		}) );
+		return components.concat( part.split( '/' ).filter( Boolean ) );
 	}, [] );
 };

--- a/lib/util/split-path.js
+++ b/lib/util/split-path.js
@@ -1,0 +1,54 @@
+/**
+ * @module util/split-path
+ */
+'use strict';
+
+var namedGroupPattern = require( './named-group-regexp' ).pattern;
+
+// Convert capture groups to non-matching groups, because all capture groups
+// are included in the resulting array when an RE is passed to `.split()`
+// (We re-use the existing named group's capture pattern instead of creating
+// a new RegExp just for this purpose)
+var patternWithoutSubgroups = namedGroupPattern
+	.replace(/([^\\])\(([^?])/g, '$1(?:$2');
+
+// Make a new RegExp using the same pattern as one single unified capture group,
+// so the match as a whole will be preserved after `.split()`
+var namedGroupRE = new RegExp( '(' + patternWithoutSubgroups + ')' );
+
+/**
+ * Divide a route string up into hierarchical components by breaking it apart
+ * on forward slash characters.
+ *
+ * There are plugins (including Jetpack) that register routes with regex capture
+ * groups which also contain forward slashes, so those groups have to be pulled
+ * out first before the remainder of the string can be .split() as normal.
+ *
+ * @param {String} pathStr A route path string to break into components
+ * @returns {String[]} An array of route component strings
+ */
+module.exports = function( pathStr ) {
+	// Divide a string like "/some/path/(?P<with_named_groups>)/etc" into an
+	// array `[ "/some/path/", "(?P<with_named_groups>)", "/etc" ]`
+	var parts = pathStr.split( namedGroupRE );
+
+	// Reduce through the array of parts, splitting any non-capture-group parts
+	// on forward slashes and discarding empty strings to create the final array
+	// of path components
+	return parts.reduce(function( components, part ) {
+		if ( ! part ) {
+			// Ignore empty strings parts
+			return components;
+		}
+
+		if ( namedGroupRE.test( part ) ) {
+			// Include named capture groups as-is
+			return components.concat( part );
+		}
+
+		// Split the part on / and filter out empty strings
+		return components.concat( part.split( '/' ).filter(function( str ) {
+			return str;
+		}) );
+	}, [] );
+};

--- a/lib/util/split-path.js
+++ b/lib/util/split-path.js
@@ -10,11 +10,13 @@ var namedGroupPattern = require( './named-group-regexp' ).pattern;
 // (We re-use the existing named group's capture pattern instead of creating
 // a new RegExp just for this purpose)
 var patternWithoutSubgroups = namedGroupPattern
-	.replace(/([^\\])\(([^?])/g, '$1(?:$2');
+	.replace( /([^\\])\(([^?])/g, '$1(?:$2' );
 
 // Make a new RegExp using the same pattern as one single unified capture group,
-// so the match as a whole will be preserved after `.split()`
-var namedGroupRE = new RegExp( '(' + patternWithoutSubgroups + ')' );
+// so the match as a whole will be preserved after `.split()`. Permit non-slash
+// characters before or after the named capture group, although those components
+// will not yield functioning setters.
+var namedGroupRE = new RegExp( '([^/]*' + patternWithoutSubgroups + '[^/]*)' );
 
 /**
  * Divide a route string up into hierarchical components by breaking it apart
@@ -29,13 +31,11 @@ var namedGroupRE = new RegExp( '(' + patternWithoutSubgroups + ')' );
  */
 module.exports = function( pathStr ) {
 	// Divide a string like "/some/path/(?P<with_named_groups>)/etc" into an
-	// array `[ "/some/path/", "(?P<with_named_groups>)", "/etc" ]`
-	var parts = pathStr.split( namedGroupRE );
-
-	// Reduce through the array of parts, splitting any non-capture-group parts
-	// on forward slashes and discarding empty strings to create the final array
-	// of path components
-	return parts.reduce(function( components, part ) {
+	// array `[ "/some/path/", "(?P<with_named_groups>)", "/etc" ]`.
+	// Then, reduce through the array of parts, splitting any non-capture-group
+	// parts on forward slashes and discarding empty strings to create the final
+	// array of path components.
+	return pathStr.split( namedGroupRE ).reduce(function( components, part ) {
 		if ( ! part ) {
 			// Ignore empty strings parts
 			return components;

--- a/tests/unit/lib/util/named-group-regexp.js
+++ b/tests/unit/lib/util/named-group-regexp.js
@@ -1,7 +1,7 @@
 'use strict';
 var expect = require( 'chai' ).expect;
 
-var namedGroupRE = require( '../../../../lib/util/named-group-regexp' );
+var namedGroupRE = require( '../../../../lib/util/named-group-regexp' ).namedGroupRE;
 
 describe( 'named PCRE group RegExp', function() {
 
@@ -29,6 +29,14 @@ describe( 'named PCRE group RegExp', function() {
 		expect( result ).not.to.be.null;
 		expect( result[ 1 ] ).to.equal( 'id' );
 		expect( result[ 2 ] ).to.equal( '\\d+' );
+	});
+
+	it( 'identifies RE patterns including forward slashes', function() {
+		var pathComponent = '(?P<plugin>[a-z\\/\\.\\-_]+)';
+		var result = pathComponent.match( namedGroupRE );
+		expect( result ).not.to.be.null;
+		expect( result[ 1 ] ).to.equal( 'plugin' );
+		expect( result[ 2 ] ).to.equal( '[a-z\\/\\.\\-_]+' );
 	});
 
 	it( 'will match an empty string if a "RE Pattern" if the pattern is omitted', function() {

--- a/tests/unit/lib/util/split-path.js
+++ b/tests/unit/lib/util/split-path.js
@@ -1,8 +1,5 @@
 'use strict';
-var chai = require( 'chai' );
-var sinon = require( 'sinon' );
-chai.use( require( 'sinon-chai' ) );
-var expect = chai.expect;
+var expect = require( 'chai' ).expect;
 
 var splitPath = require( '../../../../lib/util/split-path' );
 
@@ -31,6 +28,20 @@ describe( 'splitPath utility', function() {
 		expect( result ).to.deep.equal([
 			'plugin',
 			'(?P<plugin>[a-z\\/\\.\\-_]+)'
+		]);
+	});
+
+	it( 'correctly splits a string with levels containing text outside named groups', function() {
+		// From user-contributed example on https://developer.wordpress.org/reference/functions/register_rest_route/
+		// Note that this library does not support this syntax, but ensuring that
+		// common variants of path strings are split correctly avoids situations
+		// where an unexpected string format could cause an error.
+		var result = splitPath( '/users/market=(?P<market>[a-zA-Z0-9-]+)/lat=(?P<lat>[a-z0-9 .\\-]+)/long=(?P<long>[a-z0-9 .\\-]+)' );
+		expect( result ).to.deep.equal([
+			'users',
+			'market=(?P<market>[a-zA-Z0-9-]+)',
+			'lat=(?P<lat>[a-z0-9 .\\-]+)',
+			'long=(?P<long>[a-z0-9 .\\-]+)'
 		]);
 	});
 

--- a/tests/unit/lib/util/split-path.js
+++ b/tests/unit/lib/util/split-path.js
@@ -45,4 +45,14 @@ describe( 'splitPath utility', function() {
 		]);
 	});
 
+	it( 'correctly splits a string with this situation', function() {
+		var result = splitPath( '/plugin/(?P<plugin_slug>[^/]+)/committers/?' );
+		expect( result ).to.deep.equal([
+			'plugin',
+			'(?P<plugin_slug>[^/]+)',
+			'committers',
+			'?'
+		]);
+	});
+
 });

--- a/tests/unit/lib/util/split-path.js
+++ b/tests/unit/lib/util/split-path.js
@@ -1,0 +1,37 @@
+'use strict';
+var chai = require( 'chai' );
+var sinon = require( 'sinon' );
+chai.use( require( 'sinon-chai' ) );
+var expect = chai.expect;
+
+var splitPath = require( '../../../../lib/util/split-path' );
+
+describe( 'splitPath utility', function() {
+
+	it( 'is a function', function() {
+		expect( splitPath ).to.be.a( 'function' );
+	});
+
+	it( 'splits a simple path on the "/" character', function() {
+		expect( splitPath( 'a/b/c/d' ) ).to.deep.equal([ 'a', 'b', 'c', 'd' ]);
+	});
+
+	it( 'correctly splits a string containing named capture groups', function() {
+		var result = splitPath( '/posts/(?P<parent>[\\d]+)/revisions/(?P<id>[\\d]+)' );
+		expect( result ).to.deep.equal([
+			'posts',
+			'(?P<parent>[\\d]+)',
+			'revisions',
+			'(?P<id>[\\d]+)'
+		]);
+	});
+
+	it( 'correctly splits a string when a named group regex contains a "/"', function() {
+		var result = splitPath( '/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)' );
+		expect( result ).to.deep.equal([
+			'plugin',
+			'(?P<plugin>[a-z\\/\\.\\-_]+)'
+		]);
+	});
+
+});

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -100,6 +100,22 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
+	describe( 'handler for /plugin/(?P<plugin_slug>[^/]+)/committers/?)', function() {
+
+		it( 'will ignore the trailing /? (the ? is intended to mark the / as optional', function() {
+			var factory = registerRoute( 'plugins/v1', '/plugin/(?P<plugin_slug>[^/]+)/committers/?' );
+			var handler = factory({
+				endpoint: '/'
+			});
+			expect( handler ).to.have.property( 'pluginSlug' );
+			expect( handler.pluginSlug ).to.be.a( 'function' );
+			expect( handler ).to.have.property( 'committers' );
+			expect( handler.committers ).to.be.a( 'function' );
+			expect( handler.pluginSlug( 'rest-api' ).committers().toString() ).to.equal( '/plugins/v1/plugin/rest-api/committers' );
+		});
+
+	});
+
 	describe( 'handler for unsupported route definition format', function() {
 
 		it( 'will parse the route without error but not yield functioning setters', function() {

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -87,16 +87,42 @@ describe( 'wp.registerRoute', function() {
 
 	// Example of a Jetpack route with regexes containing forward slashes
 	describe( 'handler for /jetpack/v4/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)', function() {
-		var handler;
 
 		it( 'permits setting path parts with forward slashes', function() {
 			var factory = registerRoute( 'jetpack/v4', '/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)' );
-			handler = factory({
+			var handler = factory({
 				endpoint: '/'
 			});
 			expect( handler ).to.have.property( 'plugin' );
 			expect( handler.plugin ).to.be.a( 'function' );
 			expect( handler.plugin( 'a/b_c' ).toString() ).to.equal( '/jetpack/v4/plugin/a/b_c' );
+		});
+
+	});
+
+	describe( 'handler for unsupported route definition format', function() {
+
+		it( 'will parse the route without error but not yield functioning setters', function() {
+			var factory;
+			expect(function() {
+				factory = registerRoute(
+					'mmw/v1',
+					'/users/market=(?P<market>[a-zA-Z0-9-]+)/lat=(?P<lat>[a-z0-9 .\\-]+)/long=(?P<long>[a-z0-9 .\\-]+)'
+				);
+			}).not.to.throw();
+			var handler = factory({
+				endpoint: '/'
+			});
+			expect( handler ).to.have.property( 'market' );
+			expect( handler.market ).to.be.a( 'function' );
+			expect( handler ).to.have.property( 'lat' );
+			expect( handler.lat ).to.be.a( 'function' );
+			expect( handler ).to.have.property( 'long' );
+			expect( handler.long ).to.be.a( 'function' );
+			// This is not "correct", but this syntax is not supported: the purpose of this
+			// test is to ensure that the code executes without error
+			expect( handler.market( 'nz' ).lat( '40.9006 S' ).long( '174.8860 E' ).toString() )
+				.to.equal( '/mmw/v1/users/nz/40.9006 S/174.8860 E' );
 		});
 
 	});

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -85,6 +85,22 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
+	// Example of a Jetpack route with regexes containing forward slashes
+	describe( 'handler for /jetpack/v4/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)', function() {
+		var handler;
+
+		it( 'permits setting path parts with forward slashes', function() {
+			var factory = registerRoute( 'jetpack/v4', '/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)' );
+			handler = factory({
+				endpoint: '/'
+			});
+			expect( handler ).to.have.property( 'plugin' );
+			expect( handler.plugin ).to.be.a( 'function' );
+			expect( handler.plugin( 'a/b_c' ).toString() ).to.equal( '/jetpack/v4/plugin/a/b_c' );
+		});
+
+	});
+
 	describe( 'handler for /a/(?P<snake_cased_path_setter>\\d+)', function() {
 		var handler;
 


### PR DESCRIPTION
Some plugins, most notably Jetpack, contain named capture groups in their route definitions with regular expressions which include forward slash characters. Our naive method of creating the path part hierarchy was to `.split( '/' )`, which would break these regular expressions in two and cause an error when the route object is being built.

To work around this, we can separate out the named capture groups and only `.split( '/' )` the remaining leftover, non-capture-group parts of the path string.

Fixes #310