### PR TITLE
Maintain authentication when making paginated .prev/.next requests

### DIFF
--- a/lib/http-transport.js
+++ b/lib/http-transport.js
@@ -12,6 +12,7 @@ var url = require( 'url' );
 
 var WPRequest = require( './constructors/wp-request' );
 var checkMethodSupport = require( './util/check-method-support' );
+var extend = require( 'node.extend' );
 var objectReduce = require( './util/object-reduce' );
 var isEmptyObject = require( './util/is-empty-object' );
 
@@ -140,12 +141,13 @@ function extractResponseBody( response ) {
  * - `prev` {WPRequest} A WPRequest object bound to the "previous" page (if page exists)
  *
  * @private
- * @param result {Object} The response object from the HTTP request
- * @param endpoint {String} The base URL of the requested API endpoint
- * @returns {Object} The body of the HTTP request, conditionally augmented with
- *                   pagination metadata
+ * @param {Object} result           The response object from the HTTP request
+ * @param {Object} options          The options hash from the original request
+ * @param {String} options.endpoint The base URL of the requested API endpoint
+ * @param {Object} httpTransport    The HTTP transport object used by the original request
+ * @returns {Object} The pagination metadata object for this HTTP request, or else null
  */
-function createPaginationObject( result, endpoint, httpTransport ) {
+function createPaginationObject( result, options, httpTransport ) {
 	var _paging = null;
 
 	if ( ! result.headers || ! result.headers[ 'x-wp-totalpages' ] ) {
@@ -170,20 +172,24 @@ function createPaginationObject( result, endpoint, httpTransport ) {
 		links: links
 	};
 
+	// Re-use any options from the original request, updating only the endpoint
+	// (this ensures that request properties like authentication are preserved)
+	var endpoint = options.endpoint;
+
 	// Create a WPRequest instance pre-bound to the "next" page, if available
 	if ( links.next ) {
-		_paging.next = new WPRequest({
+		_paging.next = new WPRequest( extend( {}, options, {
 			transport: httpTransport,
 			endpoint: mergeUrl( endpoint, links.next )
-		});
+		}));
 	}
 
 	// Create a WPRequest instance pre-bound to the "prev" page, if available
 	if ( links.prev ) {
-		_paging.prev = new WPRequest({
+		_paging.prev = new WPRequest( extend( {}, options, {
 			transport: httpTransport,
 			endpoint: mergeUrl( endpoint, links.prev )
-		});
+		}));
 	}
 
 	return _paging;
@@ -252,10 +258,8 @@ function invokeAndPromisify( request, callback, transform ) {
  *                  pagination information if the result is a partial collection.
  */
 function returnBody( wpreq, result ) {
-	var endpoint = wpreq._options.endpoint;
-	var httpTransport = wpreq.transport;
 	var body = extractResponseBody( result );
-	var _paging = createPaginationObject( result, endpoint, httpTransport );
+	var _paging = createPaginationObject( result, wpreq._options, wpreq.transport );
 	if ( _paging ) {
 		body._paging = _paging;
 	}

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -246,6 +246,20 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
+		it( 'maintains authentication across paging requests', function() {
+			var prom = authenticated.posts()
+				.context( 'edit' )
+				.get()
+				.then(function( posts ) {
+					return posts._paging.next.get();
+				})
+				.then(function( page2 ) {
+					expect( page2[0].content ).to.have.property( 'raw' );
+					return SUCCESS;
+				});
+			return expect( prom ).to.eventually.equal( SUCCESS );
+		});
+
 	});
 
 	describe( 'filter methods', function() {


### PR DESCRIPTION
When we create the WPRequest object to handle the previous or next pages of a collection (when available), we were passing only the endpoint and the HTTP Transport object -- this creates a valid WPRequest object, but authentication parameters are then not passed on to the new request objects. This PR updates the logic within the transport to maintain any set options on the request, overwriting only the endpoint URI, so that authentication will be maintained when paging through a collection.

Fixes #325 
props @motleydev