### PR TITLE
Update test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: node_js
 script: "npm run test:ci"
 node_js:
   - "node"
+  - "lts/*"
+  - "10"
+  - "8"
   - "6"
-  - "5"
-  - "4"
 # Opt-in to travis container infrastructure
 sudo: false

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -8,6 +8,7 @@
 	"strict": "global",
 	"undef": true,
 	"unused": true,
+	"esversion": 6,
 
 	"node": true,
 

--- a/tests/integration/autodiscovery.js
+++ b/tests/integration/autodiscovery.js
@@ -27,11 +27,11 @@ var expectedResults = {
 	firstPostTitle: 'Markup: HTML Tags and Formatting'
 };
 
-describe( 'integration: discover()', function() {
+describe( 'integration: discover()', () => {
 	var apiPromise;
 	var sinonSandbox;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		apiPromise = WPAPI.discover( 'http://wpapi.loc' );
 		// Stub warn and error
 		sinonSandbox = sinon.sandbox.create();
@@ -44,11 +44,11 @@ describe( 'integration: discover()', function() {
 		sinonSandbox.restore();
 	});
 
-	it( 'returns a promise', function() {
+	it( 'returns a promise', () => {
 		expect( apiPromise ).to.be.an.instanceOf( Promise );
 	});
 
-	it( 'eventually returns a configured WP instance', function() {
+	it( 'eventually returns a configured WP instance', () => {
 		var prom = apiPromise
 			.then(function( result ) {
 				expect( result ).to.be.an.instanceOf( WPAPI );
@@ -60,7 +60,7 @@ describe( 'integration: discover()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'auto-binds to the detected endpoint on the provided site', function() {
+	it( 'auto-binds to the detected endpoint on the provided site', () => {
 		var prom = apiPromise
 			.then(function( site ) {
 				expect( site.posts().toString() ).to.equal( 'http://wpapi.loc/wp-json/wp/v2/posts' );
@@ -69,7 +69,7 @@ describe( 'integration: discover()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can correctly instantiate requests against the detected and bound site', function() {
+	it( 'can correctly instantiate requests against the detected and bound site', () => {
 		var prom = apiPromise
 			.then(function( site ) {
 				return site.posts();
@@ -81,9 +81,9 @@ describe( 'integration: discover()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	describe( 'can authenticate', function() {
+	describe( 'can authenticate', () => {
 
-		it( 'requests against the detected and bound site', function() {
+		it( 'requests against the detected and bound site', () => {
 			var prom = apiPromise
 				.then(function( site ) {
 					return site.auth( credentials );
@@ -99,7 +99,7 @@ describe( 'integration: discover()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'one-off requests against the detected and bound site', function() {
+		it( 'one-off requests against the detected and bound site', () => {
 			var prom = apiPromise
 				.then(function( site ) {
 					return site.users()

--- a/tests/integration/autodiscovery.js
+++ b/tests/integration/autodiscovery.js
@@ -39,7 +39,7 @@ describe( 'integration: discover()', () => {
 		sinonSandbox.stub( global.console, 'error' );
 	});
 
-	afterEach(function() {
+	afterEach( () => {
 		// Restore sandbox
 		sinonSandbox.restore();
 	});
@@ -50,7 +50,7 @@ describe( 'integration: discover()', () => {
 
 	it( 'eventually returns a configured WP instance', () => {
 		var prom = apiPromise
-			.then(function( result ) {
+			.then( ( result ) => {
 				expect( result ).to.be.an.instanceOf( WPAPI );
 				expect( result.namespace( 'wp/v2' ) ).to.be.an( 'object' );
 				expect( result.posts ).to.be.a( 'function' );
@@ -62,7 +62,7 @@ describe( 'integration: discover()', () => {
 
 	it( 'auto-binds to the detected endpoint on the provided site', () => {
 		var prom = apiPromise
-			.then(function( site ) {
+			.then( ( site ) => {
 				expect( site.posts().toString() ).to.equal( 'http://wpapi.loc/wp-json/wp/v2/posts' );
 				return SUCCESS;
 			});
@@ -71,10 +71,8 @@ describe( 'integration: discover()', () => {
 
 	it( 'can correctly instantiate requests against the detected and bound site', () => {
 		var prom = apiPromise
-			.then(function( site ) {
-				return site.posts();
-			})
-			.then(function( posts ) {
+			.then( ( site ) => site.posts() )
+			.then( ( posts ) => {
 				expect( getTitles( posts )[ 0 ] ).to.equal( expectedResults.firstPostTitle );
 				return SUCCESS;
 			});
@@ -85,13 +83,9 @@ describe( 'integration: discover()', () => {
 
 		it( 'requests against the detected and bound site', () => {
 			var prom = apiPromise
-				.then(function( site ) {
-					return site.auth( credentials );
-				})
-				.then(function( site ) {
-					return site.users().me();
-				})
-				.then(function( user ) {
+				.then( ( site ) => site.auth( credentials ) )
+				.then( ( site ) => site.users().me() )
+				.then( ( user ) => {
 					expect( user ).to.be.an( 'object' );
 					expect( user.slug ).to.equal( credentials.username );
 					return SUCCESS;
@@ -101,12 +95,8 @@ describe( 'integration: discover()', () => {
 
 		it( 'one-off requests against the detected and bound site', () => {
 			var prom = apiPromise
-				.then(function( site ) {
-					return site.users()
-						.auth( credentials )
-						.me();
-				})
-				.then(function( user ) {
+				.then( ( site ) => site.users().auth( credentials ).me() )
+				.then( ( user ) => {
 					expect( user ).to.be.an( 'object' );
 					expect( user.slug ).to.equal( credentials.username );
 					return SUCCESS;

--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -65,7 +65,7 @@ describe( 'integration: categories()', () => {
 	it( 'can be used to retrieve a collection of category terms', () => {
 		var prom = wp.categories()
 			.get()
-			.then(function( categories ) {
+			.then( ( categories ) => {
 				expect( categories ).to.be.an( 'array' );
 				expect( categories.length ).to.equal( 10 );
 				return SUCCESS;
@@ -76,7 +76,7 @@ describe( 'integration: categories()', () => {
 	it( 'retrieves the first 10 categories by default', () => {
 		var prom = wp.categories()
 			.get()
-			.then(function( categories ) {
+			.then( ( categories ) => {
 				expect( categories ).to.be.an( 'array' );
 				expect( categories.length ).to.equal( 10 );
 				return SUCCESS;
@@ -89,7 +89,7 @@ describe( 'integration: categories()', () => {
 		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories ).to.have.property( '_paging' );
 					expect( categories._paging ).to.be.an( 'object' );
 					return SUCCESS;
@@ -100,7 +100,7 @@ describe( 'integration: categories()', () => {
 		it( 'include the total number of categories', () => {
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories._paging ).to.have.property( 'total' );
 					expect( categories._paging.total ).to.equal( '65' );
 					return SUCCESS;
@@ -111,7 +111,7 @@ describe( 'integration: categories()', () => {
 		it( 'include the total number of pages available', () => {
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories._paging ).to.have.property( 'totalPages' );
 					expect( categories._paging.totalPages ).to.equal( '7' );
 					return SUCCESS;
@@ -122,7 +122,7 @@ describe( 'integration: categories()', () => {
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories._paging ).to.have.property( 'next' );
 					expect( categories._paging.next ).to.be.an( 'object' );
 					expect( categories._paging.next ).to.be.an.instanceOf( WPRequest );
@@ -132,7 +132,7 @@ describe( 'integration: categories()', () => {
 					return wp.categories()
 						.page( categories._paging.totalPages )
 						.get()
-						.then(function( categories ) {
+						.then( ( categories ) => {
 							expect( categories._paging ).not.to.have.property( 'next' );
 							expect( getNames( categories ) ).to.deep.equal( expectedResults.names.pageLast );
 							return SUCCESS;
@@ -144,10 +144,10 @@ describe( 'integration: categories()', () => {
 		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					return categories._paging.next
 						.get()
-						.then(function( categories ) {
+						.then( ( categories ) => {
 							expect( categories ).to.be.an( 'array' );
 							expect( categories.length ).to.equal( 10 );
 							expect( getNames( categories ) ).to.deep.equal( expectedResults.names.page2 );
@@ -160,11 +160,11 @@ describe( 'integration: categories()', () => {
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories._paging ).not.to.have.property( 'prev' );
 					return categories._paging.next
 						.get()
-						.then(function( categories ) {
+						.then( ( categories ) => {
 							expect( categories._paging ).to.have.property( 'prev' );
 							expect( categories._paging.prev ).to.be.an( 'object' );
 							expect( categories._paging.prev ).to.be.an.instanceOf( WPRequest );
@@ -180,11 +180,11 @@ describe( 'integration: categories()', () => {
 			var prom = wp.categories()
 				.page( 2 )
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( getNames( categories ) ).to.deep.equal( expectedResults.names.page2 );
 					return categories._paging.prev
 						.get()
-						.then(function( categories ) {
+						.then( ( categories ) => {
 							expect( categories ).to.be.an( 'array' );
 							expect( categories.length ).to.equal( 10 );
 							expect( getNames( categories ) ).to.deep.equal( expectedResults.names.page1 );
@@ -202,13 +202,13 @@ describe( 'integration: categories()', () => {
 			var selectedCategory;
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					// Pick one of the categories
 					selectedCategory = categories[ 3 ];
 					// Query for that category directly
 					return wp.categories().id( selectedCategory.id );
 				})
-				.then(function( category ) {
+				.then( ( category ) => {
 					expect( category ).to.be.an( 'object' );
 					expect( category ).to.have.property( 'id' );
 					expect( category.id ).to.equal( selectedCategory.id );
@@ -231,18 +231,18 @@ describe( 'integration: categories()', () => {
 			var selectedCategory;
 			var prom = wp.categories()
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					// Pick one of the categories
 					selectedCategory = categories[ 3 ];
 					// Search for that category by slug
 					return wp.categories().search( selectedCategory.slug );
 				})
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories ).to.be.an( 'array' );
 					expect( categories.length ).to.equal( 1 );
 					return categories[ 0 ];
 				})
-				.then(function( category ) {
+				.then( ( category ) => {
 					expect( category ).to.be.an( 'object' );
 					expect( category ).to.have.property( 'id' );
 					expect( category.id ).to.equal( selectedCategory.id );
@@ -261,12 +261,10 @@ describe( 'integration: categories()', () => {
 			var prom = wp.categories()
 				.search( 'parent' )
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories ).to.be.an( 'array' );
 					expect( categories.length ).to.equal( 4 );
-					var slugs = categories.map(function( cat ) {
-						return cat.slug;
-					}).sort().join( ' ' );
+					var slugs = categories.map( ( cat ) => cat.slug ).sort().join( ' ' );
 					expect( slugs ).to.equal( 'foo-a-foo-parent foo-parent parent parent-category' );
 					return SUCCESS;
 				});
@@ -277,7 +275,7 @@ describe( 'integration: categories()', () => {
 			var prom = wp.categories()
 				.search( 'parent' )
 				.get()
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					// Iterating over response of search is the best we can do until
 					// filtering for taxonomy term collections is reinstated
 					for ( var i = 0; i < 4; i++ ) {
@@ -286,7 +284,7 @@ describe( 'integration: categories()', () => {
 						}
 					}
 				})
-				.then(function( category ) {
+				.then( ( category ) => {
 					expect( category ).to.have.property( 'slug' );
 					expect( category.slug ).to.equal( 'parent' );
 					expect( category ).to.have.property( 'name' );
@@ -310,16 +308,11 @@ describe( 'integration: categories()', () => {
 			var prom = wp.categories()
 				.search( 'parent' )
 				.get()
-				.then(function( categories ) {
-					for ( var i = 0; i < 4; i++ ) {
-						if ( categories[ i ].slug === 'parent' ) {
-							// Return a query for the matching category's child
-							parentCat = categories[ i ];
-							return wp.categories().parent( parentCat.id );
-						}
-					}
+				.then( ( categories ) => {
+					parentCat = categories.find( cat => cat.slug === 'parent' );
+					return wp.categories().parent( parentCat.id );
 				})
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories ).to.be.an( 'array' );
 					expect( categories.length ).to.equal( 1 );
 					var category = categories[ 0 ];
@@ -331,7 +324,7 @@ describe( 'integration: categories()', () => {
 					// Go one level deeper
 					return wp.categories().parent( childCat1.id );
 				})
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories ).to.be.an( 'array' );
 					expect( categories.length ).to.equal( 1 );
 					var category = categories[ 0 ];
@@ -343,7 +336,7 @@ describe( 'integration: categories()', () => {
 					// Go one level deeper
 					return wp.categories().parent( childCat2.id );
 				})
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories ).to.be.an( 'array' );
 					expect( categories.length ).to.equal( 0 );
 					return SUCCESS;
@@ -361,10 +354,10 @@ describe( 'integration: categories()', () => {
 				.perPage( 1 )
 				.embed()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					var post = posts[ 0 ];
 					// Find the categories for this post
-					post._embedded['wp:term'].forEach(function( terms ) {
+					post._embedded['wp:term'].forEach( ( terms ) => {
 						if ( terms.length && terms[ 0 ].taxonomy === 'category' ) {
 							postCategories = terms;
 						}
@@ -372,15 +365,15 @@ describe( 'integration: categories()', () => {
 					var postId = post.id;
 					return wp.categories().post( postId );
 				})
-				.then(function( categories ) {
+				.then( ( categories ) => {
 					expect( categories.length ).to.equal( postCategories.length );
-					categories.forEach(function( cat, idx ) {
+					categories.forEach( ( cat, idx ) => {
 						[
 							'id',
 							'name',
 							'slug',
 							'taxonomy'
-						].forEach(function( prop ) {
+						].forEach( ( prop ) => {
 							expect( cat[ prop ] ).to.equal( postCategories[ idx ][ prop ] );
 						});
 					});

--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -53,16 +53,16 @@ var expectedResults = {
 	}
 };
 
-describe( 'integration: categories()', function() {
+describe( 'integration: categories()', () => {
 	var wp;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
 	});
 
-	it( 'can be used to retrieve a collection of category terms', function() {
+	it( 'can be used to retrieve a collection of category terms', () => {
 		var prom = wp.categories()
 			.get()
 			.then(function( categories ) {
@@ -73,7 +73,7 @@ describe( 'integration: categories()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'retrieves the first 10 categories by default', function() {
+	it( 'retrieves the first 10 categories by default', () => {
 		var prom = wp.categories()
 			.get()
 			.then(function( categories ) {
@@ -84,9 +84,9 @@ describe( 'integration: categories()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	describe( 'paging properties', function() {
+	describe( 'paging properties', () => {
 
-		it( 'are exposed as _paging on the response array', function() {
+		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.categories()
 				.get()
 				.then(function( categories ) {
@@ -97,7 +97,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of categories', function() {
+		it( 'include the total number of categories', () => {
 			var prom = wp.categories()
 				.get()
 				.then(function( categories ) {
@@ -108,7 +108,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of pages available', function() {
+		it( 'include the total number of pages available', () => {
 			var prom = wp.categories()
 				.get()
 				.then(function( categories ) {
@@ -119,7 +119,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the next page as .next', function() {
+		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.categories()
 				.get()
 				.then(function( categories ) {
@@ -141,7 +141,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the next page of results via .next', function() {
+		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.categories()
 				.get()
 				.then(function( categories ) {
@@ -157,7 +157,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the previous page as .prev', function() {
+		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.categories()
 				.get()
 				.then(function( categories ) {
@@ -176,7 +176,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the previous page of results via .prev', function() {
+		it( 'allows access to the previous page of results via .prev', () => {
 			var prom = wp.categories()
 				.page( 2 )
 				.get()
@@ -196,9 +196,9 @@ describe( 'integration: categories()', function() {
 
 	});
 
-	describe( 'id()', function() {
+	describe( 'id()', () => {
 
-		it( 'can be used to access an individual category term', function() {
+		it( 'can be used to access an individual category term', () => {
 			var selectedCategory;
 			var prom = wp.categories()
 				.get()
@@ -225,9 +225,9 @@ describe( 'integration: categories()', function() {
 
 	});
 
-	describe( 'search()', function() {
+	describe( 'search()', () => {
 
-		it( 'can be used to retrieve a category by slug', function() {
+		it( 'can be used to retrieve a category by slug', () => {
 			var selectedCategory;
 			var prom = wp.categories()
 				.get()
@@ -257,7 +257,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'returns all categories matching the provided search string', function() {
+		it( 'returns all categories matching the provided search string', () => {
 			var prom = wp.categories()
 				.search( 'parent' )
 				.get()
@@ -273,7 +273,7 @@ describe( 'integration: categories()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'can be used to retrieve a category by slug from a set of search results', function() {
+		it( 'can be used to retrieve a category by slug from a set of search results', () => {
 			var prom = wp.categories()
 				.search( 'parent' )
 				.get()
@@ -300,9 +300,9 @@ describe( 'integration: categories()', function() {
 
 	});
 
-	describe( 'parent()', function() {
+	describe( 'parent()', () => {
 
-		it( 'can be used to retrieve direct children of a specific category', function() {
+		it( 'can be used to retrieve direct children of a specific category', () => {
 			var parentCat;
 			var childCat1;
 			var childCat2;
@@ -353,9 +353,9 @@ describe( 'integration: categories()', function() {
 
 	});
 
-	describe( '.post()', function() {
+	describe( '.post()', () => {
 
-		it( 'can be used to retrieve terms for a specific post', function() {
+		it( 'can be used to retrieve terms for a specific post', () => {
 			var postCategories;
 			var prom = wp.posts()
 				.perPage( 1 )

--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -275,15 +275,9 @@ describe( 'integration: categories()', () => {
 			var prom = wp.categories()
 				.search( 'parent' )
 				.get()
-				.then( ( categories ) => {
-					// Iterating over response of search is the best we can do until
-					// filtering for taxonomy term collections is reinstated
-					for ( var i = 0; i < 4; i++ ) {
-						if ( categories[ i ].slug === 'parent' ) {
-							return categories[ i ];
-						}
-					}
-				})
+				// Iterating over response of search is the best we can do until
+				// filtering for taxonomy term collections is reinstated
+				.then( ( categories ) => categories.find( cat => cat.slug === 'parent' ) )
 				.then( ( category ) => {
 					expect( category ).to.have.property( 'slug' );
 					expect( category.slug ).to.equal( 'parent' );

--- a/tests/integration/comments.js
+++ b/tests/integration/comments.js
@@ -71,16 +71,16 @@ function getPostsAndAuthors( comments ) {
 	});
 }
 
-describe( 'integration: comments()', function() {
+describe( 'integration: comments()', () => {
 	var wp;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
 	});
 
-	it( 'can be used to retrieve a list of comments, omitting a password-protected comment', function() {
+	it( 'can be used to retrieve a list of comments, omitting a password-protected comment', () => {
 		var prom = wp.comments()
 			.get()
 			.then(function( comments ) {
@@ -91,7 +91,7 @@ describe( 'integration: comments()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'fetches the first page, omitting a password-protected comment', function() {
+	it( 'fetches the first page, omitting a password-protected comment', () => {
 		var prom = wp.comments()
 			.get()
 			.then(function( comments ) {
@@ -101,7 +101,7 @@ describe( 'integration: comments()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'fetches the 10 oldest comments when sorted "asc"', function() {
+	it( 'fetches the 10 oldest comments when sorted "asc"', () => {
 		var prom = wp.comments()
 			.order( 'asc' )
 			.get()
@@ -112,9 +112,9 @@ describe( 'integration: comments()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	describe( 'paging properties', function() {
+	describe( 'paging properties', () => {
 
-		it( 'are exposed as _paging on the response array', function() {
+		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.comments()
 				.get()
 				.then(function( posts ) {
@@ -125,7 +125,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of posts', function() {
+		it( 'include the total number of posts', () => {
 			var prom = wp.comments()
 				.get()
 				.then(function( posts ) {
@@ -136,7 +136,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of pages available', function() {
+		it( 'include the total number of pages available', () => {
 			var prom = wp.comments()
 				.get()
 				.then(function( posts ) {
@@ -147,7 +147,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the next page as .next', function() {
+		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.comments()
 				.get()
 				.then(function( posts ) {
@@ -169,7 +169,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the next page of results via .next', function() {
+		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.comments()
 				.get()
 				.then(function( posts ) {
@@ -185,7 +185,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the previous page as .prev', function() {
+		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.comments()
 				.get()
 				.then(function( posts ) {
@@ -204,7 +204,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the previous page of results via .prev', function() {
+		it( 'allows access to the previous page of results via .prev', () => {
 			var prom = wp.comments()
 				.page( 2 )
 				.get()
@@ -225,12 +225,12 @@ describe( 'integration: comments()', function() {
 
 	});
 
-	describe( 'querying by ID', function() {
+	describe( 'querying by ID', () => {
 		var commentCollection;
 		var commentId;
 		var commentProm;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			commentCollection = [];
 			commentProm = wp.comments()
 				.get()
@@ -243,7 +243,7 @@ describe( 'integration: comments()', function() {
 				});
 		});
 
-		it( 'returns an object, not an array', function() {
+		it( 'returns an object, not an array', () => {
 			var prom = commentProm
 				.then(function( comment ) {
 					expect( Array.isArray( comment ) ).to.equal( false );
@@ -253,7 +253,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'returns the correct comment', function() {
+		it( 'returns the correct comment', () => {
 			var prom = commentProm.then(function( comment ) {
 				expect( comment.id ).to.equal( commentId );
 				[ 'author_name', 'post', 'parent', 'date', 'status' ].forEach(function( prop ) {
@@ -266,11 +266,11 @@ describe( 'integration: comments()', function() {
 
 	});
 
-	describe( '.post() query', function() {
+	describe( '.post() query', () => {
 		var pageComments;
 		var commentProm;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var pageId = 155;
 			commentProm = wp.pages()
 				.id( pageId )
@@ -287,11 +287,11 @@ describe( 'integration: comments()', function() {
 				});
 		});
 
-		it( 'returns an array of posts', function() {
+		it( 'returns an array of posts', () => {
 			return expect( commentProm ).to.eventually.be.an( 'array' );
 		});
 
-		it( 'returns the correct number of comments', function() {
+		it( 'returns the correct number of comments', () => {
 			var prom = commentProm
 				.then(function( comments ) {
 					expect( comments.length ).to.equal( 3 );
@@ -301,7 +301,7 @@ describe( 'integration: comments()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'returns the correct comments', function() {
+		it( 'returns the correct comments', () => {
 			var prom = commentProm
 				.then(function( comments ) {
 					pageComments.forEach(function( comment, i ) {

--- a/tests/integration/comments.js
+++ b/tests/integration/comments.js
@@ -66,9 +66,7 @@ var expectedResults = {
 // Inspecting the posts and authors of the returned comments arrays is an easy
 // way to validate that the right page of results was returned
 function getPostsAndAuthors( comments ) {
-	return comments.map(function( comment ) {
-		return comment.post + comment.author_name;
-	});
+	return comments.map( ( comment ) => comment.post + comment.author_name );
 }
 
 describe( 'integration: comments()', () => {
@@ -83,7 +81,7 @@ describe( 'integration: comments()', () => {
 	it( 'can be used to retrieve a list of comments, omitting a password-protected comment', () => {
 		var prom = wp.comments()
 			.get()
-			.then(function( comments ) {
+			.then( ( comments ) => {
 				expect( comments ).to.be.an( 'array' );
 				expect( comments.length ).to.equal( 9 );
 				return SUCCESS;
@@ -94,7 +92,7 @@ describe( 'integration: comments()', () => {
 	it( 'fetches the first page, omitting a password-protected comment', () => {
 		var prom = wp.comments()
 			.get()
-			.then(function( comments ) {
+			.then( ( comments ) => {
 				expect( getPostsAndAuthors( comments ) ).to.deep.equal( expectedResults.postsAndAuthors.page1 );
 				return SUCCESS;
 			});
@@ -105,7 +103,7 @@ describe( 'integration: comments()', () => {
 		var prom = wp.comments()
 			.order( 'asc' )
 			.get()
-			.then(function( comments ) {
+			.then( ( comments ) => {
 				expect( getPostsAndAuthors( comments ) ).to.deep.equal( expectedResults.postsAndAuthorsAsc.page1 );
 				return SUCCESS;
 			});
@@ -117,7 +115,7 @@ describe( 'integration: comments()', () => {
 		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.comments()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts ).to.have.property( '_paging' );
 					expect( posts._paging ).to.be.an( 'object' );
 					return SUCCESS;
@@ -128,7 +126,7 @@ describe( 'integration: comments()', () => {
 		it( 'include the total number of posts', () => {
 			var prom = wp.comments()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts._paging ).to.have.property( 'total' );
 					expect( posts._paging.total ).to.equal( '25' );
 					return SUCCESS;
@@ -139,7 +137,7 @@ describe( 'integration: comments()', () => {
 		it( 'include the total number of pages available', () => {
 			var prom = wp.comments()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts._paging ).to.have.property( 'totalPages' );
 					expect( posts._paging.totalPages ).to.equal( '3' );
 					return SUCCESS;
@@ -150,7 +148,7 @@ describe( 'integration: comments()', () => {
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.comments()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts._paging ).to.have.property( 'next' );
 					expect( posts._paging.next ).to.be.an( 'object' );
 					expect( posts._paging.next ).to.be.an.instanceOf( WPRequest );
@@ -160,7 +158,7 @@ describe( 'integration: comments()', () => {
 					return wp.comments()
 						.page( posts._paging.totalPages )
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts._paging ).not.to.have.property( 'next' );
 							expect( getPostsAndAuthors( posts ) ).to.deep.equal( expectedResults.postsAndAuthors.page3 );
 							return SUCCESS;
@@ -172,10 +170,10 @@ describe( 'integration: comments()', () => {
 		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.comments()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					return posts._paging.next
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts ).to.be.an( 'array' );
 							expect( posts.length ).to.equal( 10 );
 							expect( getPostsAndAuthors( posts ) ).to.deep.equal( expectedResults.postsAndAuthors.page2 );
@@ -188,11 +186,11 @@ describe( 'integration: comments()', () => {
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.comments()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts._paging ).not.to.have.property( 'prev' );
 					return posts._paging.next
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts._paging ).to.have.property( 'prev' );
 							expect( posts._paging.prev ).to.be.an( 'object' );
 							expect( posts._paging.prev ).to.be.an.instanceOf( WPRequest );
@@ -208,11 +206,11 @@ describe( 'integration: comments()', () => {
 			var prom = wp.comments()
 				.page( 2 )
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( getPostsAndAuthors( posts ) ).to.deep.equal( expectedResults.postsAndAuthors.page2 );
 					return posts._paging.prev
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts ).to.be.an( 'array' );
 							// 9 because one comment is for a password-protected post
 							expect( posts.length ).to.equal( 9 );
@@ -234,7 +232,7 @@ describe( 'integration: comments()', () => {
 			commentCollection = [];
 			commentProm = wp.comments()
 				.get()
-				.then(function( comments ) {
+				.then( ( comments ) => {
 					commentCollection = comments;
 					commentId = commentCollection[4].id;
 					return wp.comments()
@@ -245,7 +243,7 @@ describe( 'integration: comments()', () => {
 
 		it( 'returns an object, not an array', () => {
 			var prom = commentProm
-				.then(function( comment ) {
+				.then( ( comment ) => {
 					expect( Array.isArray( comment ) ).to.equal( false );
 					expect( comment ).to.be.an( 'object' );
 					return SUCCESS;
@@ -254,9 +252,9 @@ describe( 'integration: comments()', () => {
 		});
 
 		it( 'returns the correct comment', () => {
-			var prom = commentProm.then(function( comment ) {
+			var prom = commentProm.then( ( comment ) => {
 				expect( comment.id ).to.equal( commentId );
-				[ 'author_name', 'post', 'parent', 'date', 'status' ].forEach(function( prop ) {
+				[ 'author_name', 'post', 'parent', 'date', 'status' ].forEach( ( prop ) => {
 					expect( comment[ prop ] ).to.equal( commentCollection[4][ prop ] );
 				});
 				return SUCCESS;
@@ -276,11 +274,9 @@ describe( 'integration: comments()', () => {
 				.id( pageId )
 				.embed()
 				.get()
-				.then(function( page ) {
+				.then( ( page ) => {
 					// Do a flatten reduction because .replies will be an array of arrays
-					pageComments = page._embedded.replies.reduce(function( flatArr, arr ) {
-						return flatArr.concat( arr );
-					}, [] );
+					pageComments = page._embedded.replies.reduce( ( flatArr, arr ) => flatArr.concat( arr ), [] );
 					return wp.comments()
 						.post( pageId )
 						.get();
@@ -293,7 +289,7 @@ describe( 'integration: comments()', () => {
 
 		it( 'returns the correct number of comments', () => {
 			var prom = commentProm
-				.then(function( comments ) {
+				.then( ( comments ) => {
 					expect( comments.length ).to.equal( 3 );
 					expect( comments.length ).to.equal( pageComments.length );
 					return SUCCESS;
@@ -303,9 +299,9 @@ describe( 'integration: comments()', () => {
 
 		it( 'returns the correct comments', () => {
 			var prom = commentProm
-				.then(function( comments ) {
-					pageComments.forEach(function( comment, i ) {
-						[ 'id', 'parent', 'author', 'author_name' ].forEach(function( prop ) {
+				.then( ( comments ) => {
+					pageComments.forEach( ( comment, i ) => {
+						[ 'id', 'parent', 'author', 'author_name' ].forEach( ( prop ) => {
 							expect( comment[ prop ] ).to.equal( comments[ i ][ prop ] );
 						});
 						expect( comment.content.rendered ).to.equal( comments[ i ].content.rendered );

--- a/tests/integration/custom-http-headers.js
+++ b/tests/integration/custom-http-headers.js
@@ -15,10 +15,10 @@ var WPAPI = require( '../../' );
 var getTitles = require( './helpers/get-rendered-prop' ).bind( null, 'title' );
 var base64credentials = new Buffer( 'apiuser:password' ).toString( 'base64' );
 
-describe( 'integration: custom HTTP Headers', function() {
+describe( 'integration: custom HTTP Headers', () => {
 	var wp;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
@@ -26,7 +26,7 @@ describe( 'integration: custom HTTP Headers', function() {
 
 	// Testing basic authentication is an acceptable proxy for whether a header
 	// value (Authentication:, in this case) is being set
-	it( 'can be provided using WPRequest#setHeaders()', function() {
+	it( 'can be provided using WPRequest#setHeaders()', () => {
 		var prom = wp.posts()
 			.setHeaders( 'Authorization', 'Basic ' + base64credentials )
 			.status([ 'future', 'draft' ])
@@ -41,7 +41,7 @@ describe( 'integration: custom HTTP Headers', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be provided at the WPAPI instance level using WPAPI#setHeaders()', function() {
+	it( 'can be provided at the WPAPI instance level using WPAPI#setHeaders()', () => {
 		var authenticated = WPAPI
 			.site( 'http://wpapi.loc/wp-json' )
 			.setHeaders( 'Authorization', 'Basic ' + base64credentials );

--- a/tests/integration/custom-http-headers.js
+++ b/tests/integration/custom-http-headers.js
@@ -31,7 +31,7 @@ describe( 'integration: custom HTTP Headers', () => {
 			.setHeaders( 'Authorization', 'Basic ' + base64credentials )
 			.status([ 'future', 'draft' ])
 			.get()
-			.then(function( posts ) {
+			.then( ( posts ) => {
 				expect( getTitles( posts ) ).to.deep.equal([
 					'Scheduled',
 					'Draft'
@@ -48,14 +48,14 @@ describe( 'integration: custom HTTP Headers', () => {
 		var prom = authenticated.posts()
 			.status([ 'future', 'draft' ])
 			.get()
-			.then(function( posts ) {
+			.then( ( posts ) => {
 				expect( getTitles( posts ) ).to.deep.equal([
 					'Scheduled',
 					'Draft'
 				]);
 				return authenticated.users().me();
 			})
-			.then(function( me ) {
+			.then( ( me ) => {
 				expect( me.slug ).to.equal( 'apiuser' );
 				return SUCCESS;
 			});

--- a/tests/integration/custom-http-transport.js
+++ b/tests/integration/custom-http-transport.js
@@ -27,7 +27,7 @@ describe( 'integration: custom HTTP transport methods', () => {
 
 	beforeEach( () => {
 		cache = {};
-		cachingGet = sinon.spy(function( wpreq, cb ) {
+		cachingGet = sinon.spy( ( wpreq, cb ) => {
 			var result = cache[ wpreq ];
 			// If a cache hit is found, return it via the same callback/promise
 			// signature as the default transport method
@@ -39,7 +39,7 @@ describe( 'integration: custom HTTP transport methods', () => {
 			}
 
 			// Delegate to default transport if no cached data was found
-			return WPAPI.transport.get( wpreq, cb ).then(function( result ) {
+			return WPAPI.transport.get( wpreq, cb ).then( ( result ) => {
 				cache[ wpreq ] = result;
 				return result;
 			});
@@ -48,7 +48,7 @@ describe( 'integration: custom HTTP transport methods', () => {
 		return WPAPI.site( 'http://wpapi.loc/wp-json' )
 			.posts()
 			.perPage( 1 )
-			.then(function( posts ) {
+			.then( ( posts ) => {
 				id = posts[ 0 ].id;
 
 				// Set up our spy here so the request to get the ID isn't counted
@@ -56,7 +56,7 @@ describe( 'integration: custom HTTP transport methods', () => {
 			});
 	});
 
-	afterEach(function() {
+	afterEach( () => {
 		httpTransport.get.restore();
 	});
 
@@ -74,23 +74,23 @@ describe( 'integration: custom HTTP transport methods', () => {
 		query1 = wp.posts().id( id );
 		var prom = query1
 			.get()
-			.then(function( result ) {
+			.then( ( result ) => {
 				expect( result.id ).to.equal( id );
 				expect( cachingGet.callCount ).to.equal( 1 );
 				expect( httpTransport.get.callCount ).to.equal( 1 );
 				expect( httpTransport.get ).to.have.been.calledWith( query1 );
 				expect( result ).to.equal( cache[ 'http://wpapi.loc/wp-json/wp/v2/posts/' + id ] );
 			})
-			.then(function() {
+			.then( () => {
 				query2 = wp.posts().id( id );
 				return query2.get();
 			})
-			.then(function( result ) {
+			.then( ( result ) => {
 				expect( cachingGet.callCount ).to.equal( 2 );
 				expect( httpTransport.get.callCount ).to.equal( 1 );
 				// sinon will try to use toString when comparing arguments in calledWith,
 				// so we mess with that method to properly demonstrate the inequality
-				query2.toString = function() {};
+				query2.toString = () => {};
 				expect( httpTransport.get ).not.to.have.been.calledWith( query2 );
 				expect( result ).to.equal( cache[ 'http://wpapi.loc/wp-json/wp/v2/posts/' + id ] );
 				return SUCCESS;
@@ -112,7 +112,7 @@ describe( 'integration: custom HTTP transport methods', () => {
 				/* jshint validthis:true */
 				return WPAPI.transport.get.call( this, wpreq, cb );
 			}
-			return WPAPI.transport.get( wpreq ).then(function( results ) {
+			return WPAPI.transport.get( wpreq ).then( ( results ) => {
 				var result = extractSlug( results );
 				if ( cb && typeof cb === 'function' ) {
 					cb( null, result );
@@ -129,7 +129,7 @@ describe( 'integration: custom HTTP transport methods', () => {
 		});
 
 		var prom = wp.posts().slug( 'template-more-tag' )
-			.then(function( results ) {
+			.then( ( results ) => {
 				expect( results ).to.be.an( 'object' );
 				expect( Array.isArray( results ) ).to.equal( false );
 				expect( results.title.rendered ).to.equal( 'Template: More Tag' );
@@ -144,13 +144,11 @@ describe( 'integration: custom HTTP transport methods', () => {
 			this.data = arr;
 		}
 		Collection.prototype.pluck = function( key ) {
-			return this.data.map(function( val ) {
-				return val[ key ];
-			});
+			return this.data.map( ( val ) => val[ key ] );
 		};
 		function addCollectionMethodsGet( wpreq, cb ) {
 			/* jshint validthis:true */
-			return WPAPI.transport.get.call( this, wpreq, cb ).then(function( results ) {
+			return WPAPI.transport.get.call( this, wpreq, cb ).then( ( results ) => {
 				if ( Array.isArray( results ) ) {
 					return new Collection( results );
 				}
@@ -165,7 +163,7 @@ describe( 'integration: custom HTTP transport methods', () => {
 		});
 
 		var prom = wp.posts()
-			.then(function( results ) {
+			.then( ( results ) => {
 				expect( results ).to.be.an.instanceOf( Collection );
 				expect( results.pluck( 'slug' ) ).to.deep.equal([
 					'markup-html-tags-and-formatting',

--- a/tests/integration/custom-http-transport.js
+++ b/tests/integration/custom-http-transport.js
@@ -19,13 +19,13 @@ var httpTransport = require( '../../lib/http-transport' );
 
 var credentials = require( './helpers/constants' ).credentials;
 
-describe( 'integration: custom HTTP transport methods', function() {
+describe( 'integration: custom HTTP transport methods', () => {
 	var wp;
 	var id;
 	var cache;
 	var cachingGet;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		cache = {};
 		cachingGet = sinon.spy(function( wpreq, cb ) {
 			var result = cache[ wpreq ];
@@ -60,7 +60,7 @@ describe( 'integration: custom HTTP transport methods', function() {
 		httpTransport.get.restore();
 	});
 
-	it( 'can be defined to e.g. use a cache when available', function() {
+	it( 'can be defined to e.g. use a cache when available', () => {
 		var query1;
 		var query2;
 
@@ -99,7 +99,7 @@ describe( 'integration: custom HTTP transport methods', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be defined to transform responses', function() {
+	it( 'can be defined to transform responses', () => {
 		function extractSlug( results ) {
 			if ( Array.isArray( results ) && results.length === 1 ) {
 				return results[0];
@@ -139,7 +139,7 @@ describe( 'integration: custom HTTP transport methods', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be defined to augment responses', function() {
+	it( 'can be defined to augment responses', () => {
 		function Collection( arr ) {
 			this.data = arr;
 		}

--- a/tests/integration/error-states.js
+++ b/tests/integration/error-states.js
@@ -16,7 +16,7 @@ describe( 'error states:', () => {
 		var wp = WPAPI.site( 'http://wpapi.loc/wrong-root-endpoint' );
 		var prom = wp.posts()
 			.get()
-			.catch(function( err ) {
+			.catch( ( err ) => {
 				expect( err ).to.be.an.instanceOf( Error );
 				expect( err ).to.have.property( 'status' );
 				expect( err.status ).to.equal( 404 );

--- a/tests/integration/error-states.js
+++ b/tests/integration/error-states.js
@@ -10,9 +10,9 @@ var expect = chai.expect;
 
 var WPAPI = require( '../../' );
 
-describe( 'error states:', function() {
+describe( 'error states:', () => {
 
-	it( 'invalid root endpoint causes a transport-level (superagent) 404 error', function() {
+	it( 'invalid root endpoint causes a transport-level (superagent) 404 error', () => {
 		var wp = WPAPI.site( 'http://wpapi.loc/wrong-root-endpoint' );
 		var prom = wp.posts()
 			.get()

--- a/tests/integration/media.js
+++ b/tests/integration/media.js
@@ -64,11 +64,11 @@ var expectedResults = {
 	}
 };
 
-describe( 'integration: media()', function() {
+describe( 'integration: media()', () => {
 	var wp;
 	var authenticated;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
@@ -77,7 +77,7 @@ describe( 'integration: media()', function() {
 		}).auth( credentials );
 	});
 
-	it( 'an be used to retrieve a list of media items', function() {
+	it( 'an be used to retrieve a list of media items', () => {
 		var prom = wp.media()
 			.get()
 			.then(function( media ) {
@@ -88,7 +88,7 @@ describe( 'integration: media()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'fetches the 10 most recent media by default', function() {
+	it( 'fetches the 10 most recent media by default', () => {
 		var prom = wp.media()
 			.get()
 			.then(function( media ) {
@@ -98,9 +98,9 @@ describe( 'integration: media()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	describe( 'paging properties', function() {
+	describe( 'paging properties', () => {
 
-		it( 'are exposed as _paging on the response array', function() {
+		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.media()
 				.get()
 				.then(function( media ) {
@@ -111,7 +111,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of media: use .headers() for coverage reasons', function() {
+		it( 'include the total number of media: use .headers() for coverage reasons', () => {
 			var prom = wp.media()
 				.headers()
 				.then(function( postHeadersResponse ) {
@@ -122,7 +122,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of pages available', function() {
+		it( 'include the total number of pages available', () => {
 			var prom = wp.media()
 				.get()
 				.then(function( media ) {
@@ -133,7 +133,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the next page as .next', function() {
+		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.media()
 				.get()
 				.then(function( media ) {
@@ -155,7 +155,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the next page of results via .next', function() {
+		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.media()
 				.get()
 				.then(function( media ) {
@@ -171,7 +171,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the previous page as .prev', function() {
+		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.media()
 				.get()
 				.then(function( media ) {
@@ -190,7 +190,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the previous page of results via .prev', function() {
+		it( 'allows access to the previous page of results via .prev', () => {
 			var prom = wp.media()
 				.page( 2 )
 				.get()
@@ -210,9 +210,9 @@ describe( 'integration: media()', function() {
 
 	});
 
-	describe( 'without authentication', function() {
+	describe( 'without authentication', () => {
 
-		it( 'cannot POST', function() {
+		it( 'cannot POST', () => {
 			var prom = wp.media()
 				.file( filePath )
 				.create({
@@ -230,7 +230,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'cannot PUT', function() {
+		it( 'cannot PUT', () => {
 			var prom = wp.media()
 				.perPage( 1 )
 				.get()
@@ -253,7 +253,7 @@ describe( 'integration: media()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'cannot DELETE', function() {
+		it( 'cannot DELETE', () => {
 			var prom = wp.media()
 				.perPage( 1 )
 				.get()
@@ -276,7 +276,7 @@ describe( 'integration: media()', function() {
 
 	});
 
-	it( 'can create, update & delete media when authenticated', function() {
+	it( 'can create, update & delete media when authenticated', () => {
 		var id;
 		var imageUrl;
 

--- a/tests/integration/media.js
+++ b/tests/integration/media.js
@@ -80,7 +80,7 @@ describe( 'integration: media()', () => {
 	it( 'an be used to retrieve a list of media items', () => {
 		var prom = wp.media()
 			.get()
-			.then(function( media ) {
+			.then( ( media ) => {
 				expect( media ).to.be.an( 'array' );
 				expect( media.length ).to.equal( 10 );
 				return SUCCESS;
@@ -91,7 +91,7 @@ describe( 'integration: media()', () => {
 	it( 'fetches the 10 most recent media by default', () => {
 		var prom = wp.media()
 			.get()
-			.then(function( media ) {
+			.then( ( media ) => {
 				expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page1 );
 				return SUCCESS;
 			});
@@ -103,7 +103,7 @@ describe( 'integration: media()', () => {
 		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.media()
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					expect( media ).to.have.property( '_paging' );
 					expect( media._paging ).to.be.an( 'object' );
 					return SUCCESS;
@@ -114,7 +114,7 @@ describe( 'integration: media()', () => {
 		it( 'include the total number of media: use .headers() for coverage reasons', () => {
 			var prom = wp.media()
 				.headers()
-				.then(function( postHeadersResponse ) {
+				.then( ( postHeadersResponse ) => {
 					expect( postHeadersResponse ).to.have.property( 'x-wp-total' );
 					expect( postHeadersResponse[ 'x-wp-total' ] ).to.equal( '38' );
 					return SUCCESS;
@@ -125,7 +125,7 @@ describe( 'integration: media()', () => {
 		it( 'include the total number of pages available', () => {
 			var prom = wp.media()
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					expect( media._paging ).to.have.property( 'totalPages' );
 					expect( media._paging.totalPages ).to.equal( '4' );
 					return SUCCESS;
@@ -136,7 +136,7 @@ describe( 'integration: media()', () => {
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.media()
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					expect( media._paging ).to.have.property( 'next' );
 					expect( media._paging.next ).to.be.an( 'object' );
 					expect( media._paging.next ).to.be.an.instanceOf( WPRequest );
@@ -146,7 +146,7 @@ describe( 'integration: media()', () => {
 					return wp.media()
 						.page( media._paging.totalPages )
 						.get()
-						.then(function( media ) {
+						.then( ( media ) => {
 							expect( media._paging ).not.to.have.property( 'next' );
 							expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page4 );
 							return SUCCESS;
@@ -158,10 +158,10 @@ describe( 'integration: media()', () => {
 		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.media()
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					return media._paging.next
 						.get()
-						.then(function( media ) {
+						.then( ( media ) => {
 							expect( media ).to.be.an( 'array' );
 							expect( media.length ).to.equal( 10 );
 							expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page2 );
@@ -174,11 +174,11 @@ describe( 'integration: media()', () => {
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.media()
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					expect( media._paging ).not.to.have.property( 'prev' );
 					return media._paging.next
 						.get()
-						.then(function( media ) {
+						.then( ( media ) => {
 							expect( media._paging ).to.have.property( 'prev' );
 							expect( media._paging.prev ).to.be.an( 'object' );
 							expect( media._paging.prev ).to.be.an.instanceOf( WPRequest );
@@ -194,11 +194,11 @@ describe( 'integration: media()', () => {
 			var prom = wp.media()
 				.page( 2 )
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page2 );
 					return media._paging.prev
 						.get()
-						.then(function( media ) {
+						.then( ( media ) => {
 							expect( media ).to.be.an( 'array' );
 							expect( media.length ).to.equal( 10 );
 							expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page1 );
@@ -219,7 +219,7 @@ describe( 'integration: media()', () => {
 					title: 'Media File',
 					content: 'Some Content'
 				})
-				.catch(function( err ) {
+				.catch( ( err ) => {
 					httpTestUtils.rethrowIfChaiError( err );
 					expect( err.code ).to.equal( 'rest_cannot_create' );
 					expect( err.data ).to.deep.equal({
@@ -234,7 +234,7 @@ describe( 'integration: media()', () => {
 			var prom = wp.media()
 				.perPage( 1 )
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					var id = media[ 0 ].id;
 					return wp.media()
 						.id( id )
@@ -242,7 +242,7 @@ describe( 'integration: media()', () => {
 							title: 'New Title'
 						});
 				})
-				.catch(function( err ) {
+				.catch( ( err ) => {
 					httpTestUtils.rethrowIfChaiError( err );
 					expect( err.code ).to.equal( 'rest_cannot_edit' );
 					expect( err.data ).to.deep.equal({
@@ -257,13 +257,13 @@ describe( 'integration: media()', () => {
 			var prom = wp.media()
 				.perPage( 1 )
 				.get()
-				.then(function( media ) {
+				.then( ( media ) => {
 					var id = media[ 0 ].id;
 					return wp.media().id( id ).delete({
 						force: true
 					});
 				})
-				.catch(function( err ) {
+				.catch( ( err ) => {
 					httpTestUtils.rethrowIfChaiError( err );
 					expect( err.code ).to.equal( 'rest_cannot_delete' );
 					expect( err.data ).to.deep.equal({
@@ -287,7 +287,7 @@ describe( 'integration: media()', () => {
 				title: 'Untitled',
 				caption: 'A painting from Emily Garfield\'s "Conduits" series'
 			})
-			.then(function( createdMedia ) {
+			.then( ( createdMedia ) => {
 				id = createdMedia.id;
 				imageUrl = createdMedia.source_url;
 				expect( createdMedia.title.rendered ).to.equal( 'Untitled' );
@@ -297,15 +297,14 @@ describe( 'integration: media()', () => {
 				expect( imageUrl ).to.match( /^http:\/\/wpapi.loc\/content\/uploads\/.*\/ehg-conduits.jpg$/ );
 			})
 			// UPDATE
-			.then(function() {
-				return authenticated.media()
-					.id( id )
-					.update({
-						title: 'Conduits Series',
-						alt_text: 'A photograph of an abstract painting by Emily Garfield'
-					});
-			})
-			.then(function( result ) {
+			.then( () => authenticated.media()
+				.id( id )
+				.update({
+					title: 'Conduits Series',
+					alt_text: 'A photograph of an abstract painting by Emily Garfield'
+				})
+			)
+			.then( ( result ) => {
 				expect( result.id ).to.equal( id );
 				expect( result.title.rendered ).to.equal( 'Conduits Series' );
 				expect( result.alt_text ).to.equal( 'A photograph of an abstract painting by Emily Garfield' );
@@ -313,32 +312,29 @@ describe( 'integration: media()', () => {
 			})
 			// READ
 			// Validate thumbnails were created
-			.then(function( result ) {
+			.then( ( result ) => {
 				var sizes = result.media_details.sizes;
-				var sizeURLs = objectReduce( sizes, function( urls, size ) {
-					return urls.concat( size.source_url );
-				}, [] );
+				var sizeURLs = objectReduce( sizes, ( urls, size ) => urls.concat( size.source_url ), [] );
+
 				// Expect all sizes to have different URLs
 				expect( Object.keys( sizes ).length ).to.equal( _unique( sizeURLs ).length );
-				return sizeURLs.reduce(function( previous, sizeURL ) {
-					return previous.then(function() {
-						return httpTestUtils.expectStatusCode( sizeURL, 200 );
-					});
-				}, Promise.resolve() );
+				return sizeURLs.reduce( ( previous, sizeURL ) => previous.then( () => (
+					httpTestUtils.expectStatusCode( sizeURL, 200 )
+				) ), Promise.resolve() );
 			})
 			// Validate image was uploaded correctly
-			.then(function() {
+			.then( () => {
 				return httpTestUtils.expectFileEqualsURL( filePath, imageUrl );
 			})
 			// DELETE
-			.then(function() {
+			.then( () => {
 				// Attempt to delete media: expect this to fail, since media does not
 				// support being trashed and can only be permanently removed
 				return authenticated.media()
 					.id( id )
 					.delete();
 			})
-			.catch(function( error ) {
+			.catch( ( error ) => {
 				httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).to.equal( 'rest_trash_not_supported' );
 				expect( error.data ).to.deep.equal({
@@ -351,7 +347,7 @@ describe( 'integration: media()', () => {
 						force: true
 					});
 			})
-			.then(function( response ) {
+			.then( ( response ) => {
 				expect( response ).to.be.an( 'object' );
 				// DELETE action returns the media object as the .previous property
 				expect( response.previous ).to.be.an( 'object' );
@@ -359,7 +355,7 @@ describe( 'integration: media()', () => {
 				// Query for the media: expect this to fail, since it has been deleted
 				return wp.media().id( id );
 			})
-			.catch(function( error ) {
+			.catch( ( error ) => {
 				httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).to.equal( 'rest_post_invalid_id' );
 				expect( error.data ).to.deep.equal({
@@ -367,10 +363,10 @@ describe( 'integration: media()', () => {
 				});
 			})
 			// Validate image file has been removed
-			.then(function() {
+			.then( () => {
 				return httpTestUtils.expectStatusCode( imageUrl, 404 );
 			})
-			.then(function() {
+			.then( () => {
 				return SUCCESS;
 			});
 		return expect( prom ).to.eventually.equal( SUCCESS );

--- a/tests/integration/pages.js
+++ b/tests/integration/pages.js
@@ -44,16 +44,16 @@ var expectedResults = {
 	}
 };
 
-describe( 'integration: pages()', function() {
+describe( 'integration: pages()', () => {
 	var wp;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
 	});
 
-	it( 'can be used to retrieve a list of recent pages', function() {
+	it( 'can be used to retrieve a list of recent pages', () => {
 		var prom = wp.pages()
 			.get()
 			.then(function( pages ) {
@@ -64,7 +64,7 @@ describe( 'integration: pages()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'fetches the 10 most recent pages by default', function() {
+	it( 'fetches the 10 most recent pages by default', () => {
 		var prom = wp.pages()
 			.get()
 			.then(function( pages ) {
@@ -74,9 +74,9 @@ describe( 'integration: pages()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	describe( 'paging properties', function() {
+	describe( 'paging properties', () => {
 
-		it( 'are exposed as _paging on the response array', function() {
+		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.pages()
 				.get()
 				.then(function( pages ) {
@@ -87,7 +87,7 @@ describe( 'integration: pages()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of pages', function() {
+		it( 'include the total number of pages', () => {
 			var prom = wp.pages()
 				.get()
 				.then(function( pages ) {
@@ -98,7 +98,7 @@ describe( 'integration: pages()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of pages available', function() {
+		it( 'include the total number of pages available', () => {
 			var prom = wp.pages()
 				.get()
 				.then(function( pages ) {
@@ -109,7 +109,7 @@ describe( 'integration: pages()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the next page as .next', function() {
+		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.pages()
 				.get()
 				.then(function( pages ) {
@@ -131,7 +131,7 @@ describe( 'integration: pages()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the next page of results via .next', function() {
+		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.pages()
 				.get()
 				.then(function( pages ) {
@@ -147,7 +147,7 @@ describe( 'integration: pages()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the previous page as .prev', function() {
+		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.pages()
 				.get()
 				.then(function( pages ) {
@@ -166,7 +166,7 @@ describe( 'integration: pages()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the previous page of results via .prev', function() {
+		it( 'allows access to the previous page of results via .prev', () => {
 			var prom = wp.pages()
 				.page( 2 )
 				.get()
@@ -186,11 +186,11 @@ describe( 'integration: pages()', function() {
 
 	});
 
-	describe( 'filter methods', function() {
+	describe( 'filter methods', () => {
 
-		describe( 'slug', function() {
+		describe( 'slug', () => {
 
-			it( 'can be used to return only pages with the specified slug', function() {
+			it( 'can be used to return only pages with the specified slug', () => {
 				var prom = wp.pages()
 					.slug( 'clearing-floats' )
 					.get()

--- a/tests/integration/pages.js
+++ b/tests/integration/pages.js
@@ -56,7 +56,7 @@ describe( 'integration: pages()', () => {
 	it( 'can be used to retrieve a list of recent pages', () => {
 		var prom = wp.pages()
 			.get()
-			.then(function( pages ) {
+			.then( ( pages ) => {
 				expect( pages ).to.be.an( 'array' );
 				expect( pages.length ).to.equal( 10 );
 				return SUCCESS;
@@ -67,7 +67,7 @@ describe( 'integration: pages()', () => {
 	it( 'fetches the 10 most recent pages by default', () => {
 		var prom = wp.pages()
 			.get()
-			.then(function( pages ) {
+			.then( ( pages ) => {
 				expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page1 );
 				return SUCCESS;
 			});
@@ -79,7 +79,7 @@ describe( 'integration: pages()', () => {
 		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.pages()
 				.get()
-				.then(function( pages ) {
+				.then( ( pages ) => {
 					expect( pages ).to.have.property( '_paging' );
 					expect( pages._paging ).to.be.an( 'object' );
 					return SUCCESS;
@@ -90,7 +90,7 @@ describe( 'integration: pages()', () => {
 		it( 'include the total number of pages', () => {
 			var prom = wp.pages()
 				.get()
-				.then(function( pages ) {
+				.then( ( pages ) => {
 					expect( pages._paging ).to.have.property( 'total' );
 					expect( pages._paging.total ).to.equal( '18' );
 					return SUCCESS;
@@ -101,7 +101,7 @@ describe( 'integration: pages()', () => {
 		it( 'include the total number of pages available', () => {
 			var prom = wp.pages()
 				.get()
-				.then(function( pages ) {
+				.then( ( pages ) => {
 					expect( pages._paging ).to.have.property( 'totalPages' );
 					expect( pages._paging.totalPages ).to.equal( '2' );
 					return SUCCESS;
@@ -112,7 +112,7 @@ describe( 'integration: pages()', () => {
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.pages()
 				.get()
-				.then(function( pages ) {
+				.then( ( pages ) => {
 					expect( pages._paging ).to.have.property( 'next' );
 					expect( pages._paging.next ).to.be.an( 'object' );
 					expect( pages._paging.next ).to.be.an.instanceOf( WPRequest );
@@ -122,7 +122,7 @@ describe( 'integration: pages()', () => {
 					return wp.pages()
 						.page( pages._paging.totalPages )
 						.get()
-						.then(function( pages ) {
+						.then( ( pages ) => {
 							expect( pages._paging ).not.to.have.property( 'next' );
 							expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page2 );
 							return SUCCESS;
@@ -134,15 +134,12 @@ describe( 'integration: pages()', () => {
 		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.pages()
 				.get()
-				.then(function( pages ) {
-					return pages._paging.next
-						.get()
-						.then(function( pages ) {
-							expect( pages ).to.be.an( 'array' );
-							expect( pages.length ).to.equal( 8 );
-							expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page2 );
-							return SUCCESS;
-						});
+				.then( ( pages ) => pages._paging.next.get() )
+				.then( ( pages ) => {
+					expect( pages ).to.be.an( 'array' );
+					expect( pages.length ).to.equal( 8 );
+					expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page2 );
+					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
@@ -150,18 +147,17 @@ describe( 'integration: pages()', () => {
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.pages()
 				.get()
-				.then(function( pages ) {
+				.then( ( pages ) => {
 					expect( pages._paging ).not.to.have.property( 'prev' );
-					return pages._paging.next
-						.get()
-						.then(function( pages ) {
-							expect( pages._paging ).to.have.property( 'prev' );
-							expect( pages._paging.prev ).to.be.an( 'object' );
-							expect( pages._paging.prev ).to.be.an.instanceOf( WPRequest );
-							expect( pages._paging.prev._options.endpoint ).to
-								.equal( 'http://wpapi.loc/wp-json/wp/v2/pages?page=1' );
-							return SUCCESS;
-						});
+					return pages._paging.next.get();
+				})
+				.then( ( pages ) => {
+					expect( pages._paging ).to.have.property( 'prev' );
+					expect( pages._paging.prev ).to.be.an( 'object' );
+					expect( pages._paging.prev ).to.be.an.instanceOf( WPRequest );
+					expect( pages._paging.prev._options.endpoint ).to
+						.equal( 'http://wpapi.loc/wp-json/wp/v2/pages?page=1' );
+					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
@@ -170,16 +166,15 @@ describe( 'integration: pages()', () => {
 			var prom = wp.pages()
 				.page( 2 )
 				.get()
-				.then(function( pages ) {
+				.then( ( pages ) => {
 					expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page2 );
-					return pages._paging.prev
-						.get()
-						.then(function( pages ) {
-							expect( pages ).to.be.an( 'array' );
-							expect( pages.length ).to.equal( 10 );
-							expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page1 );
-							return SUCCESS;
-						});
+					return pages._paging.prev.get();
+				})
+				.then( ( pages ) => {
+					expect( pages ).to.be.an( 'array' );
+					expect( pages.length ).to.equal( 10 );
+					expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page1 );
+					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
@@ -194,7 +189,7 @@ describe( 'integration: pages()', () => {
 				var prom = wp.pages()
 					.slug( 'clearing-floats' )
 					.get()
-					.then(function( pages ) {
+					.then( ( pages ) => {
 						expect( pages.length ).to.equal( 1 );
 						expect( getTitles( pages ) ).to.deep.equal([
 							'Clearing Floats'

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -78,7 +78,7 @@ describe( 'integration: posts()', () => {
 	it( 'can be used to retrieve a list of recent posts', () => {
 		var prom = wp.posts()
 			.get()
-			.then(function( posts ) {
+			.then( ( posts ) => {
 				expect( posts ).to.be.an( 'array' );
 				expect( posts.length ).to.equal( 10 );
 				return SUCCESS;
@@ -89,7 +89,7 @@ describe( 'integration: posts()', () => {
 	it( 'fetches the 10 most recent posts by default', () => {
 		var prom = wp.posts()
 			.get()
-			.then(function( posts ) {
+			.then( ( posts ) => {
 				expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1 );
 				return SUCCESS;
 			});
@@ -100,7 +100,7 @@ describe( 'integration: posts()', () => {
 		var prom = wp.posts()
 			.param( '_wpapi_force_html', true )
 			.get()
-			.then(function( posts ) {
+			.then( ( posts ) => {
 				expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1 );
 				return SUCCESS;
 			});
@@ -112,7 +112,7 @@ describe( 'integration: posts()', () => {
 		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.posts()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts ).to.have.property( '_paging' );
 					expect( posts._paging ).to.be.an( 'object' );
 					return SUCCESS;
@@ -124,7 +124,7 @@ describe( 'integration: posts()', () => {
 			var prom = wp.posts()
 				.param( '_wpapi_force_html', true )
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts ).to.have.property( '_paging' );
 					expect( posts._paging ).to.be.an( 'object' );
 					return SUCCESS;
@@ -135,7 +135,7 @@ describe( 'integration: posts()', () => {
 		it( 'include the total number of posts: use .headers() for coverage reasons', () => {
 			var prom = wp.posts()
 				.headers()
-				.then(function( postHeadersResponse ) {
+				.then( ( postHeadersResponse ) => {
 					expect( postHeadersResponse ).to.have.property( 'x-wp-total' );
 					expect( postHeadersResponse[ 'x-wp-total' ] ).to.equal( '38' );
 					return SUCCESS;
@@ -146,7 +146,7 @@ describe( 'integration: posts()', () => {
 		it( 'include the total number of pages available', () => {
 			var prom = wp.posts()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts._paging ).to.have.property( 'totalPages' );
 					expect( posts._paging.totalPages ).to.equal( '4' );
 					return SUCCESS;
@@ -157,7 +157,7 @@ describe( 'integration: posts()', () => {
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.posts()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts._paging ).to.have.property( 'next' );
 					expect( posts._paging.next ).to.be.an( 'object' );
 					expect( posts._paging.next ).to.be.an.instanceOf( WPRequest );
@@ -167,7 +167,7 @@ describe( 'integration: posts()', () => {
 					return wp.posts()
 						.page( posts._paging.totalPages )
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts._paging ).not.to.have.property( 'next' );
 							expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page4 );
 							return SUCCESS;
@@ -179,10 +179,10 @@ describe( 'integration: posts()', () => {
 		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.posts()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					return posts._paging.next
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts ).to.be.an( 'array' );
 							// @TODO: re-enable once PPP support is merged
 							// expect( posts.length ).to.equal( 10 );
@@ -197,10 +197,10 @@ describe( 'integration: posts()', () => {
 			var prom = wp.posts()
 				.param( '_wpapi_force_html', true )
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					return posts._paging.next
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts ).to.be.an( 'array' );
 							return SUCCESS;
 						});
@@ -211,11 +211,11 @@ describe( 'integration: posts()', () => {
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.posts()
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					expect( posts._paging ).not.to.have.property( 'prev' );
 					return posts._paging.next
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts._paging ).to.have.property( 'prev' );
 							expect( posts._paging.prev ).to.be.an( 'object' );
 							expect( posts._paging.prev ).to.be.an.instanceOf( WPRequest );
@@ -231,12 +231,12 @@ describe( 'integration: posts()', () => {
 			var prom = wp.posts()
 				.page( 2 )
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					// @TODO: re-enable once PPP support is merged
 					// expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page2 );
 					return posts._paging.prev
 						.get()
-						.then(function( posts ) {
+						.then( ( posts ) => {
 							expect( posts ).to.be.an( 'array' );
 							expect( posts.length ).to.equal( 10 );
 							expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1 );
@@ -250,10 +250,10 @@ describe( 'integration: posts()', () => {
 			var prom = authenticated.posts()
 				.context( 'edit' )
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					return posts._paging.next.get();
 				})
-				.then(function( page2 ) {
+				.then( ( page2 ) => {
 					expect( page2[0].content ).to.have.property( 'raw' );
 					return SUCCESS;
 				});
@@ -270,7 +270,7 @@ describe( 'integration: posts()', () => {
 				var prom = wp.posts()
 					.slug( 'template-excerpt-generated' )
 					.get()
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( posts.length ).to.equal( 1 );
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Template: Excerpt (Generated)'
@@ -288,7 +288,7 @@ describe( 'integration: posts()', () => {
 				var prom = authenticated.posts()
 					.status([ 'future', 'draft' ])
 					.get()
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Scheduled',
 							'Draft'
@@ -306,13 +306,11 @@ describe( 'integration: posts()', () => {
 				var prom = wp.tags()
 					.slug( 'title' )
 					.get()
-					.then(function( tags ) {
-						var tagIDs = tags.map(function( tag ) {
-							return tag.id;
-						});
+					.then( ( tags ) => {
+						var tagIDs = tags.map( ( tag ) => tag.id );
 						return wp.posts().tags( tagIDs );
 					})
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( posts.length ).to.equal( 5 );
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Markup: Title With Special Characters',
@@ -332,15 +330,13 @@ describe( 'integration: posts()', () => {
 						wp.tags().search( 'featured image' ),
 						wp.tags().search( 'embeds' )
 					])
-					.then(function( results ) {
-						var tagIDs = results.reduce(function( ids, arr ) {
-							return ids.concat( arr.map(function( tag ) {
-								return tag.id;
-							}) );
-						}, [] );
+					.then( ( results ) => {
+						var tagIDs = results.reduce( ( ids, arr ) => (
+							ids.concat( arr.map( ( tag ) => tag.id ) )
+						), [] );
 						return wp.posts().tags( tagIDs );
 					})
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( posts.length ).to.equal( 6 );
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Template: Featured Image (Vertical)',
@@ -365,15 +361,13 @@ describe( 'integration: posts()', () => {
 						wp.tags().search( 'css' ),
 						wp.tags().search( 'content' )
 					])
-					.then(function( results ) {
-						var tagIDs = results.reduce(function( ids, arr ) {
-							return ids.concat( arr.map(function( tag ) {
-								return tag.id;
-							}) );
-						}, [] );
+					.then( ( results ) => {
+						var tagIDs = results.reduce( ( ids, arr ) => (
+							ids.concat( arr.map( ( tag ) => tag.id ) )
+						), [] );
 						return wp.posts().excludeTags( tagIDs );
 					})
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Markup: Title With Special Characters',
 							'Template: Featured Image (Vertical)',
@@ -399,13 +393,11 @@ describe( 'integration: posts()', () => {
 				var prom = wp.categories()
 					.slug( 'markup' )
 					.get()
-					.then(function( categories ) {
-						var categoryIDs = categories.map(function( cat ) {
-							return cat.id;
-						});
+					.then( ( categories ) => {
+						var categoryIDs = categories.map( ( cat ) => cat.id );
 						return wp.posts().categories( categoryIDs );
 					})
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( posts.length ).to.equal( 6 );
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Markup: HTML Tags and Formatting',
@@ -426,15 +418,13 @@ describe( 'integration: posts()', () => {
 						wp.categories().search( 'edge case' ),
 						wp.categories().search( 'pustule' )
 					])
-					.then(function( results ) {
-						var categoriesIDs = results.reduce(function( ids, arr ) {
-							return ids.concat( arr.map(function( cat ) {
-								return cat.id;
-							}) );
-						}, [] );
+					.then( ( results ) => {
+						var categoriesIDs = results.reduce( ( ids, arr ) => (
+							ids.concat( arr.map( ( cat ) => cat.id ) )
+						), [] );
 						return wp.posts().categories( categoriesIDs );
 					})
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( posts.length ).to.equal( 6 );
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Antidisestablishmentarianism',
@@ -459,15 +449,13 @@ describe( 'integration: posts()', () => {
 						wp.categories().slug( 'markup' ),
 						wp.categories().slug( 'post-formats' )
 					])
-					.then(function( results ) {
-						var tagIDs = results.reduce(function( ids, arr ) {
-							return ids.concat( arr.map(function( tag ) {
-								return tag.id;
-							}) );
-						}, [] );
+					.then( ( results ) => {
+						var tagIDs = results.reduce( ( ids, arr ) => (
+							ids.concat( arr.map( ( tag ) => tag.id ) )
+						), [] );
 						return wp.posts().excludeCategories( tagIDs );
 					})
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( getTitles( posts ) ).to.deep.equal([
 							'Template: Featured Image (Vertical)',
 							'Template: Featured Image (Horizontal)',
@@ -492,7 +480,7 @@ describe( 'integration: posts()', () => {
 			it( 'can be used to return only posts from before a certain date', () => {
 				var prom = wp.posts()
 					.before( '2013-01-08' )
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( posts[0].title.rendered ).to.equal( 'Markup: Title With Special Characters' );
 						return SUCCESS;
 					});
@@ -506,7 +494,7 @@ describe( 'integration: posts()', () => {
 			it( 'can be used to return only posts from after a certain date', () => {
 				var prom = wp.posts()
 					.after( '2013-01-08' )
-					.then(function( posts ) {
+					.then( ( posts ) => {
 						expect( posts.length ).to.equal( 3 );
 						expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page1.slice( 0, 3 ) );
 						return SUCCESS;
@@ -525,7 +513,7 @@ describe( 'integration: posts()', () => {
 			var prom = wp.posts()
 				.edit()
 				.get()
-				.catch(function( err ) {
+				.catch( ( err ) => {
 					expect( err.code ).to.equal( 'rest_forbidden_context' );
 					expect( err.data ).to.deep.equal({
 						status: 401
@@ -540,13 +528,13 @@ describe( 'integration: posts()', () => {
 			var prom = wp.posts()
 				.perPage( 1 )
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					id = posts[ 0 ].id;
 					return wp.posts()
 						.id( id )
 						.delete();
 				})
-				.catch(function( err ) {
+				.catch( ( err ) => {
 					expect( err.code ).to.equal( 'rest_cannot_delete' );
 					expect( err.data ).to.deep.equal({
 						status: 401
@@ -556,7 +544,7 @@ describe( 'integration: posts()', () => {
 						.id( id )
 						.get();
 				})
-				.then(function( result ) {
+				.then( ( result ) => {
 					expect( result ).to.have.property( 'id' );
 					expect( result.id ).to.equal( id );
 					return SUCCESS;
@@ -565,11 +553,11 @@ describe( 'integration: posts()', () => {
 		});
 
 		it( 'cannot create (POST) without authentication (also tests callback-mode errors)', () => {
-			var prom = new Promise(function( resolve, reject ) {
+			var prom = new Promise( ( resolve, reject ) => {
 				wp.posts().create({
 					title: 'New Post 2501',
 					content: 'Some Content'
-				}, function( err ) {
+				}, ( err ) => {
 					if ( ! err ) {
 						reject();
 					}
@@ -588,7 +576,7 @@ describe( 'integration: posts()', () => {
 			var prom = wp.posts()
 				.perPage( 1 )
 				.get()
-				.then(function( posts ) {
+				.then( ( posts ) => {
 					id = posts[ 0 ].id;
 					return wp.posts()
 						.id( id )
@@ -597,7 +585,7 @@ describe( 'integration: posts()', () => {
 							content: 'Some Content'
 						});
 				})
-				.catch(function( err ) {
+				.catch( ( err ) => {
 					expect( err.code ).to.equal( 'rest_cannot_edit' );
 					expect( err.data ).to.deep.equal({
 						status: 401
@@ -615,7 +603,7 @@ describe( 'integration: posts()', () => {
 				title: 'New Post 2501',
 				content: 'Some Content'
 			})
-			.then(function( createdPost ) {
+			.then( ( createdPost ) => {
 				id = createdPost.id;
 				expect( createdPost ).to.be.an( 'object' );
 				expect( createdPost ).to.have.property( 'status' );
@@ -633,7 +621,7 @@ describe( 'integration: posts()', () => {
 						status: 'publish'
 					});
 			})
-			.then(function( updatedPost ) {
+			.then( ( updatedPost ) => {
 				expect( updatedPost ).to.be.an( 'object' );
 				expect( updatedPost ).to.have.property( 'id' );
 				expect( updatedPost.id ).to.equal( id );
@@ -649,7 +637,7 @@ describe( 'integration: posts()', () => {
 				// without authentication
 				return wp.posts().id( id );
 			})
-			.then(function( post ) {
+			.then( ( post ) => {
 				expect( post ).to.be.an( 'object' );
 				expect( post ).to.have.property( 'id' );
 				expect( post.id ).to.equal( id );
@@ -658,8 +646,8 @@ describe( 'integration: posts()', () => {
 				expect( post.title.rendered ).to.equal( 'Updated Title' );
 				// Re-authenticate & delete (trash) this post
 				// Use a callback to exercise that part of the functionality
-				return new Promise(function( resolve, reject ) {
-					authenticated.posts().id( id ).delete(function( err, data ) {
+				return new Promise( ( resolve, reject ) => {
+					authenticated.posts().id( id ).delete( ( err, data ) => {
 						if ( err ) {
 							return reject( err );
 						}
@@ -667,7 +655,7 @@ describe( 'integration: posts()', () => {
 					});
 				});
 			})
-			.then(function( response ) {
+			.then( ( response ) => {
 				expect( response ).to.be.an( 'object' );
 				// DELETE action returns the post object
 				expect( response.id ).to.equal( id );
@@ -675,7 +663,7 @@ describe( 'integration: posts()', () => {
 				// the unauthenticated user does not have permissions to see it
 				return wp.posts().id( id );
 			})
-			.catch(function( error ) {
+			.catch( ( error ) => {
 				httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).to.equal( 'rest_forbidden' );
 				expect( error.data ).to.deep.equal({
@@ -688,7 +676,7 @@ describe( 'integration: posts()', () => {
 						force: true
 					});
 			})
-			.then(function( response ) {
+			.then( ( response ) => {
 				expect( response ).to.be.an( 'object' );
 				// DELETE action returns the fully-deleted post object as .previous
 				expect( response.previous ).to.be.an( 'object' );
@@ -697,7 +685,7 @@ describe( 'integration: posts()', () => {
 				// just trashed but now deleted permanently
 				return authenticated.posts().id( id );
 			})
-			.catch(function( error ) {
+			.catch( ( error ) => {
 				httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).to.equal( 'rest_post_invalid_id' );
 				expect( error.data ).to.deep.equal({
@@ -713,16 +701,15 @@ describe( 'integration: posts()', () => {
 		var mediaId;
 		var filePath = path.join( __dirname, 'assets/emilygarfield-untitled.jpg' );
 		// Helper function
-		function ascById( a, b ) {
-			return a.id - b.id;
-		}
+		const ascById = ( a, b ) => a.id - b.id;
+
 		var categories = [];
 		var tags = [];
 		var tagsAndPromises = Promise.all([
 			wp.categories().get(),
 			wp.tags().get()
 		])
-			.then(function( results ) {
+			.then( ( results ) => {
 				// Array to Object
 				return {
 					categories: results[ 0 ],
@@ -730,7 +717,7 @@ describe( 'integration: posts()', () => {
 				};
 			});
 		var prom = tagsAndPromises
-			.then(function( results ) {
+			.then( ( results ) => {
 				// Pick two tags and a category to assign to our new post
 				tags.push( results.tags[ 1 ], results.tags[ 4 ] );
 				categories.push( results.categories[ 3 ] );
@@ -743,11 +730,11 @@ describe( 'integration: posts()', () => {
 						title: 'New Post with Tags & Categories',
 						content: 'This post has a featured image, too',
 						status: 'publish',
-						categories: categories.map(function( cat ) { return cat.id; }),
-						tags: tags.map(function( tag ) { return tag.id; })
+						categories: categories.map( ( cat ) => cat.id ),
+						tags: tags.map( ( tag ) => tag.id )
 					});
 			})
-			.then(function( newPost ) {
+			.then( ( newPost ) => {
 				id = newPost.id;
 				// Now, upload the media we want to feature and associate with the new post
 				return authenticated.media()
@@ -756,7 +743,7 @@ describe( 'integration: posts()', () => {
 						post: id
 					});
 			})
-			.then(function( media ) {
+			.then( ( media ) => {
 				mediaId = media.id;
 				// Assign the post the associated featured media
 				return authenticated.posts()
@@ -765,14 +752,14 @@ describe( 'integration: posts()', () => {
 						featured_media: mediaId
 					});
 			})
-			.then(function() {
+			.then( () => {
 				// Re-fetch the post with embedded content to validate all is set correctly
 				return wp.posts()
 					.id( id )
 					.embed()
 					.get();
 			})
-			.then(function( post ) {
+			.then( ( post ) => {
 				// Assert that the post got formed correctly
 				// Validate featured image
 				expect( post._embedded ).to.have.property( 'wp:featuredmedia' );
@@ -786,21 +773,23 @@ describe( 'integration: posts()', () => {
 				var terms = post._embedded[ 'wp:term' ];
 				expect( terms.length ).to.equal( 2 );
 				// Validate all categories are present and accounted for
-				terms.filter(function( collection ) {
-					return collection[ 0 ].taxonomy === 'category';
-				})[ 0 ].sort( ascById ).forEach(function( cat, idx ) {
-					expect( cat.id ).to.equal( categories[ idx ].id );
-					expect( cat.name ).to.equal( categories[ idx ].name );
-				});
+				terms
+					.find( ( collection ) => collection[ 0 ].taxonomy === 'category' )
+					.sort( ascById )
+					.forEach( ( cat, idx ) => {
+						expect( cat.id ).to.equal( categories[ idx ].id );
+						expect( cat.name ).to.equal( categories[ idx ].name );
+					});
 				// Validate all tags are present and accounted for
-				terms.filter(function( collection ) {
-					return collection[ 0 ].taxonomy === 'post_tag';
-				})[ 0 ].sort( ascById ).forEach(function( tag, idx ) {
-					expect( tag.id ).to.equal( tags[ idx ].id );
-					expect( tag.name ).to.equal( tags[ idx ].name );
-				});
+				terms
+					.find( ( collection ) => collection[ 0 ].taxonomy === 'post_tag' )
+					.sort( ascById )
+					.forEach( ( tag, idx ) => {
+						expect( tag.id ).to.equal( tags[ idx ].id );
+						expect( tag.name ).to.equal( tags[ idx ].name );
+					});
 			})
-			.then(function() {
+			.then( () => {
 				// Clean up after ourselves: remove media
 				return authenticated.media()
 					.id( mediaId )
@@ -808,30 +797,25 @@ describe( 'integration: posts()', () => {
 						force: true
 					});
 			})
-			.then(function() {
-				// Query for the media, with auth: expect this to fail, since it is gone
-				return authenticated.media().id( mediaId );
-			})
-			.catch(function( error ) {
+			// Query for the media, with auth: expect this to fail, since it is gone
+			.then( () => authenticated.media().id( mediaId ) )
+			.catch( ( error ) => {
 				httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).to.equal( 'rest_post_invalid_id' );
 				expect( error.data ).to.deep.equal({
 					status: 404
 				});
 			})
-			.then(function() {
-				// Clean up after ourselves: remove post
-				return authenticated.posts()
-					.id( id )
-					.delete({
-						force: true
-					});
-			})
-			.then(function() {
-				// Query for the post, with auth: expect this to fail, since it is gone
-				return authenticated.posts().id( id );
-			})
-			.catch(function( error ) {
+			// Clean up after ourselves: remove post
+			.then( () => authenticated.posts()
+				.id( id )
+				.delete({
+					force: true
+				})
+			)
+			// Query for the post, with auth: expect this to fail, since it is gone
+			.then( () => authenticated.posts().id( id ) )
+			.catch( ( error ) => {
 				httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).to.equal( 'rest_post_invalid_id' );
 				expect( error.data ).to.deep.equal({

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -62,11 +62,11 @@ var expectedResults = {
 	}
 };
 
-describe( 'integration: posts()', function() {
+describe( 'integration: posts()', () => {
 	var wp;
 	var authenticated;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
@@ -75,7 +75,7 @@ describe( 'integration: posts()', function() {
 		}).auth( credentials );
 	});
 
-	it( 'can be used to retrieve a list of recent posts', function() {
+	it( 'can be used to retrieve a list of recent posts', () => {
 		var prom = wp.posts()
 			.get()
 			.then(function( posts ) {
@@ -86,7 +86,7 @@ describe( 'integration: posts()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'fetches the 10 most recent posts by default', function() {
+	it( 'fetches the 10 most recent posts by default', () => {
 		var prom = wp.posts()
 			.get()
 			.then(function( posts ) {
@@ -96,7 +96,7 @@ describe( 'integration: posts()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'properly parses responses returned from server as text/html', function() {
+	it( 'properly parses responses returned from server as text/html', () => {
 		var prom = wp.posts()
 			.param( '_wpapi_force_html', true )
 			.get()
@@ -107,9 +107,9 @@ describe( 'integration: posts()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	describe( 'paging properties', function() {
+	describe( 'paging properties', () => {
 
-		it( 'are exposed as _paging on the response array', function() {
+		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.posts()
 				.get()
 				.then(function( posts ) {
@@ -120,7 +120,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'are exposed as _paging on the response array when response is text/html', function() {
+		it( 'are exposed as _paging on the response array when response is text/html', () => {
 			var prom = wp.posts()
 				.param( '_wpapi_force_html', true )
 				.get()
@@ -132,7 +132,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of posts: use .headers() for coverage reasons', function() {
+		it( 'include the total number of posts: use .headers() for coverage reasons', () => {
 			var prom = wp.posts()
 				.headers()
 				.then(function( postHeadersResponse ) {
@@ -143,7 +143,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of pages available', function() {
+		it( 'include the total number of pages available', () => {
 			var prom = wp.posts()
 				.get()
 				.then(function( posts ) {
@@ -154,7 +154,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the next page as .next', function() {
+		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.posts()
 				.get()
 				.then(function( posts ) {
@@ -176,7 +176,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the next page of results via .next', function() {
+		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.posts()
 				.get()
 				.then(function( posts ) {
@@ -193,7 +193,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the next page of results via .next when response is text/html', function() {
+		it( 'allows access to the next page of results via .next when response is text/html', () => {
 			var prom = wp.posts()
 				.param( '_wpapi_force_html', true )
 				.get()
@@ -208,7 +208,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the previous page as .prev', function() {
+		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.posts()
 				.get()
 				.then(function( posts ) {
@@ -227,7 +227,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the previous page of results via .prev', function() {
+		it( 'allows access to the previous page of results via .prev', () => {
 			var prom = wp.posts()
 				.page( 2 )
 				.get()
@@ -246,7 +246,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'maintains authentication across paging requests', function() {
+		it( 'maintains authentication across paging requests', () => {
 			var prom = authenticated.posts()
 				.context( 'edit' )
 				.get()
@@ -262,11 +262,11 @@ describe( 'integration: posts()', function() {
 
 	});
 
-	describe( 'filter methods', function() {
+	describe( 'filter methods', () => {
 
-		describe( 'slug', function() {
+		describe( 'slug', () => {
 
-			it( 'can be used to return only posts with the specified slug', function() {
+			it( 'can be used to return only posts with the specified slug', () => {
 				var prom = wp.posts()
 					.slug( 'template-excerpt-generated' )
 					.get()
@@ -282,9 +282,9 @@ describe( 'integration: posts()', function() {
 
 		});
 
-		describe( 'status', function() {
+		describe( 'status', () => {
 
-			it( 'can be used to retrieve specific statuses of posts', function() {
+			it( 'can be used to retrieve specific statuses of posts', () => {
 				var prom = authenticated.posts()
 					.status([ 'future', 'draft' ])
 					.get()
@@ -300,9 +300,9 @@ describe( 'integration: posts()', function() {
 
 		});
 
-		describe( 'tags', function() {
+		describe( 'tags', () => {
 
-			it( 'can be used to return only posts with a provided tag', function() {
+			it( 'can be used to return only posts with a provided tag', () => {
 				var prom = wp.tags()
 					.slug( 'title' )
 					.get()
@@ -326,7 +326,7 @@ describe( 'integration: posts()', function() {
 				return expect( prom ).to.eventually.equal( SUCCESS );
 			});
 
-			it( 'can be used to return posts with any of the provided tags', function() {
+			it( 'can be used to return posts with any of the provided tags', () => {
 				var prom = Promise
 					.all([
 						wp.tags().search( 'featured image' ),
@@ -357,9 +357,9 @@ describe( 'integration: posts()', function() {
 
 		});
 
-		describe( 'excludeTags', function() {
+		describe( 'excludeTags', () => {
 
-			it( 'can be used to omit posts in specific tags', function() {
+			it( 'can be used to omit posts in specific tags', () => {
 				var prom = Promise
 					.all([
 						wp.tags().search( 'css' ),
@@ -393,9 +393,9 @@ describe( 'integration: posts()', function() {
 
 		});
 
-		describe( 'categories', function() {
+		describe( 'categories', () => {
 
-			it( 'can be used to return only posts with a provided category', function() {
+			it( 'can be used to return only posts with a provided category', () => {
 				var prom = wp.categories()
 					.slug( 'markup' )
 					.get()
@@ -420,7 +420,7 @@ describe( 'integration: posts()', function() {
 				return expect( prom ).to.eventually.equal( SUCCESS );
 			});
 
-			it( 'can be used to return posts with any of the provided categories', function() {
+			it( 'can be used to return posts with any of the provided categories', () => {
 				var prom = Promise
 					.all([
 						wp.categories().search( 'edge case' ),
@@ -451,9 +451,9 @@ describe( 'integration: posts()', function() {
 
 		});
 
-		describe( 'excludeCategories', function() {
+		describe( 'excludeCategories', () => {
 
-			it( 'can be used to omit posts in specific categories', function() {
+			it( 'can be used to omit posts in specific categories', () => {
 				var prom = Promise
 					.all([
 						wp.categories().slug( 'markup' ),
@@ -487,9 +487,9 @@ describe( 'integration: posts()', function() {
 
 		});
 
-		describe( 'before', function() {
+		describe( 'before', () => {
 
-			it( 'can be used to return only posts from before a certain date', function() {
+			it( 'can be used to return only posts from before a certain date', () => {
 				var prom = wp.posts()
 					.before( '2013-01-08' )
 					.then(function( posts ) {
@@ -501,9 +501,9 @@ describe( 'integration: posts()', function() {
 
 		});
 
-		describe( 'after', function() {
+		describe( 'after', () => {
 
-			it( 'can be used to return only posts from after a certain date', function() {
+			it( 'can be used to return only posts from after a certain date', () => {
 				var prom = wp.posts()
 					.after( '2013-01-08' )
 					.then(function( posts ) {
@@ -519,9 +519,9 @@ describe( 'integration: posts()', function() {
 	});
 
 	// Post creation, update & deletion suites
-	describe( 'authorization errors', function() {
+	describe( 'authorization errors', () => {
 
-		it( 'cannot use context=edit without authentication', function() {
+		it( 'cannot use context=edit without authentication', () => {
 			var prom = wp.posts()
 				.edit()
 				.get()
@@ -535,7 +535,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'cannot DELETE without authentication', function() {
+		it( 'cannot DELETE without authentication', () => {
 			var id;
 			var prom = wp.posts()
 				.perPage( 1 )
@@ -564,7 +564,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'cannot create (POST) without authentication (also tests callback-mode errors)', function() {
+		it( 'cannot create (POST) without authentication (also tests callback-mode errors)', () => {
 			var prom = new Promise(function( resolve, reject ) {
 				wp.posts().create({
 					title: 'New Post 2501',
@@ -583,7 +583,7 @@ describe( 'integration: posts()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'cannot update (PUT) without authentication', function() {
+		it( 'cannot update (PUT) without authentication', () => {
 			var id;
 			var prom = wp.posts()
 				.perPage( 1 )
@@ -608,7 +608,7 @@ describe( 'integration: posts()', function() {
 		});
 	});
 
-	it( 'can create, update & delete a post when authenticated', function() {
+	it( 'can create, update & delete a post when authenticated', () => {
 		var id;
 		var prom = authenticated.posts()
 			.create({
@@ -708,7 +708,7 @@ describe( 'integration: posts()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	}).timeout( 10000 );
 
-	it( 'can create a post with tags, categories and featured media', function() {
+	it( 'can create a post with tags, categories and featured media', () => {
 		var id;
 		var mediaId;
 		var filePath = path.join( __dirname, 'assets/emilygarfield-untitled.jpg' );
@@ -844,7 +844,7 @@ describe( 'integration: posts()', function() {
 
 	// Callback context
 
-	it( 'can GET posts with a context-bound callback', function( done ) {
+	it( 'can GET posts with a context-bound callback', ( done ) => {
 		function Ctor() {}
 		Ctor.prototype.setState = function( state ) {
 			this.state = state;

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -667,7 +667,7 @@ describe( 'integration: posts()', () => {
 				httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).to.equal( 'rest_forbidden' );
 				expect( error.data ).to.deep.equal({
-					status: 403
+					status: 401
 				});
 				// Re-authenticate & permanently delete this post
 				return authenticated.posts()

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -179,16 +179,14 @@ describe( 'integration: posts()', () => {
 		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.posts()
 				.get()
+				.then( ( posts ) => posts._paging.next.get() )
+
 				.then( ( posts ) => {
-					return posts._paging.next
-						.get()
-						.then( ( posts ) => {
-							expect( posts ).to.be.an( 'array' );
-							// @TODO: re-enable once PPP support is merged
-							// expect( posts.length ).to.equal( 10 );
-							// expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page2 );
-							return SUCCESS;
-						});
+					expect( posts ).to.be.an( 'array' );
+					// @TODO: re-enable once PPP support is merged
+					// expect( posts.length ).to.equal( 10 );
+					// expect( getTitles( posts ) ).to.deep.equal( expectedResults.titles.page2 );
+					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
@@ -197,13 +195,10 @@ describe( 'integration: posts()', () => {
 			var prom = wp.posts()
 				.param( '_wpapi_force_html', true )
 				.get()
+				.then( ( posts ) => posts._paging.next.get() )
 				.then( ( posts ) => {
-					return posts._paging.next
-						.get()
-						.then( ( posts ) => {
-							expect( posts ).to.be.an( 'array' );
-							return SUCCESS;
-						});
+					expect( posts ).to.be.an( 'array' );
+					return SUCCESS;
 				});
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
@@ -250,9 +245,7 @@ describe( 'integration: posts()', () => {
 			var prom = authenticated.posts()
 				.context( 'edit' )
 				.get()
-				.then( ( posts ) => {
-					return posts._paging.next.get();
-				})
+				.then( ( posts ) => posts._paging.next.get() )
 				.then( ( page2 ) => {
 					expect( page2[0].content ).to.have.property( 'raw' );
 					return SUCCESS;

--- a/tests/integration/settings.js
+++ b/tests/integration/settings.js
@@ -28,7 +28,7 @@ describe( 'integration: settings()', () => {
 	it( 'cannot be used to retrieve site settings unless authenticated', () => {
 		var prom = wp.settings()
 			.get()
-			.catch(function( err ) {
+			.catch( ( err ) => {
 				expect( err.code ).to.equal( 'rest_forbidden' );
 				expect( err.data ).to.deep.equal({
 					status: 403
@@ -41,7 +41,7 @@ describe( 'integration: settings()', () => {
 	it( 'can be used to retrieve a list of site settings when authenticated', () => {
 		var prom = authenticated.settings()
 			.get()
-			.then(function( settings ) {
+			.then( ( settings ) => {
 				expect( settings ).to.be.an( 'object' );
 
 				// Validate existence of all expected keys
@@ -77,18 +77,16 @@ describe( 'integration: settings()', () => {
 	it( 'can be used to update settings', () => {
 		var prom = authenticated.settings()
 			.get()
-			.then(function( settings ) {
+			.then( ( settings ) => {
 				expect( settings.description ).to.equal( 'Just another WordPress site' );
 				return authenticated.settings()
 					.update({
 						description: 'It\'s amazing what you\'ll find face to face'
 					});
 			})
-			.then(function() {
-				// Initialize new request to see if changes persisted
-				return authenticated.settings().get();
-			})
-			.then(function( settings ) {
+			// Initialize new request to see if changes persisted
+			.then( () => authenticated.settings().get() )
+			.then( ( settings ) => {
 				expect( settings.description ).to.equal( 'It&#039;s amazing what you&#039;ll find face to face' );
 				// Reset to original value
 				return authenticated.settings()
@@ -96,11 +94,9 @@ describe( 'integration: settings()', () => {
 						description: 'Just another WordPress site'
 					});
 			})
-			.then(function() {
-				// Request one final time to validate value has been set back
-				return authenticated.settings().get();
-			})
-			.then(function( settings ) {
+			// Request one final time to validate value has been set back
+			.then( () => authenticated.settings().get() )
+			.then( ( settings ) => {
 				expect( settings.description ).to.equal( 'Just another WordPress site' );
 				return SUCCESS;
 			});

--- a/tests/integration/settings.js
+++ b/tests/integration/settings.js
@@ -31,7 +31,7 @@ describe( 'integration: settings()', () => {
 			.catch( ( err ) => {
 				expect( err.code ).to.equal( 'rest_forbidden' );
 				expect( err.data ).to.deep.equal({
-					status: 403
+					status: 401
 				});
 				return SUCCESS;
 			});

--- a/tests/integration/settings.js
+++ b/tests/integration/settings.js
@@ -12,11 +12,11 @@ var WPAPI = require( '../../' );
 
 var credentials = require( './helpers/constants' ).credentials;
 
-describe( 'integration: settings()', function() {
+describe( 'integration: settings()', () => {
 	var wp;
 	var authenticated;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
@@ -25,7 +25,7 @@ describe( 'integration: settings()', function() {
 		}).auth( credentials );
 	});
 
-	it( 'cannot be used to retrieve site settings unless authenticated', function() {
+	it( 'cannot be used to retrieve site settings unless authenticated', () => {
 		var prom = wp.settings()
 			.get()
 			.catch(function( err ) {
@@ -38,7 +38,7 @@ describe( 'integration: settings()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be used to retrieve a list of site settings when authenticated', function() {
+	it( 'can be used to retrieve a list of site settings when authenticated', () => {
 		var prom = authenticated.settings()
 			.get()
 			.then(function( settings ) {
@@ -74,7 +74,7 @@ describe( 'integration: settings()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be used to update settings', function() {
+	it( 'can be used to update settings', () => {
 		var prom = authenticated.settings()
 			.get()
 			.then(function( settings ) {

--- a/tests/integration/tags.js
+++ b/tests/integration/tags.js
@@ -58,16 +58,16 @@ var expectedResults = {
 	}
 };
 
-describe( 'integration: tags()', function() {
+describe( 'integration: tags()', () => {
 	var wp;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
 	});
 
-	it( 'can be used to retrieve a collection of category terms', function() {
+	it( 'can be used to retrieve a collection of category terms', () => {
 		var prom = wp.tags()
 			.get()
 			.then(function( tags ) {
@@ -78,7 +78,7 @@ describe( 'integration: tags()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'retrieves the first 10 tags by default', function() {
+	it( 'retrieves the first 10 tags by default', () => {
 		var prom = wp.tags()
 			.get()
 			.then(function( tags ) {
@@ -89,9 +89,9 @@ describe( 'integration: tags()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	describe( 'paging properties', function() {
+	describe( 'paging properties', () => {
 
-		it( 'are exposed as _paging on the response array', function() {
+		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.tags()
 				.get()
 				.then(function( tags ) {
@@ -102,7 +102,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of tags', function() {
+		it( 'include the total number of tags', () => {
 			var prom = wp.tags()
 				.get()
 				.then(function( tags ) {
@@ -113,7 +113,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'include the total number of pages available', function() {
+		it( 'include the total number of pages available', () => {
 			var prom = wp.tags()
 				.get()
 				.then(function( tags ) {
@@ -124,7 +124,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the next page as .next', function() {
+		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.tags()
 				.get()
 				.then(function( tags ) {
@@ -145,7 +145,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the next page of results via .next', function() {
+		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.tags()
 				.get()
 				.then(function( tags ) {
@@ -161,7 +161,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'provides a bound WPRequest for the previous page as .prev', function() {
+		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.tags()
 				.get()
 				.then(function( tags ) {
@@ -180,7 +180,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'allows access to the previous page of results via .prev', function() {
+		it( 'allows access to the previous page of results via .prev', () => {
 			var prom = wp.tags()
 				.page( 2 )
 				.get()
@@ -200,9 +200,9 @@ describe( 'integration: tags()', function() {
 
 	});
 
-	describe( 'id()', function() {
+	describe( 'id()', () => {
 
-		it( 'can be used to access an individual tag term', function() {
+		it( 'can be used to access an individual tag term', () => {
 			var selectedTag;
 			var prom = wp.tags()
 				.get()
@@ -228,9 +228,9 @@ describe( 'integration: tags()', function() {
 
 	});
 
-	describe( 'search()', function() {
+	describe( 'search()', () => {
 
-		it( 'can be used to retrieve a tag by slug', function() {
+		it( 'can be used to retrieve a tag by slug', () => {
 			var selectedTag;
 			var prom = wp.tags()
 				.get()
@@ -259,7 +259,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'returns all tags matching the provided search string', function() {
+		it( 'returns all tags matching the provided search string', () => {
 			var prom = wp.tags()
 				.search( 'post' )
 				.get()
@@ -275,7 +275,7 @@ describe( 'integration: tags()', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'can be used to retrieve a tag by slug from a set of search results', function() {
+		it( 'can be used to retrieve a tag by slug from a set of search results', () => {
 			var prom = wp.tags()
 				.search( 'post' )
 				.get()

--- a/tests/integration/tags.js
+++ b/tests/integration/tags.js
@@ -70,7 +70,7 @@ describe( 'integration: tags()', () => {
 	it( 'can be used to retrieve a collection of category terms', () => {
 		var prom = wp.tags()
 			.get()
-			.then(function( tags ) {
+			.then( ( tags ) => {
 				expect( tags ).to.be.an( 'array' );
 				expect( tags.length ).to.equal( 10 );
 				return SUCCESS;
@@ -81,7 +81,7 @@ describe( 'integration: tags()', () => {
 	it( 'retrieves the first 10 tags by default', () => {
 		var prom = wp.tags()
 			.get()
-			.then(function( tags ) {
+			.then( ( tags ) => {
 				expect( tags ).to.be.an( 'array' );
 				expect( tags.length ).to.equal( 10 );
 				return SUCCESS;
@@ -94,7 +94,7 @@ describe( 'integration: tags()', () => {
 		it( 'are exposed as _paging on the response array', () => {
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( tags ).to.have.property( '_paging' );
 					expect( tags._paging ).to.be.an( 'object' );
 					return SUCCESS;
@@ -105,7 +105,7 @@ describe( 'integration: tags()', () => {
 		it( 'include the total number of tags', () => {
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( tags._paging ).to.have.property( 'total' );
 					expect( tags._paging.total ).to.equal( '110' );
 					return SUCCESS;
@@ -116,7 +116,7 @@ describe( 'integration: tags()', () => {
 		it( 'include the total number of pages available', () => {
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( tags._paging ).to.have.property( 'totalPages' );
 					expect( tags._paging.totalPages ).to.equal( '11' );
 					return SUCCESS;
@@ -127,7 +127,7 @@ describe( 'integration: tags()', () => {
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( tags._paging ).to.have.property( 'next' );
 					expect( tags._paging.next ).to.be.an( 'object' );
 					expect( tags._paging.next ).to.be.an.instanceOf( WPRequest );
@@ -136,7 +136,7 @@ describe( 'integration: tags()', () => {
 					// Get last page & ensure "next" no longer appears
 					return wp.tags().page( tags._paging.totalPages )
 						.get()
-						.then(function( tags ) {
+						.then( ( tags ) => {
 							expect( tags._paging ).not.to.have.property( 'next' );
 							expect( getNames( tags ) ).to.deep.equal( expectedResults.names.pageLast );
 							return SUCCESS;
@@ -148,10 +148,10 @@ describe( 'integration: tags()', () => {
 		it( 'allows access to the next page of results via .next', () => {
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					return tags._paging.next
 						.get()
-						.then(function( tags ) {
+						.then( ( tags ) => {
 							expect( tags ).to.be.an( 'array' );
 							expect( tags.length ).to.equal( 10 );
 							expect( getNames( tags ) ).to.deep.equal( expectedResults.names.page2 );
@@ -164,11 +164,11 @@ describe( 'integration: tags()', () => {
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( tags._paging ).not.to.have.property( 'prev' );
 					return tags._paging.next
 						.get()
-						.then(function( tags ) {
+						.then( ( tags ) => {
 							expect( tags._paging ).to.have.property( 'prev' );
 							expect( tags._paging.prev ).to.be.an( 'object' );
 							expect( tags._paging.prev ).to.be.an.instanceOf( WPRequest );
@@ -184,11 +184,11 @@ describe( 'integration: tags()', () => {
 			var prom = wp.tags()
 				.page( 2 )
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( getNames( tags ) ).to.deep.equal( expectedResults.names.page2 );
 					return tags._paging.prev
 						.get()
-						.then(function( tags ) {
+						.then( ( tags ) => {
 							expect( tags ).to.be.an( 'array' );
 							expect( tags.length ).to.equal( 10 );
 							expect( getNames( tags ) ).to.deep.equal( expectedResults.names.page1 );
@@ -206,13 +206,13 @@ describe( 'integration: tags()', () => {
 			var selectedTag;
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					// Pick one of the tags
 					selectedTag = tags[ 3 ];
 					// Query for that tag directly
 					return wp.tags().id( selectedTag.id );
 				})
-				.then(function( tag ) {
+				.then( ( tag ) => {
 					expect( tag ).to.be.an( 'object' );
 					expect( tag ).to.have.property( 'id' );
 					expect( tag.id ).to.equal( selectedTag.id );
@@ -234,18 +234,18 @@ describe( 'integration: tags()', () => {
 			var selectedTag;
 			var prom = wp.tags()
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					// Pick one of the tags
 					selectedTag = tags[ 3 ];
 					// Search for that tag by slug
 					return wp.tags().search( selectedTag.slug );
 				})
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( tags ).to.be.an( 'array' );
 					expect( tags.length ).to.equal( 1 );
 					return tags[ 0 ];
 				})
-				.then(function( tag ) {
+				.then( ( tag ) => {
 					expect( tag ).to.be.an( 'object' );
 					expect( tag ).to.have.property( 'id' );
 					expect( tag.id ).to.equal( selectedTag.id );
@@ -263,12 +263,10 @@ describe( 'integration: tags()', () => {
 			var prom = wp.tags()
 				.search( 'post' )
 				.get()
-				.then(function( tags ) {
+				.then( ( tags ) => {
 					expect( tags ).to.be.an( 'array' );
 					expect( tags.length ).to.equal( 2 );
-					var slugs = tags.map(function( tag ) {
-						return tag.slug;
-					}).sort().join( ' ' );
+					var slugs = tags.map( ( tag ) => tag.slug ).sort().join( ' ' );
 					expect( slugs ).to.equal( 'post post-formats' );
 					return SUCCESS;
 				});
@@ -279,16 +277,10 @@ describe( 'integration: tags()', () => {
 			var prom = wp.tags()
 				.search( 'post' )
 				.get()
-				.then(function( tags ) {
-					// Iterating over response of search is the best we can do until
-					// filtering for taxonomy term collections is reinstated
-					for ( var i = 0; i < tags.length; i++ ) {
-						if ( tags[ i ].slug === 'post' ) {
-							return tags[ i ];
-						}
-					}
-				})
-				.then(function( tag ) {
+				// Iterating over response of search is the best we can do until
+				// filtering for taxonomy term collections is reinstated
+				.then( ( tags ) => tags.find( tag => tag.slug === 'post' ) )
+				.then( ( tag ) => {
 					expect( tag ).to.have.property( 'slug' );
 					expect( tag.slug ).to.equal( 'post' );
 					expect( tag ).to.have.property( 'name' );

--- a/tests/integration/taxonomies.js
+++ b/tests/integration/taxonomies.js
@@ -10,16 +10,16 @@ var expect = chai.expect;
 
 var WPAPI = require( '../../' );
 
-describe( 'integration: taxonomies()', function() {
+describe( 'integration: taxonomies()', () => {
 	var wp;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
 	});
 
-	it( 'can be used to retrieve a dictionary of registered taxonomies', function() {
+	it( 'can be used to retrieve a dictionary of registered taxonomies', () => {
 		var prom = wp.taxonomies()
 			.get()
 			.then(function( taxonomies ) {
@@ -33,7 +33,7 @@ describe( 'integration: taxonomies()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be chained with a taxonomy() call to fetch the category taxonomy', function() {
+	it( 'can be chained with a taxonomy() call to fetch the category taxonomy', () => {
 		var prom = wp.taxonomies()
 			.taxonomy( 'category' )
 			.get()
@@ -48,7 +48,7 @@ describe( 'integration: taxonomies()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be chained with a taxonomy() call to fetch the post_tag taxonomy', function() {
+	it( 'can be chained with a taxonomy() call to fetch the post_tag taxonomy', () => {
 		var prom = wp.taxonomies()
 			.taxonomy( 'post_tag' )
 			.get()

--- a/tests/integration/taxonomies.js
+++ b/tests/integration/taxonomies.js
@@ -22,7 +22,7 @@ describe( 'integration: taxonomies()', () => {
 	it( 'can be used to retrieve a dictionary of registered taxonomies', () => {
 		var prom = wp.taxonomies()
 			.get()
-			.then(function( taxonomies ) {
+			.then( ( taxonomies ) => {
 				expect( taxonomies ).to.be.an( 'object' );
 				expect( taxonomies ).to.have.property( 'category' );
 				expect( taxonomies.category ).to.be.an( 'object' );
@@ -37,7 +37,7 @@ describe( 'integration: taxonomies()', () => {
 		var prom = wp.taxonomies()
 			.taxonomy( 'category' )
 			.get()
-			.then(function( category ) {
+			.then( ( category ) => {
 				expect( category ).to.be.an( 'object' );
 				expect( category ).to.have.property( 'slug' );
 				expect( category.slug ).to.equal( 'category' );
@@ -52,7 +52,7 @@ describe( 'integration: taxonomies()', () => {
 		var prom = wp.taxonomies()
 			.taxonomy( 'post_tag' )
 			.get()
-			.then(function( tag ) {
+			.then( ( tag ) => {
 				expect( tag ).to.be.an( 'object' );
 				expect( tag ).to.have.property( 'slug' );
 				expect( tag.slug ).to.equal( 'post_tag' );

--- a/tests/integration/types.js
+++ b/tests/integration/types.js
@@ -22,7 +22,7 @@ describe( 'integration: types()', () => {
 	it( 'can be used to retrieve a dictionary of registered types', () => {
 		var prom = wp.types()
 			.get()
-			.then(function( types ) {
+			.then( ( types ) => {
 				expect( types ).to.be.an( 'object' );
 				expect( types ).to.have.property( 'post' );
 				expect( types.post ).to.be.an( 'object' );
@@ -39,7 +39,7 @@ describe( 'integration: types()', () => {
 		var prom = wp.types()
 			.type( 'post' )
 			.get()
-			.then(function( post ) {
+			.then( ( post ) => {
 				expect( post ).to.be.an( 'object' );
 				expect( post ).to.have.property( 'slug' );
 				expect( post.slug ).to.equal( 'post' );
@@ -54,7 +54,7 @@ describe( 'integration: types()', () => {
 		var prom = wp.types()
 			.type( 'page' )
 			.get()
-			.then(function( page ) {
+			.then( ( page ) => {
 				expect( page ).to.be.an( 'object' );
 				expect( page ).to.have.property( 'slug' );
 				expect( page.slug ).to.equal( 'page' );

--- a/tests/integration/types.js
+++ b/tests/integration/types.js
@@ -10,16 +10,16 @@ var expect = chai.expect;
 
 var WPAPI = require( '../../' );
 
-describe( 'integration: types()', function() {
+describe( 'integration: types()', () => {
 	var wp;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		wp = new WPAPI({
 			endpoint: 'http://wpapi.loc/wp-json'
 		});
 	});
 
-	it( 'can be used to retrieve a dictionary of registered types', function() {
+	it( 'can be used to retrieve a dictionary of registered types', () => {
 		var prom = wp.types()
 			.get()
 			.then(function( types ) {
@@ -35,7 +35,7 @@ describe( 'integration: types()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be chained with a type() call to fetch the "post" type', function() {
+	it( 'can be chained with a type() call to fetch the "post" type', () => {
 		var prom = wp.types()
 			.type( 'post' )
 			.get()
@@ -50,7 +50,7 @@ describe( 'integration: types()', function() {
 		return expect( prom ).to.eventually.equal( SUCCESS );
 	});
 
-	it( 'can be chained with a type() call to fetch the page type', function() {
+	it( 'can be chained with a type() call to fetch the page type', () => {
 		var prom = wp.types()
 			.type( 'page' )
 			.get()

--- a/tests/unit/lib/autodiscovery.js
+++ b/tests/unit/lib/autodiscovery.js
@@ -3,20 +3,20 @@ var expect = require( 'chai' ).expect;
 
 var autodiscovery = require( '../../../lib/autodiscovery' );
 
-describe( 'autodiscovery helper methods', function() {
+describe( 'autodiscovery helper methods', () => {
 
-	describe( '.locateAPIRootHeader()', function() {
+	describe( '.locateAPIRootHeader()', () => {
 		var locateAPIRootHeader;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			locateAPIRootHeader = autodiscovery.locateAPIRootHeader;
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( locateAPIRootHeader ).to.be.a( 'function' );
 		});
 
-		it( 'throws an error if no link header is found', function() {
+		it( 'throws an error if no link header is found', () => {
 			expect(function() {
 				locateAPIRootHeader({
 					headers: {}
@@ -24,7 +24,7 @@ describe( 'autodiscovery helper methods', function() {
 			}).to.throw( 'No header link found with rel="https://api.w.org/"' );
 		});
 
-		it( 'parsed and returns the header with the rel for the REST API endpoint', function() {
+		it( 'parsed and returns the header with the rel for the REST API endpoint', () => {
 			var result = locateAPIRootHeader({
 				headers: {
 					link: '<http://wpapi.loc/wp-json/>; rel="https://api.w.org/"'

--- a/tests/unit/lib/autodiscovery.js
+++ b/tests/unit/lib/autodiscovery.js
@@ -17,7 +17,7 @@ describe( 'autodiscovery helper methods', () => {
 		});
 
 		it( 'throws an error if no link header is found', () => {
-			expect(function() {
+			expect( () => {
 				locateAPIRootHeader({
 					headers: {}
 				});

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -8,39 +8,39 @@ var WPRequest = require( '../../../../lib/constructors/wp-request' );
 var filterMixins = require( '../../../../lib/mixins/filters' );
 var checkMethodSupport = require( '../../../../lib/util/check-method-support' );
 
-describe( 'WPRequest', function() {
+describe( 'WPRequest', () => {
 
 	var request;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		request = new WPRequest({
 			endpoint: '/'
 		});
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should create a WPRequest instance', function() {
+		it( 'should create a WPRequest instance', () => {
 			expect( request instanceof WPRequest ).to.be.true;
 		});
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			request = new WPRequest({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( request.toString() ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should define a _supportedMethods array', function() {
+		it( 'should define a _supportedMethods array', () => {
 			var _supportedMethods = request._supportedMethods.sort().join( '|' );
 			expect( _supportedMethods ).to.equal( 'delete|get|head|post|put' );
 		});
 
 	});
 
-	describe( '._renderQuery() [internal]', function() {
+	describe( '._renderQuery() [internal]', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Object.keys( filterMixins ).forEach(function( mixin ) {
 				if ( ! request[ mixin ] ) {
 					request[ mixin ] = filterMixins[ mixin ];
@@ -48,7 +48,7 @@ describe( 'WPRequest', function() {
 			});
 		});
 
-		it( 'properly parses taxonomy filters', function() {
+		it( 'properly parses taxonomy filters', () => {
 			request._taxonomyFilters = {
 				tag: [ 'clouds ', 'islands' ],
 				custom_tax: [ 7 ]
@@ -59,7 +59,7 @@ describe( 'WPRequest', function() {
 				.equal( '?filter%5Bcustom_tax%5D=7&filter%5Btag%5D=clouds%2Bislands' );
 		});
 
-		it( 'lower-cases taxonomy terms', function() {
+		it( 'lower-cases taxonomy terms', () => {
 			request._taxonomyFilters = {
 				tag: [ 'Diamond-Dust' ]
 			};
@@ -67,7 +67,7 @@ describe( 'WPRequest', function() {
 			expect( query ).to.equal( '?filter%5Btag%5D=diamond-dust' );
 		});
 
-		it( 'properly parses regular filters', function() {
+		it( 'properly parses regular filters', () => {
 			request._filters = {
 				post_status: 'publish', s: 'Some search string'
 			};
@@ -76,14 +76,14 @@ describe( 'WPRequest', function() {
 				.equal( '?filter%5Bpost_status%5D=publish&filter%5Bs%5D=Some%20search%20string' );
 		});
 
-		it( 'properly parses array filters', function() {
+		it( 'properly parses array filters', () => {
 			request._filters = { post__in: [ 0, 1 ] };
 			var query = request._renderQuery();
 			expect( query ).to
 				.equal( '?filter%5Bpost__in%5D%5B%5D=0&filter%5Bpost__in%5D%5B%5D=1' );
 		});
 
-		it( 'correctly merges taxonomy and regular filters & renders them in order', function() {
+		it( 'correctly merges taxonomy and regular filters & renders them in order', () => {
 			request._taxonomyFilters = {
 				cat: [ 7, 10 ]
 			};
@@ -97,13 +97,13 @@ describe( 'WPRequest', function() {
 
 	});
 
-	describe( '.checkMethodSupport()', function() {
+	describe( '.checkMethodSupport()', () => {
 
-		it( 'should return true when called with a supported method', function() {
+		it( 'should return true when called with a supported method', () => {
 			expect( checkMethodSupport( 'get', request ) ).to.equal( true );
 		});
 
-		it( 'should throw an error when called with an unsupported method', function() {
+		it( 'should throw an error when called with an unsupported method', () => {
 			request._supportedMethods = [ 'get' ];
 
 			expect(function() {
@@ -113,53 +113,53 @@ describe( 'WPRequest', function() {
 
 	});
 
-	describe( '.namespace()', function() {
+	describe( '.namespace()', () => {
 
-		it( 'is defined', function() {
+		it( 'is defined', () => {
 			expect( request ).to.have.property( 'namespace' );
 			expect( request.namespace ).to.be.a( 'function' );
 		});
 
-		it( 'sets a value that is prepended to the path', function() {
+		it( 'sets a value that is prepended to the path', () => {
 			request.namespace( 'ns' );
 			expect( request._renderPath() ).to.equal( 'ns' );
 		});
 
-		it( 'can accept & set a namespace in the (:domain/:version) format', function() {
+		it( 'can accept & set a namespace in the (:domain/:version) format', () => {
 			request.namespace( 'ns/v3' );
 			expect( request._renderPath() ).to.equal( 'ns/v3' );
 		});
 
-		it( 'can be removed (to use the legacy api v1) with an empty string', function() {
+		it( 'can be removed (to use the legacy api v1) with an empty string', () => {
 			request.namespace( 'windows/xp' ).namespace( '' );
 			expect( request._renderPath() ).to.equal( '' );
 		});
 
-		it( 'can be removed (to use the legacy api v1) by omitting arguments', function() {
+		it( 'can be removed (to use the legacy api v1) by omitting arguments', () => {
 			request.namespace( 'wordpress/95' ).namespace();
 			expect( request._renderPath() ).to.equal( '' );
 		});
 
 	});
 
-	describe( '.param()', function() {
+	describe( '.param()', () => {
 
-		it( 'method exists', function() {
+		it( 'method exists', () => {
 			expect( request ).to.have.property( 'param' );
 			expect( request.param ).to.be.a( 'function' );
 		});
 
-		it( 'will have no effect if called without any arguments', function() {
+		it( 'will have no effect if called without any arguments', () => {
 			request.param();
 			expect( request._renderQuery() ).to.equal( '' );
 		});
 
-		it( 'will set a query parameter value', function() {
+		it( 'will set a query parameter value', () => {
 			request.param( 'key', 'value' );
 			expect( request._renderQuery() ).to.equal( '?key=value' );
 		});
 
-		it( 'will unset a query parameter value if called with empty string', function() {
+		it( 'will unset a query parameter value if called with empty string', () => {
 			request.param( 'key', 'value' );
 			expect( request._renderQuery() ).to.equal( '?key=value' );
 			request.param( 'key', 'value' );
@@ -167,7 +167,7 @@ describe( 'WPRequest', function() {
 			expect( request._renderQuery() ).to.equal( '' );
 		});
 
-		it( 'will unset a query parameter value if called with null', function() {
+		it( 'will unset a query parameter value if called with null', () => {
 			request.param( 'key', 'value' );
 			expect( request._renderQuery() ).to.equal( '?key=value' );
 			request.param( 'key', 'value' );
@@ -175,24 +175,24 @@ describe( 'WPRequest', function() {
 			expect( request._renderQuery() ).to.equal( '' );
 		});
 
-		it( 'will have no effect if called with no value', function() {
+		it( 'will have no effect if called with no value', () => {
 			request.param( 'key' );
 			expect( request._renderQuery() ).to.equal( '' );
 		});
 
-		it( 'will have no effect if called with an empty object', function() {
+		it( 'will have no effect if called with an empty object', () => {
 			request.param({});
 			expect( request._renderQuery() ).to.equal( '' );
 		});
 
-		it( 'should set the internal _params hash', function() {
+		it( 'should set the internal _params hash', () => {
 			request.param( 'type', 'some_cpt' );
 			expect( request._renderQuery() ).to.equal( '?type=some_cpt' );
 			request.param( 'context', 'edit' );
 			expect( request._renderQuery() ).to.equal( '?context=edit&type=some_cpt' );
 		});
 
-		it( 'should set multiple parameters by passing a hash object', function() {
+		it( 'should set multiple parameters by passing a hash object', () => {
 			request.param({
 				page: 309,
 				context: 'view'
@@ -200,17 +200,17 @@ describe( 'WPRequest', function() {
 			expect( request._renderQuery() ).to.equal( '?context=view&page=309' );
 		});
 
-		it( 'should de-dupe & sort array values', function() {
+		it( 'should de-dupe & sort array values', () => {
 			request.param( 'type', [ 'post', 'page', 'post', 'page', 'cpt_item' ] );
 			expect( request._renderQuery() ).to.equal( '?type%5B%5D=cpt_item&type%5B%5D=page&type%5B%5D=post' );
 		});
 
 	});
 
-	describe( '.param() convenience methods', function() {
+	describe( '.param() convenience methods', () => {
 		var getQueryStr;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			getQueryStr = function( req ) {
 				var query = req
 					._renderQuery()
@@ -219,36 +219,36 @@ describe( 'WPRequest', function() {
 			};
 		});
 
-		describe( '.context()', function() {
+		describe( '.context()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				request = new WPRequest({
 					endpoint: '/'
 				});
 			});
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'context' );
 				expect( request.context ).to.be.a( 'function' );
 			});
 
-			it( 'wraps .param()', function() {
+			it( 'wraps .param()', () => {
 				sinon.stub( request, 'param' );
 				request.context( 'view' );
 				expect( request.param ).to.have.been.calledWith( 'context', 'view' );
 			});
 
-			it( 'should map to the "context=VALUE" query parameter', function() {
+			it( 'should map to the "context=VALUE" query parameter', () => {
 				var path = request.context( 'edit' ).toString();
 				expect( path ).to.equal( '/?context=edit' );
 			});
 
-			it( 'should replace values when called multiple times', function() {
+			it( 'should replace values when called multiple times', () => {
 				var path = request.context( 'edit' ).context( 'view' ).toString();
 				expect( path ).to.equal( '/?context=view' );
 			});
 
-			it( 'should provide a .edit() shortcut for .context( "edit" )', function() {
+			it( 'should provide a .edit() shortcut for .context( "edit" )', () => {
 				sinon.spy( request, 'context' );
 				request.edit();
 				expect( request.context ).to.have.been.calledWith( 'edit' );
@@ -258,305 +258,305 @@ describe( 'WPRequest', function() {
 
 		});
 
-		describe( '.embed()', function() {
+		describe( '.embed()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'embed' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.embed ).to.be.a( 'function' );
 			});
 
-			it( 'should set the "_embed" parameter', function() {
+			it( 'should set the "_embed" parameter', () => {
 				request.embed();
 				expect( request._params._embed ).to.equal( true );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.embed() ).to.equal( request );
 			});
 
 		});
 
-		describe( '.page()', function() {
+		describe( '.page()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'page' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.page ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.page() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.page();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "page" query parameter when provided a value', function() {
+			it( 'sets the "page" query parameter when provided a value', () => {
 				var result = request.page( 7 );
 				expect( getQueryStr( result ) ).to.equal( 'page=7' );
 			});
 
-			it( 'should be chainable and replace values when called multiple times', function() {
+			it( 'should be chainable and replace values when called multiple times', () => {
 				var result = request.page( 71 ).page( 2 );
 				expect( getQueryStr( result ) ).to.equal( 'page=2' );
 			});
 
 		});
 
-		describe( '.perPage()', function() {
+		describe( '.perPage()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'perPage' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.perPage ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.perPage() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.perPage();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "per_page" query parameter when provided a value', function() {
+			it( 'sets the "per_page" query parameter when provided a value', () => {
 				var result = request.perPage( 7 );
 				expect( getQueryStr( result ) ).to.equal( 'per_page=7' );
 			});
 
-			it( 'should be chainable and replace values when called multiple times', function() {
+			it( 'should be chainable and replace values when called multiple times', () => {
 				var result = request.perPage( 71 ).perPage( 2 );
 				expect( getQueryStr( result ) ).to.equal( 'per_page=2' );
 			});
 
 		});
 
-		describe( '.offset()', function() {
+		describe( '.offset()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'offset' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.offset ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.offset() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.offset();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "offset" query parameter when provided a value', function() {
+			it( 'sets the "offset" query parameter when provided a value', () => {
 				var result = request.offset( 7 );
 				expect( getQueryStr( result ) ).to.equal( 'offset=7' );
 			});
 
-			it( 'should be chainable and replace values when called multiple times', function() {
+			it( 'should be chainable and replace values when called multiple times', () => {
 				var result = request.offset( 71 ).offset( 2 );
 				expect( getQueryStr( result ) ).to.equal( 'offset=2' );
 			});
 
 		});
 
-		describe( '.order()', function() {
+		describe( '.order()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'order' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.order ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.order() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.order();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "order" query parameter when provided a value', function() {
+			it( 'sets the "order" query parameter when provided a value', () => {
 				var result = request.order( 'asc' );
 				expect( getQueryStr( result ) ).to.equal( 'order=asc' );
 			});
 
-			it( 'should be chainable and replace values when called multiple times', function() {
+			it( 'should be chainable and replace values when called multiple times', () => {
 				var result = request.order( 'asc' ).order( 'desc' );
 				expect( getQueryStr( result ) ).to.equal( 'order=desc' );
 			});
 
 		});
 
-		describe( '.orderby()', function() {
+		describe( '.orderby()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'orderby' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.orderby ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.orderby() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.orderby();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "orderby" query parameter when provided a value', function() {
+			it( 'sets the "orderby" query parameter when provided a value', () => {
 				var result = request.orderby( 'title' );
 				expect( getQueryStr( result ) ).to.equal( 'orderby=title' );
 			});
 
-			it( 'should be chainable and replace values when called multiple times', function() {
+			it( 'should be chainable and replace values when called multiple times', () => {
 				var result = request.orderby( 'title' ).orderby( 'slug' );
 				expect( getQueryStr( result ) ).to.equal( 'orderby=slug' );
 			});
 
 		});
 
-		describe( '.search()', function() {
+		describe( '.search()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'search' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.search ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.search() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.search();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "search" query parameter when provided a value', function() {
+			it( 'sets the "search" query parameter when provided a value', () => {
 				var result = request.search( 'my search string' );
 				expect( getQueryStr( result ) ).to.equal( 'search=my search string' );
 			});
 
-			it( 'overwrites previously-set values on subsequent calls', function() {
+			it( 'overwrites previously-set values on subsequent calls', () => {
 				var result = request.search( 'query' ).search( 'newquery' );
 				expect( getQueryStr( result ) ).to.equal( 'search=newquery' );
 			});
 
 		});
 
-		describe( '.include()', function() {
+		describe( '.include()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'include' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.include ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.include() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.include();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "include" query parameter when provided a value', function() {
+			it( 'sets the "include" query parameter when provided a value', () => {
 				var result = request.include( 7 );
 				expect( getQueryStr( result ) ).to.equal( 'include=7' );
 			});
 
-			it( 'can set an array of "include" values', function() {
+			it( 'can set an array of "include" values', () => {
 				var result = request.include([ 7, 41, 98 ]);
 				expect( getQueryStr( result ) ).to.equal( 'include[]=41&include[]=7&include[]=98' );
 			});
 
-			it( 'should be chainable and replace values when called multiple times', function() {
+			it( 'should be chainable and replace values when called multiple times', () => {
 				var result = request.include( 71 ).include( 2 );
 				expect( getQueryStr( result ) ).to.equal( 'include=2' );
 			});
 
 		});
 
-		describe( '.exclude()', function() {
+		describe( '.exclude()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'exclude' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.exclude ).to.be.a( 'function' );
 			});
 
-			it( 'should be chainable', function() {
+			it( 'should be chainable', () => {
 				expect( request.exclude() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.exclude();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "exclude" query parameter when provided a value', function() {
+			it( 'sets the "exclude" query parameter when provided a value', () => {
 				var result = request.exclude( 7 );
 				expect( getQueryStr( result ) ).to.equal( 'exclude=7' );
 			});
 
-			it( 'can set an array of "exclude" values', function() {
+			it( 'can set an array of "exclude" values', () => {
 				var result = request.exclude([ 7, 41, 98 ]);
 				expect( getQueryStr( result ) ).to.equal( 'exclude[]=41&exclude[]=7&exclude[]=98' );
 			});
 
-			it( 'should be chainable and replace values when called multiple times', function() {
+			it( 'should be chainable and replace values when called multiple times', () => {
 				var result = request.exclude( 71 ).exclude( 2 );
 				expect( getQueryStr( result ) ).to.equal( 'exclude=2' );
 			});
 
 		});
 
-		describe( '.slug()', function() {
+		describe( '.slug()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( request ).to.have.property( 'slug' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( request.slug ).to.be.a( 'function' );
 			});
 
-			it( 'supports chaining', function() {
+			it( 'supports chaining', () => {
 				expect( request.slug() ).to.equal( request );
 			});
 
-			it( 'has no effect when called with no argument', function() {
+			it( 'has no effect when called with no argument', () => {
 				var result = request.slug();
 				expect( getQueryStr( result ) ).to.equal( '' );
 			});
 
-			it( 'sets the "slug" query parameter when provided a value', function() {
+			it( 'sets the "slug" query parameter when provided a value', () => {
 				var result = request.slug( 'bran-van' );
 				expect( getQueryStr( result ) ).to.equal( 'slug=bran-van' );
 			});
@@ -565,21 +565,21 @@ describe( 'WPRequest', function() {
 
 	});
 
-	describe( '.auth()', function() {
+	describe( '.auth()', () => {
 
-		it( 'is defined', function() {
+		it( 'is defined', () => {
 			expect( request ).to.have.property( 'auth' );
 			expect( request.auth ).to.be.a( 'function' );
 		});
 
-		it( 'activates authentication for the request', function() {
+		it( 'activates authentication for the request', () => {
 			expect( request._options ).not.to.have.property( 'auth' );
 			request.auth();
 			expect( request._options ).to.have.property( 'auth' );
 			expect( request._options.auth ).to.be.true;
 		});
 
-		it( 'sets the username and password when provided in an object', function() {
+		it( 'sets the username and password when provided in an object', () => {
 			expect( request._options ).not.to.have.property( 'username' );
 			expect( request._options ).not.to.have.property( 'password' );
 			request.auth({
@@ -594,7 +594,7 @@ describe( 'WPRequest', function() {
 			expect( request._options.auth ).to.be.true;
 		});
 
-		it( 'does not set username/password if they are not provided as string values', function() {
+		it( 'does not set username/password if they are not provided as string values', () => {
 			expect( request._options ).not.to.have.property( 'username' );
 			expect( request._options ).not.to.have.property( 'password' );
 			request.auth({
@@ -607,7 +607,7 @@ describe( 'WPRequest', function() {
 			expect( request._options.auth ).to.be.true;
 		});
 
-		it( 'sets the nonce when provided in an object', function() {
+		it( 'sets the nonce when provided in an object', () => {
 			expect( request._options ).not.to.have.property( 'nonce' );
 			request.auth({
 				nonce: 'nonceynonce'
@@ -618,7 +618,7 @@ describe( 'WPRequest', function() {
 			expect( request._options.auth ).to.be.true;
 		});
 
-		it( 'can update nonce credentials', function() {
+		it( 'can update nonce credentials', () => {
 			request.auth({
 				nonce: 'nonceynonce'
 			}).auth({
@@ -632,65 +632,65 @@ describe( 'WPRequest', function() {
 
 	}); // auth
 
-	describe( '.file()', function() {
+	describe( '.file()', () => {
 
-		it( 'method exists', function() {
+		it( 'method exists', () => {
 			expect( request ).to.have.property( 'file' );
 			expect( request.file ).to.be.a( 'function' );
 		});
 
-		it( 'will have no effect if called without any arguments', function() {
+		it( 'will have no effect if called without any arguments', () => {
 			request.file();
 			expect( request._attachment ).to.be.undefined;
 		});
 
-		it( 'will set a file path to upload', function() {
+		it( 'will set a file path to upload', () => {
 			request.file( '/some/file.jpg' );
 			expect( request._attachment ).to.equal( '/some/file.jpg' );
 		});
 
-		it( 'will replace previously-set file paths if called multiple times', function() {
+		it( 'will replace previously-set file paths if called multiple times', () => {
 			request.file( '/some/file.jpg' ).file( '/some/other/file.jpg' );
 			expect( request._attachment ).to.equal( '/some/other/file.jpg' );
 		});
 
-		it( 'will clear out previously-set paths if called again without any arguments', function() {
+		it( 'will clear out previously-set paths if called again without any arguments', () => {
 			request.file( '/some/file.jpg' ).file();
 			expect( request._attachment ).to.be.undefined;
 		});
 
-		it( 'will set an attachment name to use for the provided file', function() {
+		it( 'will set an attachment name to use for the provided file', () => {
 			request.file( '/some/file.jpg', 'cat_picture.jpg' );
 			expect( request._attachmentName ).to.equal( 'cat_picture.jpg' );
 		});
 
-		it( 'will clear out previously-set name if called again without a name', function() {
+		it( 'will clear out previously-set name if called again without a name', () => {
 			request.file( '/some/file.jpg', 'cat_picture.jpg' ).file( '/some/other/file.jpg' );
 			expect( request._attachmentName ).to.be.undefined;
 		});
 
 	});
 
-	describe( '.setHeaders()', function() {
+	describe( '.setHeaders()', () => {
 
-		it( 'method exists', function() {
+		it( 'method exists', () => {
 			expect( request ).to.have.property( 'setHeaders' );
 			expect( request.setHeaders ).to.be.a( 'function' );
 		});
 
-		it( 'will have no effect if called without any arguments', function() {
+		it( 'will have no effect if called without any arguments', () => {
 			request.setHeaders();
 			expect( request._options.headers ).to.deep.equal({});
 		});
 
-		it( 'will set a header key/value pair', function() {
+		it( 'will set a header key/value pair', () => {
 			request.setHeaders( 'Authorization', 'Bearer sometoken' );
 			expect( request._options.headers ).to.deep.equal({
 				Authorization: 'Bearer sometoken'
 			});
 		});
 
-		it( 'will replace an existing header key/value pair', function() {
+		it( 'will replace an existing header key/value pair', () => {
 			request
 				.setHeaders( 'Authorization', 'Bearer sometoken' )
 				.setHeaders( 'Authorization', 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==' );
@@ -699,7 +699,7 @@ describe( 'WPRequest', function() {
 			});
 		});
 
-		it( 'will set multiple header key/value pairs with chained calls', function() {
+		it( 'will set multiple header key/value pairs with chained calls', () => {
 			request
 				.setHeaders( 'Accept-Language', 'en-US' )
 				.setHeaders( 'Authorization', 'Bearer sometoken' );
@@ -709,7 +709,7 @@ describe( 'WPRequest', function() {
 			});
 		});
 
-		it( 'will set multiple header key/value pairs when passed an object', function() {
+		it( 'will set multiple header key/value pairs when passed an object', () => {
 			request.setHeaders({
 				'Accept-Language': 'en-US',
 				Authorization: 'Bearer sometoken'
@@ -720,7 +720,7 @@ describe( 'WPRequest', function() {
 			});
 		});
 
-		it( 'will replace multiple existing header key/value pairs when passed an object', function() {
+		it( 'will replace multiple existing header key/value pairs when passed an object', () => {
 			request
 				.setHeaders({
 					'Accept-Language': 'en-US',
@@ -736,7 +736,7 @@ describe( 'WPRequest', function() {
 			});
 		});
 
-		it( 'inherits headers from the constructor options object', function() {
+		it( 'inherits headers from the constructor options object', () => {
 			request = new WPRequest({
 				endpoint: '/',
 				headers: {
@@ -750,25 +750,25 @@ describe( 'WPRequest', function() {
 
 	});
 
-	describe( '.toString()', function() {
+	describe( '.toString()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			request = new WPRequest({
 				endpoint: 'http://blogoblog.com/wp-json'
 			});
 		});
 
-		it( 'renders the URL to a string', function() {
+		it( 'renders the URL to a string', () => {
 			var str = request.param( 'a', 7 ).param( 'b', [ 1, 2 ] ).toString();
 			expect( str ).to.equal( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
 		});
 
-		it( 'exhibits normal toString() behavior via coercion', function() {
+		it( 'exhibits normal toString() behavior via coercion', () => {
 			var str = '' + request.param( 'a', 7 ).param( 'b', [ 1, 2 ] );
 			expect( str ).to.equal( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
 		});
 
-		it( 'correctly merges query strings for "plain permalinks" endpoints', function() {
+		it( 'correctly merges query strings for "plain permalinks" endpoints', () => {
 			request = new WPRequest({
 				endpoint: 'https://blogoblog.com?rest_route=/'
 			});
@@ -778,36 +778,36 @@ describe( 'WPRequest', function() {
 
 	});
 
-	describe( '.setPathPart()', function() {
+	describe( '.setPathPart()', () => {
 
-		it( 'is defined', function() {
+		it( 'is defined', () => {
 			expect( request ).to.have.property( 'setPathPart' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( request.setPathPart ).to.be.a( 'function' );
 		});
 
-		it( 'is chainable', function() {
+		it( 'is chainable', () => {
 			expect( request.setPathPart() ).to.equal( request );
 		});
 
-		it( 'sets a path part', function() {
+		it( 'sets a path part', () => {
 			request.setPathPart( 0, 'foo' );
 			expect( request.toString() ).to.equal( '/foo' );
 		});
 
-		it( 'sets multiple path parts', function() {
+		it( 'sets multiple path parts', () => {
 			request.setPathPart( 0, 'foo' ).setPathPart( 1, 'bar' );
 			expect( request.toString() ).to.equal( '/foo/bar' );
 		});
 
-		it( 'sets multiple non-consecutive path parts', function() {
+		it( 'sets multiple non-consecutive path parts', () => {
 			request.setPathPart( 0, 'foo' ).setPathPart( 2, 'baz' );
 			expect( request.toString() ).to.equal( '/foo/baz' );
 		});
 
-		it( 'throws an error if called multiple times for the same level', function() {
+		it( 'throws an error if called multiple times for the same level', () => {
 			expect(function() {
 				request.setPathPart( 0, 'foo' ).setPathPart( 0, 'bar' );
 			}).to.throw( 'Cannot overwrite value foo' );
@@ -815,28 +815,28 @@ describe( 'WPRequest', function() {
 
 	});
 
-	describe( '.validatePath()', function() {
+	describe( '.validatePath()', () => {
 
-		it( 'is defined', function() {
+		it( 'is defined', () => {
 			expect( request ).to.have.property( 'validatePath' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( request.validatePath ).to.be.a( 'function' );
 		});
 
-		it( 'is chainable', function() {
+		it( 'is chainable', () => {
 			expect( request.validatePath() ).to.equal( request );
 		});
 
-		it( 'is called by toString()', function() {
+		it( 'is called by toString()', () => {
 			sinon.spy( request, 'validatePath' );
 			request.toString();
 			expect( request.validatePath ).to.have.been.called;
 			request.validatePath.restore();
 		});
 
-		it( 'allows any sequence of path parts if no _levels are specified', function() {
+		it( 'allows any sequence of path parts if no _levels are specified', () => {
 			delete request._levels;
 			expect(function() {
 				request
@@ -848,7 +848,7 @@ describe( 'WPRequest', function() {
 			expect( request.toString() ).to.equal( '/foo/baz/bar' );
 		});
 
-		it( 'allows omitted _levels so long as there are no gaps', function() {
+		it( 'allows omitted _levels so long as there are no gaps', () => {
 			request._levels = {
 				'0': [ { component: 'posts' } ],
 				'1': [ { component: '(?P<id>[\\d]+)' } ]
@@ -859,7 +859,7 @@ describe( 'WPRequest', function() {
 			expect( request.toString() ).to.equal( '/posts' );
 		});
 
-		it( 'allows any value for a level if no validate function is specified', function() {
+		it( 'allows any value for a level if no validate function is specified', () => {
 			request._levels = {
 				'0': [ { component: '(?P<id>[\\d]+)' } ]
 			};
@@ -869,7 +869,7 @@ describe( 'WPRequest', function() {
 			expect( request.toString() ).to.equal( '/foo' );
 		});
 
-		it( 'requires a level to conform to a validate function, when provided', function() {
+		it( 'requires a level to conform to a validate function, when provided', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
@@ -881,7 +881,7 @@ describe( 'WPRequest', function() {
 			}).to.throw( 'foo does not match (?P<id>[\\d]+)' );
 		});
 
-		it( 'allows any value for a level that passes a validate function, when provided', function() {
+		it( 'allows any value for a level that passes a validate function, when provided', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
@@ -894,7 +894,7 @@ describe( 'WPRequest', function() {
 			expect( request.toString() ).to.equal( '/42' );
 		});
 
-		it( 'requires a level to conform to any of several validate functions when provided', function() {
+		it( 'requires a level to conform to any of several validate functions when provided', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
@@ -912,7 +912,7 @@ describe( 'WPRequest', function() {
 			}).to.throw( 'foo does not match any of (?P<id>[\\d]+), posts, pages' );
 		});
 
-		it( 'allows any value for a level that passes any of the available validate functions', function() {
+		it( 'allows any value for a level that passes any of the available validate functions', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
@@ -931,7 +931,7 @@ describe( 'WPRequest', function() {
 			expect( request.toString() ).to.equal( '/posts' );
 		});
 
-		it( 'catches missing path parts if _levels are specified', function() {
+		it( 'catches missing path parts if _levels are specified', () => {
 			request._levels = {
 				'0': [ { component: '(?P<parent>[\\d]+)' } ],
 				'1': [ { component: 'revisions' } ]

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -41,7 +41,7 @@ describe( 'WPRequest', () => {
 	describe( '._renderQuery() [internal]', () => {
 
 		beforeEach( () => {
-			Object.keys( filterMixins ).forEach(function( mixin ) {
+			Object.keys( filterMixins ).forEach( ( mixin ) => {
 				if ( ! request[ mixin ] ) {
 					request[ mixin ] = filterMixins[ mixin ];
 				}
@@ -106,7 +106,7 @@ describe( 'WPRequest', () => {
 		it( 'should throw an error when called with an unsupported method', () => {
 			request._supportedMethods = [ 'get' ];
 
-			expect(function() {
+			expect( () => {
 				checkMethodSupport( 'post', request );
 			}).to.throw();
 		});
@@ -211,7 +211,7 @@ describe( 'WPRequest', () => {
 		var getQueryStr;
 
 		beforeEach( () => {
-			getQueryStr = function( req ) {
+			getQueryStr = ( req ) => {
 				var query = req
 					._renderQuery()
 					.replace( /^\?/, '' );
@@ -808,7 +808,7 @@ describe( 'WPRequest', () => {
 		});
 
 		it( 'throws an error if called multiple times for the same level', () => {
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 0, 'foo' ).setPathPart( 0, 'bar' );
 			}).to.throw( 'Cannot overwrite value foo' );
 		});
@@ -838,7 +838,7 @@ describe( 'WPRequest', () => {
 
 		it( 'allows any sequence of path parts if no _levels are specified', () => {
 			delete request._levels;
-			expect(function() {
+			expect( () => {
 				request
 					.setPathPart( 0, 'foo' )
 					.setPathPart( 4, 'bar' )
@@ -853,7 +853,7 @@ describe( 'WPRequest', () => {
 				'0': [ { component: 'posts' } ],
 				'1': [ { component: '(?P<id>[\\d]+)' } ]
 			};
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 0, 'posts' ).validatePath();
 			}).not.to.throw();
 			expect( request.toString() ).to.equal( '/posts' );
@@ -863,7 +863,7 @@ describe( 'WPRequest', () => {
 			request._levels = {
 				'0': [ { component: '(?P<id>[\\d]+)' } ]
 			};
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 0, 'foo' ).validatePath();
 			}).not.to.throw();
 			expect( request.toString() ).to.equal( '/foo' );
@@ -873,10 +873,10 @@ describe( 'WPRequest', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
-					validate: function( val ) { return /^[\d]+$/.test( val ); }
+					validate: ( val ) => /^[\d]+$/.test( val )
 				} ]
 			};
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 0, 'foo' ).validatePath();
 			}).to.throw( 'foo does not match (?P<id>[\\d]+)' );
 		});
@@ -885,10 +885,10 @@ describe( 'WPRequest', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
-					validate: function( val ) { return /^[\d]+$/.test( val ); }
+					validate: ( val ) => /^[\d]+$/.test( val )
 				} ]
 			};
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 0, '42' ).validatePath();
 			}).not.to.throw();
 			expect( request.toString() ).to.equal( '/42' );
@@ -898,16 +898,16 @@ describe( 'WPRequest', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
-					validate: function( val ) { return /^[\d]+$/.test( val ); }
+					validate: ( val ) => /^[\d]+$/.test( val )
 				}, {
 					component: 'posts',
-					validate: function( val ) { return 'posts' === val; }
+					validate: ( val ) => 'posts' === val
 				}, {
 					component: 'pages',
-					validate: function( val ) { return 'pages' === val; }
+					validate: ( val ) => 'pages' === val
 				} ]
 			};
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 0, 'foo' ).validatePath();
 			}).to.throw( 'foo does not match any of (?P<id>[\\d]+), posts, pages' );
 		});
@@ -916,16 +916,16 @@ describe( 'WPRequest', () => {
 			request._levels = {
 				'0': [ {
 					component: '(?P<id>[\\d]+)',
-					validate: function( val ) { return /^[\d]+$/.test( val ); }
+					validate: ( val ) => /^[\d]+$/.test( val )
 				}, {
 					component: 'posts',
-					validate: function( val ) { return 'posts' === val; }
+					validate: ( val ) => 'posts' === val
 				}, {
 					component: 'pages',
-					validate: function( val ) { return 'pages' === val; }
+					validate: ( val ) => 'pages' === val
 				} ]
 			};
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 0, 'posts' ).validatePath();
 			}).not.to.throw();
 			expect( request.toString() ).to.equal( '/posts' );
@@ -937,7 +937,7 @@ describe( 'WPRequest', () => {
 				'1': [ { component: 'revisions' } ]
 				// '2': [ { component: '(?P<id>[\\d]+)' } ]
 			};
-			expect(function() {
+			expect( () => {
 				request.setPathPart( 1, 'revisions' ).validatePath();
 			}).to.throw( 'Incomplete URL! Missing component: / ??? /revisions' );
 		});

--- a/tests/unit/lib/data/simplify-object.js
+++ b/tests/unit/lib/data/simplify-object.js
@@ -5,35 +5,35 @@ var simplifyObject = require( '../../../../lib/data/simplify-object' );
 
 var fullPostsCollectionRouteDefinition = require( './posts-collection-route-definition.json' );
 
-describe( 'simplifyObject', function() {
+describe( 'simplifyObject', () => {
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( simplifyObject ).to.be.a( 'function' );
 	});
 
-	it( 'passes through strings without modification', function() {
+	it( 'passes through strings without modification', () => {
 		expect( simplifyObject( 'foo' ) ).to.be.a( 'string' );
 		expect( simplifyObject( 'foo' ) ).to.equal( 'foo' );
 	});
 
-	it( 'passes through numbers without modification', function() {
+	it( 'passes through numbers without modification', () => {
 		expect( simplifyObject( 7 ) ).to.be.a( 'number' );
 		expect( simplifyObject( 7 ) ).to.equal( 7 );
 	});
 
-	it( 'passes through booleans without modification', function() {
+	it( 'passes through booleans without modification', () => {
 		expect( simplifyObject( true ) ).to.be.a( 'boolean' );
 		expect( simplifyObject( true ) ).to.equal( true );
 	});
 
-	it( 'passes through arrays of simple values without modification', function() {
+	it( 'passes through arrays of simple values without modification', () => {
 		expect( simplifyObject([]) ).to.be.an( 'array' );
 		expect( simplifyObject([ 1, 2, 3 ]) ).to.deep.equal([ 1, 2, 3 ]);
 		expect( simplifyObject([ 'a', 'b', 'c' ]) ).to.deep.equal([ 'a', 'b', 'c' ]);
 		expect( simplifyObject([ true, false ]) ).to.deep.equal([ true, false ]);
 	});
 
-	it( 'passes through most objects without modification', function() {
+	it( 'passes through most objects without modification', () => {
 		expect( simplifyObject({
 			some: 'set',
 			of: 'basic',
@@ -55,7 +55,7 @@ describe( 'simplifyObject', function() {
 		});
 	});
 
-	it( 'strips out _links properties', function() {
+	it( 'strips out _links properties', () => {
 		expect( simplifyObject({
 			some: 'object with a',
 			_links: {
@@ -66,7 +66,7 @@ describe( 'simplifyObject', function() {
 		});
 	});
 
-	it( 'removes unneeded keys from children of .args objects', function() {
+	it( 'removes unneeded keys from children of .args objects', () => {
 		expect( simplifyObject({
 			args: {
 				context: {
@@ -82,7 +82,7 @@ describe( 'simplifyObject', function() {
 		});
 	});
 
-	it( 'properly transforms a full route definition object', function() {
+	it( 'properly transforms a full route definition object', () => {
 		expect( simplifyObject( fullPostsCollectionRouteDefinition ) ).to.deep.equal({
 			namespace: 'wp/v2',
 			methods: [ 'GET', 'POST' ],

--- a/tests/unit/lib/mixins/filters.js
+++ b/tests/unit/lib/mixins/filters.js
@@ -6,12 +6,12 @@ var inherit = require( 'util' ).inherits;
 var filterMixins = require( '../../../../lib/mixins/filters' );
 var WPRequest = require( '../../../../lib/constructors/wp-request' );
 
-describe( 'mixins: filter', function() {
+describe( 'mixins: filter', () => {
 	var Req;
 	var req;
 	var getQueryStr;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		Req = function() {
 			WPRequest.apply( this, arguments );
 		};
@@ -27,55 +27,55 @@ describe( 'mixins: filter', function() {
 		};
 	});
 
-	describe( '.filter()', function() {
+	describe( '.filter()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.filter = filterMixins.filter;
 		});
 
-		it( 'mixin method is defined', function() {
+		it( 'mixin method is defined', () => {
 			expect( filterMixins ).to.have.property( 'filter' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( filterMixins.filter ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.filter() ).to.equal( req );
 		});
 
-		it( 'will nave no effect if called with no filter value', function() {
+		it( 'will nave no effect if called with no filter value', () => {
 			var result = req.filter( 'a' );
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'sets the filter query parameter on a request instance', function() {
+		it( 'sets the filter query parameter on a request instance', () => {
 			var result = req.filter( 'a', 'b' );
 			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b' );
 		});
 
-		it( 'can set multiple filters on the request', function() {
+		it( 'can set multiple filters on the request', () => {
 			var result = req.filter( 'a', 'b' ).filter( 'c', 'd' );
 			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b&filter[c]=d' );
 		});
 
-		it( 'will overwrite previously-set filter values', function() {
+		it( 'will overwrite previously-set filter values', () => {
 			var result = req.filter( 'a', 'b' ).filter( 'a', 'd' );
 			expect( getQueryStr( result ) ).to.equal( 'filter[a]=d' );
 		});
 
-		it( 'will unset a filter if called with an empty string', function() {
+		it( 'will unset a filter if called with an empty string', () => {
 			var result = req.filter( 'a', 'b' ).filter( 'a', '' );
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'will unset a filter if called with null', function() {
+		it( 'will unset a filter if called with null', () => {
 			var result = req.filter( 'a', 'b' ).filter( 'a', null );
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'can set multiple filters in one call when passed an object', function() {
+		it( 'can set multiple filters in one call when passed an object', () => {
 			var result = req.filter({
 				a: 'b',
 				c: 'd',
@@ -84,7 +84,7 @@ describe( 'mixins: filter', function() {
 			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b&filter[c]=d&filter[e]=f' );
 		});
 
-		it( 'can set multiple filters on the request when passed an object', function() {
+		it( 'can set multiple filters on the request when passed an object', () => {
 			var result = req
 				.filter({
 					a: 'b',
@@ -96,7 +96,7 @@ describe( 'mixins: filter', function() {
 			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b&filter[c]=d&filter[e]=f' );
 		});
 
-		it( 'will overwrite multiple previously-set filter values when passed an object', function() {
+		it( 'will overwrite multiple previously-set filter values when passed an object', () => {
 			var result = req
 				.filter({
 					a: 'b',
@@ -113,68 +113,68 @@ describe( 'mixins: filter', function() {
 
 	});
 
-	describe( 'taxonomy()', function() {
+	describe( 'taxonomy()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.taxonomy = filterMixins.taxonomy;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( filterMixins ).to.have.property( 'taxonomy' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( filterMixins.taxonomy ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.taxonomy( 'tag', 'foo' ) ).to.equal( req );
 		});
 
-		describe( 'argument type check errors', function() {
+		describe( 'argument type check errors', () => {
 
-			it( 'errors if no term is provided', function() {
+			it( 'errors if no term is provided', () => {
 				expect(function() { req.taxonomy( 'tag' ); }).to.throw();
 			});
 
-			it( 'does not error if the term is a string', function() {
+			it( 'does not error if the term is a string', () => {
 				expect(function() { req.taxonomy( 'tag', 'cat' ); }).not.to.throw();
 			});
 
-			it( 'does not error if the term is an array of strings', function() {
+			it( 'does not error if the term is an array of strings', () => {
 				expect(function() { req.taxonomy( 'tag', [ 'cat', 'dog' ] ); }).not.to.throw();
 			});
 
-			it( 'does not error if term is a number', function() {
+			it( 'does not error if term is a number', () => {
 				expect(function() { req.taxonomy( 'cat', 7 ); }).not.to.throw();
 			});
 
-			it( 'does not error if term is an array of numbers', function() {
+			it( 'does not error if term is an array of numbers', () => {
 				expect(function() { req.taxonomy( 'cat', [ 7, 11 ] ); }).not.to.throw();
 			});
 
-			it( 'errors if the term is null', function() {
+			it( 'errors if the term is null', () => {
 				expect(function() { req.taxonomy( 'tag', null ); }).to.throw();
 			});
 
-			it( 'errors if the term is a boolean', function() {
+			it( 'errors if the term is a boolean', () => {
 				expect(function() { req.taxonomy( 'tag', true ); }).to.throw();
 				expect(function() { req.taxonomy( 'tag', false ); }).to.throw();
 			});
 
-			it( 'errors if the term is a Date', function() {
+			it( 'errors if the term is a Date', () => {
 				expect(function() { req.taxonomy( 'tag', new Date() ); }).to.throw();
 			});
 
-			it( 'errors if the term is an object', function() {
+			it( 'errors if the term is an object', () => {
 				expect(function() { req.taxonomy( 'tag', {} ); }).to.throw();
 			});
 
-			it( 'errors if the term is an array of types other than strings or numbers', function() {
+			it( 'errors if the term is an array of types other than strings or numbers', () => {
 				expect(function() { req.taxonomy( 'tag', [ null ] ); }).to.throw();
 			});
 
-			it( 'errors if the term is not all strings or numbers', function() {
+			it( 'errors if the term is not all strings or numbers', () => {
 				expect(function() { req.taxonomy( 'tag', [ 'cat', null ] ); }).to.throw();
 				expect(function() { req.taxonomy( 'cat', [ 7, null ] ); }).to.throw();
 				expect(function() { req.taxonomy( 'cat', [ 'foo', 7 ] ); }).to.throw();
@@ -182,33 +182,33 @@ describe( 'mixins: filter', function() {
 
 		});
 
-		describe( 'filter name aliasing behavior', function() {
+		describe( 'filter name aliasing behavior', () => {
 
-			it( 'sets the "category_name" filter for categories where the term is a string', function() {
+			it( 'sets the "category_name" filter for categories where the term is a string', () => {
 				var result = req.taxonomy( 'category', 'str' );
 				expect( getQueryStr( result ) ).to.equal( 'filter[category_name]=str' );
 			});
 
-			it( 'sets the "cat" filter for categories where the term is a number', function() {
+			it( 'sets the "cat" filter for categories where the term is a number', () => {
 				var result = req.taxonomy( 'category', 7 );
 				expect( getQueryStr( result ) ).to.equal( 'filter[cat]=7' );
 			});
 
-			it( 'sets the "tag" filter if the taxonomy is "post_tag"', function() {
+			it( 'sets the "tag" filter if the taxonomy is "post_tag"', () => {
 				var result = req.taxonomy( 'post_tag', 'sometag' );
 				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=sometag' );
 			});
 
 		});
 
-		describe( 'filter value setting behavior', function() {
+		describe( 'filter value setting behavior', () => {
 
-			it( 'de-duplicates taxonomy terms (will only set a term once)', function() {
+			it( 'de-duplicates taxonomy terms (will only set a term once)', () => {
 				var result = req.taxonomy( 'tag', 'cat' ).taxonomy( 'tag', 'cat' );
 				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=cat' );
 			});
 
-			it( 'de-dupes the taxonomy list when called with an array', function() {
+			it( 'de-dupes the taxonomy list when called with an array', () => {
 				req.taxonomy( 'post_tag', [
 					'disclosure',
 					'alunageorge',
@@ -222,25 +222,25 @@ describe( 'mixins: filter', function() {
 				});
 			});
 
-			it( 'supports setting an array of string terms', function() {
+			it( 'supports setting an array of string terms', () => {
 				// TODO: Multiple terms may be deprecated by API!
 				var result = req.taxonomy( 'tag', [ 'a', 'b' ] );
 				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=a+b' );
 			});
 
-			it( 'supports setting an array of numeric terms', function() {
+			it( 'supports setting an array of numeric terms', () => {
 				// TODO: Multiple terms may be deprecated by API!
 				var result = req.taxonomy( 'tag', [ 1, 2 ] );
 				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=1+2' );
 			});
 
-			it( 'does not overwrite previously-specified terms on subsequent calls', function() {
+			it( 'does not overwrite previously-specified terms on subsequent calls', () => {
 				// TODO: Multiple terms may be deprecated by API!
 				var result = req.taxonomy( 'tag', 'a' ).taxonomy( 'tag', [ 'b' ] );
 				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=a+b' );
 			});
 
-			it( 'sorts provided terms', function() {
+			it( 'sorts provided terms', () => {
 				var result = req.taxonomy( 'tag', 'z' ).taxonomy( 'tag', 'a' );
 				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=a+z' );
 			});
@@ -249,144 +249,144 @@ describe( 'mixins: filter', function() {
 
 	});
 
-	describe( '.path()', function() {
+	describe( '.path()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.path = filterMixins.path;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( filterMixins ).to.have.property( 'path' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( filterMixins.path ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.path( 'tag', 'foo' ) ).to.equal( req );
 		});
 
-		it( 'should create the URL for retrieving a post by path', function() {
+		it( 'should create the URL for retrieving a post by path', () => {
 			var path = req.path( 'nested/page' );
 			expect( getQueryStr( path ) ).to.equal( 'filter[pagename]=nested/page' );
 		});
 
 	});
 
-	describe( 'date filters', function() {
+	describe( 'date filters', () => {
 
-		describe( 'year()', function() {
+		describe( 'year()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				// By only applying .year and not .filter, we implicitly test that
 				// .year does not depend on the .filter mixin having been added
 				Req.prototype.year = filterMixins.year;
 			});
 
-			it( 'mixin is defined', function() {
+			it( 'mixin is defined', () => {
 				expect( filterMixins ).to.have.property( 'year' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( filterMixins.year ).to.be.a( 'function' );
 			});
 
-			it( 'supports chaining', function() {
+			it( 'supports chaining', () => {
 				expect( req.year( 'foo' ) ).to.equal( req );
 			});
 
-			it( 'is an alias for .filter( "year", ... )', function() {
+			it( 'is an alias for .filter( "year", ... )', () => {
 				Req.prototype.filter = filterMixins.filter;
 				var result1 = ( new Req() ).year( '2015' );
 				var result2 = ( new Req() ).filter( 'year', '2015' );
 				expect( getQueryStr( result1 ) ).to.equal( getQueryStr( result2 ) );
 			});
 
-			it( 'sets the "year" filter', function() {
+			it( 'sets the "year" filter', () => {
 				var result = req.year( 'str' );
 				expect( getQueryStr( result ) ).to.equal( 'filter[year]=str' );
 			});
 
 		});
 
-		describe( 'month()', function() {
+		describe( 'month()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				// By only applying .month and not .filter, we implicitly test that
 				// .month does not depend on the .filter mixin having been added
 				Req.prototype.month = filterMixins.month;
 			});
 
-			it( 'mixin is defined', function() {
+			it( 'mixin is defined', () => {
 				expect( filterMixins ).to.have.property( 'month' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( filterMixins.month ).to.be.a( 'function' );
 			});
 
-			it( 'supports chaining', function() {
+			it( 'supports chaining', () => {
 				expect( req.month( 'foo' ) ).to.equal( req );
 			});
 
-			it( 'is an alias for .filter( "monthnum", ... )', function() {
+			it( 'is an alias for .filter( "monthnum", ... )', () => {
 				Req.prototype.filter = filterMixins.filter;
 				var result1 = ( new Req() ).month( 7 );
 				var result2 = ( new Req() ).filter( 'monthnum', 7 );
 				expect( getQueryStr( result1 ) ).to.equal( getQueryStr( result2 ) );
 			});
 
-			it( 'sets the "monthnum" filter', function() {
+			it( 'sets the "monthnum" filter', () => {
 				var result = req.month( 1 );
 				expect( getQueryStr( result ) ).to.equal( 'filter[monthnum]=1' );
 			});
 
-			it( 'converts named months into their numeric monthnum equivalent', function() {
+			it( 'converts named months into their numeric monthnum equivalent', () => {
 				var result = req.month( 'March' );
 				expect( getQueryStr( result ) ).to.equal( 'filter[monthnum]=3' );
 			});
 
-			it( 'returns without setting any filter if an invalid month string is provided', function() {
+			it( 'returns without setting any filter if an invalid month string is provided', () => {
 				var result = req.month( 'Not a month' ).toString();
 				expect( result.match( /filter/ ) ).to.equal( null );
 			});
 
-			it( 'returns without setting any filter if an invalid argument is provided', function() {
+			it( 'returns without setting any filter if an invalid argument is provided', () => {
 				var result = req.month( [ 'arrrr', 'i', 'be', 'an', 'array!' ] ).toString();
 				expect( result.match( /filter/ ) ).to.equal( null );
 			});
 
 		});
 
-		describe( 'day()', function() {
+		describe( 'day()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				// By only applying .day and not .filter, we implicitly test that
 				// .day does not depend on the .filter mixin having been added
 				Req.prototype.day = filterMixins.day;
 			});
 
-			it( 'mixin is defined', function() {
+			it( 'mixin is defined', () => {
 				expect( filterMixins ).to.have.property( 'day' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( filterMixins.day ).to.be.a( 'function' );
 			});
 
-			it( 'supports chaining', function() {
+			it( 'supports chaining', () => {
 				expect( req.day( 'foo' ) ).to.equal( req );
 			});
 
-			it( 'is an alias for .filter( "day", ... )', function() {
+			it( 'is an alias for .filter( "day", ... )', () => {
 				Req.prototype.filter = filterMixins.filter;
 				var result1 = ( new Req() ).day( '2015' );
 				var result2 = ( new Req() ).filter( 'day', '2015' );
 				expect( getQueryStr( result1 ) ).to.equal( getQueryStr( result2 ) );
 			});
 
-			it( 'sets the "day" filter', function() {
+			it( 'sets the "day" filter', () => {
 				var result = req.day( 'str' );
 				expect( getQueryStr( result ) ).to.equal( 'filter[day]=str' );
 			});

--- a/tests/unit/lib/mixins/filters.js
+++ b/tests/unit/lib/mixins/filters.js
@@ -19,7 +19,7 @@ describe( 'mixins: filter', () => {
 
 		req = new Req();
 
-		getQueryStr = function( req ) {
+		getQueryStr = ( req ) => {
 			var query = req
 				._renderQuery()
 				.replace( /^\?/, '' );
@@ -134,50 +134,50 @@ describe( 'mixins: filter', () => {
 		describe( 'argument type check errors', () => {
 
 			it( 'errors if no term is provided', () => {
-				expect(function() { req.taxonomy( 'tag' ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag' ); }).to.throw();
 			});
 
 			it( 'does not error if the term is a string', () => {
-				expect(function() { req.taxonomy( 'tag', 'cat' ); }).not.to.throw();
+				expect( () => { req.taxonomy( 'tag', 'cat' ); }).not.to.throw();
 			});
 
 			it( 'does not error if the term is an array of strings', () => {
-				expect(function() { req.taxonomy( 'tag', [ 'cat', 'dog' ] ); }).not.to.throw();
+				expect( () => { req.taxonomy( 'tag', [ 'cat', 'dog' ] ); }).not.to.throw();
 			});
 
 			it( 'does not error if term is a number', () => {
-				expect(function() { req.taxonomy( 'cat', 7 ); }).not.to.throw();
+				expect( () => { req.taxonomy( 'cat', 7 ); }).not.to.throw();
 			});
 
 			it( 'does not error if term is an array of numbers', () => {
-				expect(function() { req.taxonomy( 'cat', [ 7, 11 ] ); }).not.to.throw();
+				expect( () => { req.taxonomy( 'cat', [ 7, 11 ] ); }).not.to.throw();
 			});
 
 			it( 'errors if the term is null', () => {
-				expect(function() { req.taxonomy( 'tag', null ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag', null ); }).to.throw();
 			});
 
 			it( 'errors if the term is a boolean', () => {
-				expect(function() { req.taxonomy( 'tag', true ); }).to.throw();
-				expect(function() { req.taxonomy( 'tag', false ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag', true ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag', false ); }).to.throw();
 			});
 
 			it( 'errors if the term is a Date', () => {
-				expect(function() { req.taxonomy( 'tag', new Date() ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag', new Date() ); }).to.throw();
 			});
 
 			it( 'errors if the term is an object', () => {
-				expect(function() { req.taxonomy( 'tag', {} ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag', {} ); }).to.throw();
 			});
 
 			it( 'errors if the term is an array of types other than strings or numbers', () => {
-				expect(function() { req.taxonomy( 'tag', [ null ] ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag', [ null ] ); }).to.throw();
 			});
 
 			it( 'errors if the term is not all strings or numbers', () => {
-				expect(function() { req.taxonomy( 'tag', [ 'cat', null ] ); }).to.throw();
-				expect(function() { req.taxonomy( 'cat', [ 7, null ] ); }).to.throw();
-				expect(function() { req.taxonomy( 'cat', [ 'foo', 7 ] ); }).to.throw();
+				expect( () => { req.taxonomy( 'tag', [ 'cat', null ] ); }).to.throw();
+				expect( () => { req.taxonomy( 'cat', [ 7, null ] ); }).to.throw();
+				expect( () => { req.taxonomy( 'cat', [ 'foo', 7 ] ); }).to.throw();
 			});
 
 		});

--- a/tests/unit/lib/mixins/parameters.js
+++ b/tests/unit/lib/mixins/parameters.js
@@ -19,7 +19,7 @@ describe( 'mixins: parameters', () => {
 
 		req = new Req();
 
-		getQueryStr = function( req ) {
+		getQueryStr = ( req ) => {
 			var query = req
 				._renderQuery()
 				.replace( /^\?/, '' );
@@ -48,7 +48,7 @@ describe( 'mixins: parameters', () => {
 			});
 
 			it( 'throws an error when called with a missing or invalid time', () => {
-				expect(function() {
+				expect( () => {
 					req.before();
 				}).to.throw( 'Invalid time value' );
 			});
@@ -86,7 +86,7 @@ describe( 'mixins: parameters', () => {
 			});
 
 			it( 'throws an error when called with a missing or invalid time', () => {
-				expect(function() {
+				expect( () => {
 					req.after();
 				}).to.throw( 'Invalid time value' );
 			});
@@ -131,7 +131,7 @@ describe( 'mixins: parameters', () => {
 		});
 
 		it( 'throws an error when called with a non-string, non-numeric value', () => {
-			expect(function() { req.author({}); }).to.throw();
+			expect( () => { req.author({}); }).to.throw();
 		});
 
 		it( 'sets the "author" query parameter when provided a numeric value', () => {

--- a/tests/unit/lib/mixins/parameters.js
+++ b/tests/unit/lib/mixins/parameters.js
@@ -6,12 +6,12 @@ var inherit = require( 'util' ).inherits;
 var parameterMixins = require( '../../../../lib/mixins/parameters' );
 var WPRequest = require( '../../../../lib/constructors/wp-request' );
 
-describe( 'mixins: parameters', function() {
+describe( 'mixins: parameters', () => {
 	var Req;
 	var req;
 	var getQueryStr;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		Req = function() {
 			WPRequest.apply( this, arguments );
 		};
@@ -27,38 +27,38 @@ describe( 'mixins: parameters', function() {
 		};
 	});
 
-	describe( 'date parameters', function() {
+	describe( 'date parameters', () => {
 
-		describe( '.before()', function() {
+		describe( '.before()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				Req.prototype.before = parameterMixins.before;
 			});
 
-			it( 'mixin method is defined', function() {
+			it( 'mixin method is defined', () => {
 				expect( parameterMixins ).to.have.property( 'before' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( parameterMixins.before ).to.be.a( 'function' );
 			});
 
-			it( 'supports chaining', function() {
+			it( 'supports chaining', () => {
 				expect( req.before( '1933-11-01' ) ).to.equal( req );
 			});
 
-			it( 'throws an error when called with a missing or invalid time', function() {
+			it( 'throws an error when called with a missing or invalid time', () => {
 				expect(function() {
 					req.before();
 				}).to.throw( 'Invalid time value' );
 			});
 
-			it( 'sets the "before" query parameter as an ISO 8601 Date', function() {
+			it( 'sets the "before" query parameter as an ISO 8601 Date', () => {
 				var result = req.before( '2016-07-01' );
 				expect( getQueryStr( result ) ).to.equal( 'before=2016-07-01T00:00:00.000Z' );
 			});
 
-			it( 'sets the "before" query parameter when provided a Date object', function() {
+			it( 'sets the "before" query parameter when provided a Date object', () => {
 				var date = new Date( 1986, 2, 22 );
 				var result = req.before( date );
 				// use .match and regex to avoid time zone-induced false negatives
@@ -67,36 +67,36 @@ describe( 'mixins: parameters', function() {
 
 		});
 
-		describe( '.after()', function() {
+		describe( '.after()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				Req.prototype.after = parameterMixins.after;
 			});
 
-			it( 'mixin method is defined', function() {
+			it( 'mixin method is defined', () => {
 				expect( parameterMixins ).to.have.property( 'after' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( parameterMixins.after ).to.be.a( 'function' );
 			});
 
-			it( 'supports chaining', function() {
+			it( 'supports chaining', () => {
 				expect( req.after( '1992-04-22' ) ).to.equal( req );
 			});
 
-			it( 'throws an error when called with a missing or invalid time', function() {
+			it( 'throws an error when called with a missing or invalid time', () => {
 				expect(function() {
 					req.after();
 				}).to.throw( 'Invalid time value' );
 			});
 
-			it( 'sets the "after" query parameter when provided a value', function() {
+			it( 'sets the "after" query parameter when provided a value', () => {
 				var result = req.after( '2016-03-22' );
 				expect( getQueryStr( result ) ).to.equal( 'after=2016-03-22T00:00:00.000Z' );
 			});
 
-			it( 'sets the "after" query parameter when provided a Date object', function() {
+			it( 'sets the "after" query parameter when provided a Date object', () => {
 				var date = new Date( 1987, 11, 7 );
 				var result = req.after( date );
 				// use .match and regex to avoid time zone-induced false negatives
@@ -107,450 +107,450 @@ describe( 'mixins: parameters', function() {
 
 	});
 
-	describe( '.author()', function() {
+	describe( '.author()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.author = parameterMixins.author;
 		});
 
-		it( 'mixin method is defined', function() {
+		it( 'mixin method is defined', () => {
 			expect( parameterMixins ).to.have.property( 'author' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.author ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.author( 1 ) ).to.equal( req );
 		});
 
-		it( 'has no effect when called with no argument', function() {
+		it( 'has no effect when called with no argument', () => {
 			var result = req.author();
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'throws an error when called with a non-string, non-numeric value', function() {
+		it( 'throws an error when called with a non-string, non-numeric value', () => {
 			expect(function() { req.author({}); }).to.throw();
 		});
 
-		it( 'sets the "author" query parameter when provided a numeric value', function() {
+		it( 'sets the "author" query parameter when provided a numeric value', () => {
 			var result = req.author( 1138 );
 			expect( getQueryStr( result ) ).to.equal( 'author=1138' );
 		});
 
-		it( 'sets the "author_name" filter when provided a string value', function() {
+		it( 'sets the "author_name" filter when provided a string value', () => {
 			var result = req.author( 'jamesagarfield' );
 			expect( getQueryStr( result ) ).to.equal( 'filter[author_name]=jamesagarfield' );
 		});
 
-		it( 'is chainable, and replaces author_name values on subsequent calls', function() {
+		it( 'is chainable, and replaces author_name values on subsequent calls', () => {
 			var result = req.author( 'fforde' ).author( 'bronte' );
 			expect( result ).to.equal( req );
 			expect( getQueryStr( result ) ).to.equal( 'filter[author_name]=bronte' );
 		});
 
-		it( 'is chainable, and replaces author ID values on subsequent calls', function() {
+		it( 'is chainable, and replaces author ID values on subsequent calls', () => {
 			var result = req.author( 1847 );
 			expect( getQueryStr( result ) ).to.equal( 'author=1847' );
 		});
 
-		it( 'unsets author when called with an empty string', function() {
+		it( 'unsets author when called with an empty string', () => {
 			var result = req.author( 'jorge-luis-borges' ).author( '' );
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'unsets author when called with null', function() {
+		it( 'unsets author when called with null', () => {
 			var result = req.author( 7 ).author( null );
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'unsets author parameter when called with author name string', function() {
+		it( 'unsets author parameter when called with author name string', () => {
 			var result = req.author( 7 ).author( 'haruki-murakami' );
 			expect( getQueryStr( result ) ).to.equal( 'filter[author_name]=haruki-murakami' );
 		});
 
-		it( 'unsets author name filter when called with numeric author id', function() {
+		it( 'unsets author name filter when called with numeric author id', () => {
 			var result = req.author( 'haruki-murakami' ).author( 7 );
 			expect( getQueryStr( result ) ).to.equal( 'author=7' );
 		});
 
 	});
 
-	describe( '.parent()', function() {
+	describe( '.parent()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.parent = parameterMixins.parent;
 		});
 
-		it( 'mixin method is defined', function() {
+		it( 'mixin method is defined', () => {
 			expect( parameterMixins ).to.have.property( 'parent' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.parent ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.parent() ).to.equal( req );
 		});
 
-		it( 'has no effect when called with no argument', function() {
+		it( 'has no effect when called with no argument', () => {
 			var result = req.parent();
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'sets the "parent" query parameter when provided a value', function() {
+		it( 'sets the "parent" query parameter when provided a value', () => {
 			var result = req.parent( 42 );
 			expect( getQueryStr( result ) ).to.equal( 'parent=42' );
 		});
 
-		it( 'replaces values on subsequent calls', function() {
+		it( 'replaces values on subsequent calls', () => {
 			var result = req.parent( 42 ).parent( 2501 );
 			expect( getQueryStr( result ) ).to.equal( 'parent=2501' );
 		});
 
-		it( 'can pass an array of parent values', function() {
+		it( 'can pass an array of parent values', () => {
 			var result = req.parent([ 42, 2501 ]);
 			expect( getQueryStr( result ) ).to.equal( 'parent[]=2501&parent[]=42' );
 		});
 
 	});
 
-	describe( '.post()', function() {
+	describe( '.post()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.post = parameterMixins.post;
 		});
 
-		it( 'mixin method is defined', function() {
+		it( 'mixin method is defined', () => {
 			expect( parameterMixins ).to.have.property( 'post' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.post ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.post() ).to.equal( req );
 		});
 
-		it( 'has no effect when called with no argument', function() {
+		it( 'has no effect when called with no argument', () => {
 			var result = req.post();
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'sets the "post" query parameter when provided a value', function() {
+		it( 'sets the "post" query parameter when provided a value', () => {
 			var result = req.post( 3263827 );
 			expect( getQueryStr( result ) ).to.equal( 'post=3263827' );
 		});
 
-		it( 'overwrites previously-set values on subsequent calls', function() {
+		it( 'overwrites previously-set values on subsequent calls', () => {
 			var result = req.post( 1138 ).post( 2501 );
 			expect( getQueryStr( result ) ).to.equal( 'post=2501' );
 		});
 
 	});
 
-	describe( '.password()', function() {
+	describe( '.password()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.password = parameterMixins.password;
 		});
 
-		it( 'mixin method is defined', function() {
+		it( 'mixin method is defined', () => {
 			expect( parameterMixins ).to.have.property( 'password' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.password ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.password() ).to.equal( req );
 		});
 
-		it( 'has no effect when called with no argument', function() {
+		it( 'has no effect when called with no argument', () => {
 			var result = req.password();
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'sets the "password" query parameter when provided a value', function() {
+		it( 'sets the "password" query parameter when provided a value', () => {
 			var result = req.password( 'correct horse battery staple' );
 			expect( getQueryStr( result ) ).to.equal( 'password=correct horse battery staple' );
 		});
 
-		it( 'overwrites previously-set values on subsequent calls', function() {
+		it( 'overwrites previously-set values on subsequent calls', () => {
 			var result = req.password( 'correct horse' ).password( 'battery staple' );
 			expect( getQueryStr( result ) ).to.equal( 'password=battery staple' );
 		});
 
 	});
 
-	describe( '.status()', function() {
+	describe( '.status()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.status = parameterMixins.status;
 		});
 
-		it( 'mixin method is defined', function() {
+		it( 'mixin method is defined', () => {
 			expect( parameterMixins ).to.have.property( 'status' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.status ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.status( 'publish' ) ).to.equal( req );
 		});
 
-		it( 'sets the "status" query parameter when provided a value', function() {
+		it( 'sets the "status" query parameter when provided a value', () => {
 			var result = req.status( 'future' );
 			expect( getQueryStr( result ) ).to.equal( 'status=future' );
 		});
 
-		it( 'sets an array of "status" query values when provided an array of strings', function() {
+		it( 'sets an array of "status" query values when provided an array of strings', () => {
 			var result = req.status([ 'future', 'draft' ]);
 			expect( getQueryStr( result ) ).to.equal( 'status[]=draft&status[]=future' );
 		});
 
 	});
 
-	describe( '.sticky()', function() {
+	describe( '.sticky()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.sticky = parameterMixins.sticky;
 		});
 
-		it( 'mixin method is defined', function() {
+		it( 'mixin method is defined', () => {
 			expect( parameterMixins ).to.have.property( 'sticky' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.sticky ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.sticky() ).to.equal( req );
 		});
 
-		it( 'has no effect when called with no argument', function() {
+		it( 'has no effect when called with no argument', () => {
 			var result = req.sticky();
 			expect( getQueryStr( result ) ).to.equal( '' );
 		});
 
-		it( 'sets the "sticky" query parameter when provided a value', function() {
+		it( 'sets the "sticky" query parameter when provided a value', () => {
 			var result = req.sticky( true );
 			expect( getQueryStr( result ) ).to.equal( 'sticky=true' );
 		});
 
-		it( 'overwrites previously-set values on subsequent calls', function() {
+		it( 'overwrites previously-set values on subsequent calls', () => {
 			var result = req.sticky( 1 ).sticky( 0 );
 			expect( getQueryStr( result ) ).to.equal( 'sticky=0' );
 		});
 
 	});
 
-	describe( 'categories()', function() {
+	describe( 'categories()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.categories = parameterMixins.categories;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( parameterMixins ).to.have.property( 'categories' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.categories ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.categories( 7 ) ).to.equal( req );
 		});
 
-		it( 'sets the "categories" parameter for a single category ID', function() {
+		it( 'sets the "categories" parameter for a single category ID', () => {
 			var result = req.categories( 7 );
 			expect( getQueryStr( result ) ).to.equal( 'categories=7' );
 		});
 
-		it( 'sets the "categories" parameter for multiple category IDs', function() {
+		it( 'sets the "categories" parameter for multiple category IDs', () => {
 			var result = req.categories([ 7, 13 ]);
 			expect( getQueryStr( result ) ).to.equal( 'categories[]=13&categories[]=7' );
 		});
 
 	});
 
-	describe( 'category()', function() {
+	describe( 'category()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.category = parameterMixins.category;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( parameterMixins ).to.have.property( 'category' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.category ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.category( 'foo' ) ).to.equal( req );
 		});
 
-		it( 'sets the "categories" parameter for a single category ID', function() {
+		it( 'sets the "categories" parameter for a single category ID', () => {
 			var result = req.category( 7 );
 			expect( getQueryStr( result ) ).to.equal( 'categories=7' );
 		});
 
-		it( 'sets the "categories" parameter for multiple category IDs', function() {
+		it( 'sets the "categories" parameter for multiple category IDs', () => {
 			var result = req.category([ 7, 13 ]);
 			expect( getQueryStr( result ) ).to.equal( 'categories[]=13&categories[]=7' );
 		});
 
-		it( 'sets the "category_name" filter for categories where the term is a string [DEPRECATED]', function() {
+		it( 'sets the "category_name" filter for categories where the term is a string [DEPRECATED]', () => {
 			var result = req.category( 'fiction' );
 			expect( getQueryStr( result ) ).to.equal( 'filter[category_name]=fiction' );
 		});
 
 	});
 
-	describe( 'excludeCategories()', function() {
+	describe( 'excludeCategories()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.excludeCategories = parameterMixins.excludeCategories;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( parameterMixins ).to.have.property( 'excludeCategories' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.excludeCategories ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.excludeCategories( 7 ) ).to.equal( req );
 		});
 
-		it( 'sets the "categories_exclude" parameter for a single category ID', function() {
+		it( 'sets the "categories_exclude" parameter for a single category ID', () => {
 			var result = req.excludeCategories( 7 );
 			expect( getQueryStr( result ) ).to.equal( 'categories_exclude=7' );
 		});
 
-		it( 'sets the "categories_exclude" parameter for multiple category IDs', function() {
+		it( 'sets the "categories_exclude" parameter for multiple category IDs', () => {
 			var result = req.excludeCategories([ 7, 13 ]);
 			expect( getQueryStr( result ) ).to.equal( 'categories_exclude[]=13&categories_exclude[]=7' );
 		});
 
 	});
 
-	describe( 'tags()', function() {
+	describe( 'tags()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.tags = parameterMixins.tags;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( parameterMixins ).to.have.property( 'tags' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.tags ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.tags( 7 ) ).to.equal( req );
 		});
 
-		it( 'sets the "tags" parameter for a single category ID', function() {
+		it( 'sets the "tags" parameter for a single category ID', () => {
 			var result = req.tags( 7 );
 			expect( getQueryStr( result ) ).to.equal( 'tags=7' );
 		});
 
-		it( 'sets the "tags" parameter for multiple category IDs', function() {
+		it( 'sets the "tags" parameter for multiple category IDs', () => {
 			var result = req.tags([ 7, 13 ]);
 			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
 		});
 
-		it( 'sets the "tags" parameter for multiple category IDs provided as numeric strings', function() {
+		it( 'sets the "tags" parameter for multiple category IDs provided as numeric strings', () => {
 			var result = req.tags([ '7', '13' ]);
 			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
 		});
 
 	});
 
-	describe( 'tag()', function() {
+	describe( 'tag()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.tag = parameterMixins.tag;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( parameterMixins ).to.have.property( 'tag' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.tag ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.tag( 7 ) ).to.equal( req );
 		});
 
-		it( 'sets the "tag" parameter for a single category ID', function() {
+		it( 'sets the "tag" parameter for a single category ID', () => {
 			var result = req.tag( 7 );
 			expect( getQueryStr( result ) ).to.equal( 'tags=7' );
 		});
 
-		it( 'sets the "tags" parameter for multiple category IDs', function() {
+		it( 'sets the "tags" parameter for multiple category IDs', () => {
 			var result = req.tag([ 7, 13 ]);
 			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
 		});
 
-		it( 'sets the "tags" parameter for multiple category IDs provided as numeric strings', function() {
+		it( 'sets the "tags" parameter for multiple category IDs provided as numeric strings', () => {
 			var result = req.tag([ '7', '13' ]);
 			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
 		});
 
-		it( 'sets the "tag" filter when the term is a string [DEPRECATED]', function() {
+		it( 'sets the "tag" filter when the term is a string [DEPRECATED]', () => {
 			var result = req.tag( 'bagpipe-techno' );
 			expect( getQueryStr( result ) ).to.equal( 'filter[tag]=bagpipe-techno' );
 		});
 
 	});
 
-	describe( 'excludeTags()', function() {
+	describe( 'excludeTags()', () => {
 
-		beforeEach(function() {
+		beforeEach( () => {
 			Req.prototype.excludeTags = parameterMixins.excludeTags;
 		});
 
-		it( 'mixin is defined', function() {
+		it( 'mixin is defined', () => {
 			expect( parameterMixins ).to.have.property( 'excludeTags' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( parameterMixins.excludeTags ).to.be.a( 'function' );
 		});
 
-		it( 'supports chaining', function() {
+		it( 'supports chaining', () => {
 			expect( req.excludeTags( 7 ) ).to.equal( req );
 		});
 
-		it( 'sets the "tags_exclude" parameter for a single category ID', function() {
+		it( 'sets the "tags_exclude" parameter for a single category ID', () => {
 			var result = req.excludeTags( 7 );
 			expect( getQueryStr( result ) ).to.equal( 'tags_exclude=7' );
 		});
 
-		it( 'sets the "tags_exclude" parameter for multiple category IDs', function() {
+		it( 'sets the "tags_exclude" parameter for multiple category IDs', () => {
 			var result = req.excludeTags([ 7, 13 ]);
 			expect( getQueryStr( result ) ).to.equal( 'tags_exclude[]=13&tags_exclude[]=7' );
 		});
 
-		it( 'sets the "tags_exclude" parameter for multiple category IDs provided as numeric strings', function() {
+		it( 'sets the "tags_exclude" parameter for multiple category IDs provided as numeric strings', () => {
 			var result = req.excludeTags([ '7', '13' ]);
 			expect( getQueryStr( result ) ).to.equal( 'tags_exclude[]=13&tags_exclude[]=7' );
 		});

--- a/tests/unit/lib/route-tree.js
+++ b/tests/unit/lib/route-tree.js
@@ -4,29 +4,29 @@ var expect = require( 'chai' ).expect;
 var routeTree = require( '../../../lib/route-tree' );
 var defaultRoutes = require( '../../../lib/data/default-routes.json' );
 
-describe( 'route-tree utility', function() {
+describe( 'route-tree utility', () => {
 
-	describe( '.build()', function() {
+	describe( '.build()', () => {
 		var tree;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			tree = routeTree.build( defaultRoutes );
 		});
 
-		it( 'returns an object keyed by API namespace', function() {
+		it( 'returns an object keyed by API namespace', () => {
 			var keys = Object.keys( tree ).sort();
 			expect( keys.length ).to.equal( 2 );
 			expect( keys ).to.deep.equal([ 'oembed/1.0', 'wp/v2' ]);
 		});
 
-		it( 'includes objects for all default wp/v2 routes', function() {
+		it( 'includes objects for all default wp/v2 routes', () => {
 			var routes = Object.keys( tree[ 'wp/v2' ] ).sort();
 			expect( routes ).to.have.length( 11 );
 			expect( routes.join( ',' ) ).to
 				.equal( 'categories,comments,media,pages,posts,settings,statuses,tags,taxonomies,types,users' );
 		});
 
-		it( 'includes objects for all default oembed/1.0 routes', function() {
+		it( 'includes objects for all default oembed/1.0 routes', () => {
 			var routes = Object.keys( tree[ 'oembed/1.0' ] ).sort();
 			expect( routes ).to.have.length( 1 );
 			expect( routes.join( ',' ) ).to.equal( 'embed' );
@@ -34,19 +34,19 @@ describe( 'route-tree utility', function() {
 
 		// Inspect the .posts tree as a smoke test for whether parsing the API
 		// definition object was successful
-		describe( 'posts resource tree', function() {
+		describe( 'posts resource tree', () => {
 			var posts;
 
-			beforeEach(function() {
+			beforeEach( () => {
 				posts = tree[ 'wp/v2' ].posts;
 			});
 
-			it ( 'includes a ._getArgs property', function() {
+			it( 'includes a ._getArgs property', () => {
 				expect( posts ).to.have.property( '_getArgs' );
 				expect( posts._getArgs ).to.be.an( 'object' );
 			});
 
-			it ( '._getArgs specifies a list of supported parameters', function() {
+			it( '._getArgs specifies a list of supported parameters', () => {
 				expect( posts ).to.have.property( '_getArgs' );
 				expect( posts._getArgs ).to.be.an( 'object' );
 				expect( posts._getArgs ).to.deep.equal({
@@ -74,14 +74,14 @@ describe( 'route-tree utility', function() {
 				});
 			});
 
-			it ( 'includes a .posts property', function() {
+			it( 'includes a .posts property', () => {
 				expect( posts ).to.have.property( 'posts' );
 				expect( posts.posts ).to.be.an( 'object' );
 			});
 
 			// This is a decidedly incomplete smoke test...
 			// But if this fails, so will everything else!
-			it ( '.posts defines the top level of a route tree', function() {
+			it( '.posts defines the top level of a route tree', () => {
 				var routeTree = posts.posts;
 				expect( routeTree ).to.have.property( 'level' );
 				expect( routeTree.level ).to.equal( 0 );

--- a/tests/unit/lib/util/apply-mixin.js
+++ b/tests/unit/lib/util/apply-mixin.js
@@ -28,7 +28,7 @@ describe( 'applyMixin utility', () => {
 
 	it( 'does not mutate the object if the specified key exists already', () => {
 		obj.foo = 'bar';
-		applyMixin( obj, 'foo', function() {});
+		applyMixin( obj, 'foo', () => {});
 		expect( obj ).to.deep.equal({
 			foo: 'bar'
 		});

--- a/tests/unit/lib/util/apply-mixin.js
+++ b/tests/unit/lib/util/apply-mixin.js
@@ -3,22 +3,22 @@ var expect = require( 'chai' ).expect;
 
 var applyMixin = require( '../../../../lib/util/apply-mixin' );
 
-describe( 'applyMixin utility', function() {
+describe( 'applyMixin utility', () => {
 	var obj;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		obj = {};
 	});
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( applyMixin ).to.be.a( 'function' );
 	});
 
-	it( 'returns nothing', function() {
+	it( 'returns nothing', () => {
 		expect( applyMixin() ).to.be.undefined;
 	});
 
-	it( 'assigns a method to the provided object', function() {
+	it( 'assigns a method to the provided object', () => {
 		function bar() {}
 		applyMixin( obj, 'foo', bar );
 		expect( obj ).to.deep.equal({
@@ -26,7 +26,7 @@ describe( 'applyMixin utility', function() {
 		});
 	});
 
-	it( 'does not mutate the object if the specified key exists already', function() {
+	it( 'does not mutate the object if the specified key exists already', () => {
 		obj.foo = 'bar';
 		applyMixin( obj, 'foo', function() {});
 		expect( obj ).to.deep.equal({
@@ -34,7 +34,7 @@ describe( 'applyMixin utility', function() {
 		});
 	});
 
-	it( 'does not mutate the object if third arg is not a function', function() {
+	it( 'does not mutate the object if third arg is not a function', () => {
 		applyMixin( obj, 'key', 'not a function' );
 		expect( obj ).to.deep.equal({});
 	});

--- a/tests/unit/lib/util/argument-is-numeric.js
+++ b/tests/unit/lib/util/argument-is-numeric.js
@@ -3,58 +3,58 @@ var expect = require( 'chai' ).expect;
 
 var argumentIsNumeric = require( '../../../../lib/util/argument-is-numeric' );
 
-describe( 'argumentIsNumeric utility', function() {
+describe( 'argumentIsNumeric utility', () => {
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( argumentIsNumeric ).to.be.a( 'function' );
 	});
 
-	it( 'returns true if provided an integer', function() {
+	it( 'returns true if provided an integer', () => {
 		var result = argumentIsNumeric( 7 );
 		expect( result ).to.equal( true );
 	});
 
-	it( 'returns true if provided an integer string', function() {
+	it( 'returns true if provided an integer string', () => {
 		var result = argumentIsNumeric( '2501' );
 		expect( result ).to.equal( true );
 	});
 
-	it( 'returns true if provided an array of integers', function() {
+	it( 'returns true if provided an array of integers', () => {
 		var result = argumentIsNumeric([ 1, 3, 5, 8, 13 ]);
 		expect( result ).to.equal( true );
 	});
 
-	it( 'returns true if provided an array of integer strings', function() {
+	it( 'returns true if provided an array of integer strings', () => {
 		var result = argumentIsNumeric([ '1', '3', '5', '8', '13' ]);
 		expect( result ).to.equal( true );
 	});
 
-	it( 'returns true if provided a mixed array of integers and integer strings', function() {
+	it( 'returns true if provided a mixed array of integers and integer strings', () => {
 		var result = argumentIsNumeric([ 1, '3', 5, '8', 13 ]);
 		expect( result ).to.equal( true );
 	});
 
-	it( 'returns false if provided a non-integer string', function() {
+	it( 'returns false if provided a non-integer string', () => {
 		var result = argumentIsNumeric( 'WordPress' );
 		expect( result ).to.equal( false );
 	});
 
-	it( 'returns false if provided a non-integer numeric string value', function() {
+	it( 'returns false if provided a non-integer numeric string value', () => {
 		var result = argumentIsNumeric( '3.14159' );
 		expect( result ).to.equal( false );
 	});
 
-	it( 'returns false if provided an array that contains any non-numeric string', function() {
+	it( 'returns false if provided an array that contains any non-numeric string', () => {
 		var result = argumentIsNumeric([ 1, 3, 5, 'Eight' ]);
 		expect( result ).to.equal( false );
 	});
 
-	it( 'returns false if provided an array of strings', function() {
+	it( 'returns false if provided an array of strings', () => {
 		var result = argumentIsNumeric([ 'One', 'Three' ]);
 		expect( result ).to.equal( false );
 	});
 
-	it( 'returns false if provided a non-string, non-integer, non-array value', function() {
+	it( 'returns false if provided a non-string, non-integer, non-array value', () => {
 		expect( argumentIsNumeric( {} ) ).to.equal( false );
 		expect( argumentIsNumeric( null ) ).to.equal( false );
 		expect( argumentIsNumeric( /foo/ ) ).to.equal( false );

--- a/tests/unit/lib/util/ensure.js
+++ b/tests/unit/lib/util/ensure.js
@@ -3,22 +3,22 @@ var expect = require( 'chai' ).expect;
 
 var ensure = require( '../../../../lib/util/ensure' );
 
-describe( 'ensure utility', function() {
+describe( 'ensure utility', () => {
 	var obj;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		obj = {};
 	});
 
-	it( 'is defined', function() {
+	it( 'is defined', () => {
 		expect( ensure ).to.exist;
 	});
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( ensure ).to.be.a( 'function' );
 	});
 
-	it( 'sets a default property value on an object', function() {
+	it( 'sets a default property value on an object', () => {
 		expect( obj ).not.to.have.property( 'foo' );
 		ensure( obj, 'foo', 'bar' );
 		expect( obj ).to.have.property( 'foo' );
@@ -26,7 +26,7 @@ describe( 'ensure utility', function() {
 		expect( obj.foo ).to.equal( 'bar' );
 	});
 
-	it( 'will not overwrite an existing value on an object', function() {
+	it( 'will not overwrite an existing value on an object', () => {
 		obj.foo = 'baz';
 		expect( obj ).to.have.property( 'foo' );
 		ensure( obj, 'foo', 'bar' );
@@ -35,7 +35,7 @@ describe( 'ensure utility', function() {
 		expect( obj.foo ).to.equal( 'baz' );
 	});
 
-	it( 'will not overwrite a falsy value on an object', function() {
+	it( 'will not overwrite a falsy value on an object', () => {
 		obj.foo = 0;
 		expect( obj ).to.have.property( 'foo' );
 		ensure( obj, 'foo', 'bar' );

--- a/tests/unit/lib/util/is-empty-object.js
+++ b/tests/unit/lib/util/is-empty-object.js
@@ -3,51 +3,51 @@ var expect = require( 'chai' ).expect;
 
 var isEmptyObject = require( '../../../../lib/util/is-empty-object' );
 
-describe( 'isEmptyObject utility', function() {
+describe( 'isEmptyObject utility', () => {
 
-	it( 'is defined', function() {
+	it( 'is defined', () => {
 		expect( isEmptyObject ).to.exist;
 	});
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( isEmptyObject ).to.be.a( 'function' );
 	});
 
-	it( 'returns true if passed an empty object', function() {
+	it( 'returns true if passed an empty object', () => {
 		expect( isEmptyObject( {} ) ).to.equal( true );
 	});
 
-	it( 'returns true if passed a constructed object with no instance properties', function() {
+	it( 'returns true if passed a constructed object with no instance properties', () => {
 		function Ctor() {}
 		Ctor.prototype.prop = 'val';
 		expect( isEmptyObject( new Ctor() ) ).to.equal( true );
 	});
 
-	it( 'returns false if passed an object with own properties', function() {
+	it( 'returns false if passed an object with own properties', () => {
 		expect( isEmptyObject({ prop: 'value' }) ).to.equal( false );
 	});
 
-	it( 'returns false if passed a constructed object with instance properties', function() {
+	it( 'returns false if passed a constructed object with instance properties', () => {
 		function Ctor() {
 			this.prop = 'val';
 		}
 		expect( isEmptyObject( new Ctor() ) ).to.equal( false );
 	});
 
-	it( 'returns false if passed a string', function() {
+	it( 'returns false if passed a string', () => {
 		expect( isEmptyObject( '{}' ) ).to.equal( false );
 	});
 
-	it( 'returns false if passed an empty array', function() {
+	it( 'returns false if passed an empty array', () => {
 		expect( isEmptyObject( [] ) ).to.equal( false );
 	});
 
-	it( 'returns false if passed a boolean', function() {
+	it( 'returns false if passed a boolean', () => {
 		expect( isEmptyObject( true ) ).to.equal( false );
 		expect( isEmptyObject( false ) ).to.equal( false );
 	});
 
-	it( 'returns false if passed a number', function() {
+	it( 'returns false if passed a number', () => {
 		expect( isEmptyObject( 0 ) ).to.equal( false );
 		expect( isEmptyObject( 1337 ) ).to.equal( false );
 	});

--- a/tests/unit/lib/util/key-val-to-obj.js
+++ b/tests/unit/lib/util/key-val-to-obj.js
@@ -3,26 +3,26 @@ var expect = require( 'chai' ).expect;
 
 var keyValToObj = require( '../../../../lib/util/key-val-to-obj' );
 
-describe( 'keyValToObj utility', function() {
+describe( 'keyValToObj utility', () => {
 	var obj;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		obj = {};
 	});
 
-	it( 'is defined', function() {
+	it( 'is defined', () => {
 		expect( keyValToObj ).to.exist;
 	});
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( keyValToObj ).to.be.a( 'function' );
 	});
 
-	it( 'returns an object', function() {
+	it( 'returns an object', () => {
 		expect( keyValToObj() ).to.be.an( 'object' );
 	});
 
-	it( 'sets the specified value at the provided key on the returned object', function() {
+	it( 'sets the specified value at the provided key on the returned object', () => {
 		var result = keyValToObj( 'propName', 123456 );
 		expect( result ).to.have.property( 'propName' );
 		expect( result ).to.deep.equal({
@@ -30,7 +30,7 @@ describe( 'keyValToObj utility', function() {
 		});
 	});
 
-	it( 'can be used to set an array, and sets values by reference', function() {
+	it( 'can be used to set an array, and sets values by reference', () => {
 		var arr = [ 'mimsy', 'borogoves', 'outgrabe' ];
 		var result = keyValToObj( 'words', arr );
 		expect( result ).to.have.property( 'words' );

--- a/tests/unit/lib/util/named-group-regexp.js
+++ b/tests/unit/lib/util/named-group-regexp.js
@@ -3,19 +3,19 @@ var expect = require( 'chai' ).expect;
 
 var namedGroupRE = require( '../../../../lib/util/named-group-regexp' ).namedGroupRE;
 
-describe( 'named PCRE group RegExp', function() {
+describe( 'named PCRE group RegExp', () => {
 
-	it( 'is a regular expression', function() {
+	it( 'is a regular expression', () => {
 		expect( namedGroupRE ).to.be.an.instanceof( RegExp );
 	});
 
-	it( 'will not match an arbitrary string', function() {
+	it( 'will not match an arbitrary string', () => {
 		var pathComponent = 'author';
 		var result = pathComponent.match( namedGroupRE );
 		expect( result ).to.be.null;
 	});
 
-	it( 'identifies the name and RE pattern for a PCRE named group', function() {
+	it( 'identifies the name and RE pattern for a PCRE named group', () => {
 		var pathComponent = '(?P<parent>[\\d]+)';
 		var result = pathComponent.match( namedGroupRE );
 		expect( result ).not.to.be.null;
@@ -23,7 +23,7 @@ describe( 'named PCRE group RegExp', function() {
 		expect( result[ 2 ] ).to.equal( '[\\d]+' );
 	});
 
-	it( 'identifies the name and RE pattern for another group', function() {
+	it( 'identifies the name and RE pattern for another group', () => {
 		var pathComponent = '(?P<id>\\d+)';
 		var result = pathComponent.match( namedGroupRE );
 		expect( result ).not.to.be.null;
@@ -31,7 +31,7 @@ describe( 'named PCRE group RegExp', function() {
 		expect( result[ 2 ] ).to.equal( '\\d+' );
 	});
 
-	it( 'identifies RE patterns including forward slashes', function() {
+	it( 'identifies RE patterns including forward slashes', () => {
 		var pathComponent = '(?P<plugin>[a-z\\/\\.\\-_]+)';
 		var result = pathComponent.match( namedGroupRE );
 		expect( result ).not.to.be.null;
@@ -39,7 +39,7 @@ describe( 'named PCRE group RegExp', function() {
 		expect( result[ 2 ] ).to.equal( '[a-z\\/\\.\\-_]+' );
 	});
 
-	it( 'will match an empty string if a "RE Pattern" if the pattern is omitted', function() {
+	it( 'will match an empty string if a "RE Pattern" if the pattern is omitted', () => {
 		var pathComponent = '(?P<id>)';
 		var result = pathComponent.match( namedGroupRE );
 		expect( result ).not.to.be.null;

--- a/tests/unit/lib/util/object-reduce.js
+++ b/tests/unit/lib/util/object-reduce.js
@@ -1,7 +1,7 @@
 'use strict';
 var expect = require( 'chai' ).expect;
 
-describe( 'Object reduction tools:', function() {
+describe( 'Object reduction tools:', () => {
 	// Ensure parity with the relevant signature & functionality of lodash.reduce
 	[
 		{
@@ -17,23 +17,23 @@ describe( 'Object reduction tools:', function() {
 			var objectReduce = test.fn;
 			var obj;
 
-			beforeEach(function() {
+			beforeEach( () => {
 				obj = {};
 			});
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( objectReduce ).to.exist;
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( objectReduce ).to.be.a( 'function' );
 			});
 
-			it( 'resolves to the provided initial value if called on an empty object', function() {
+			it( 'resolves to the provided initial value if called on an empty object', () => {
 				expect( objectReduce( {}, function() {}, 'Sasquatch' ) ).to.equal( 'Sasquatch' );
 			});
 
-			it( 'can be used to reduce over an object', function() {
+			it( 'can be used to reduce over an object', () => {
 				var result = objectReduce({
 					key1: 'val1',
 					key2: 'val2',

--- a/tests/unit/lib/util/object-reduce.js
+++ b/tests/unit/lib/util/object-reduce.js
@@ -11,9 +11,9 @@ describe( 'Object reduction tools:', () => {
 			name: 'objectReduce utility',
 			fn: require( '../../../../lib/util/object-reduce' )
 		}
-	].forEach(function( test ) {
+	].forEach( ( test ) => {
 
-		describe( test.name, function() {
+		describe( test.name, () => {
 			var objectReduce = test.fn;
 			var obj;
 
@@ -30,7 +30,7 @@ describe( 'Object reduction tools:', () => {
 			});
 
 			it( 'resolves to the provided initial value if called on an empty object', () => {
-				expect( objectReduce( {}, function() {}, 'Sasquatch' ) ).to.equal( 'Sasquatch' );
+				expect( objectReduce( {}, () => {}, 'Sasquatch' ) ).to.equal( 'Sasquatch' );
 			});
 
 			it( 'can be used to reduce over an object', () => {
@@ -38,9 +38,7 @@ describe( 'Object reduction tools:', () => {
 					key1: 'val1',
 					key2: 'val2',
 					key3: 'val3'
-				}, function( memo, val, key ) {
-					return memo + val + key;
-				}, 'result:' );
+				}, ( memo, val, key ) => memo + val + key, 'result:' );
 				expect( result ).to.equal( 'result:val1key1val2key2val3key3' );
 			});
 

--- a/tests/unit/lib/util/parameter-setter.js
+++ b/tests/unit/lib/util/parameter-setter.js
@@ -6,22 +6,22 @@ var expect = chai.expect;
 
 var paramSetter = require( '../../../../lib/util/parameter-setter' );
 
-describe( 'parameterSetter utility', function() {
+describe( 'parameterSetter utility', () => {
 	var obj;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		obj = {};
 	});
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( paramSetter ).to.be.a( 'function' );
 	});
 
-	it( 'returns a function', function() {
+	it( 'returns a function', () => {
 		expect( paramSetter() ).to.be.a( 'function' );
 	});
 
-	it( 'creates a setter that calls this.param()', function() {
+	it( 'creates a setter that calls this.param()', () => {
 		obj.param = sinon.stub();
 		obj.setter = paramSetter( 'foo' );
 		obj.setter( 'bar' );

--- a/tests/unit/lib/util/split-path.js
+++ b/tests/unit/lib/util/split-path.js
@@ -3,17 +3,17 @@ var expect = require( 'chai' ).expect;
 
 var splitPath = require( '../../../../lib/util/split-path' );
 
-describe( 'splitPath utility', function() {
+describe( 'splitPath utility', () => {
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( splitPath ).to.be.a( 'function' );
 	});
 
-	it( 'splits a simple path on the "/" character', function() {
+	it( 'splits a simple path on the "/" character', () => {
 		expect( splitPath( 'a/b/c/d' ) ).to.deep.equal([ 'a', 'b', 'c', 'd' ]);
 	});
 
-	it( 'correctly splits a string containing named capture groups', function() {
+	it( 'correctly splits a string containing named capture groups', () => {
 		var result = splitPath( '/posts/(?P<parent>[\\d]+)/revisions/(?P<id>[\\d]+)' );
 		expect( result ).to.deep.equal([
 			'posts',
@@ -23,7 +23,7 @@ describe( 'splitPath utility', function() {
 		]);
 	});
 
-	it( 'correctly splits a string when a named group regex contains a "/"', function() {
+	it( 'correctly splits a string when a named group regex contains a "/"', () => {
 		var result = splitPath( '/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)' );
 		expect( result ).to.deep.equal([
 			'plugin',
@@ -31,7 +31,7 @@ describe( 'splitPath utility', function() {
 		]);
 	});
 
-	it( 'correctly splits a string with levels containing text outside named groups', function() {
+	it( 'correctly splits a string with levels containing text outside named groups', () => {
 		// From user-contributed example on https://developer.wordpress.org/reference/functions/register_rest_route/
 		// Note that this library does not support this syntax, but ensuring that
 		// common variants of path strings are split correctly avoids situations
@@ -45,7 +45,7 @@ describe( 'splitPath utility', function() {
 		]);
 	});
 
-	it( 'correctly splits a string with this situation', function() {
+	it( 'correctly splits a string with this situation', () => {
 		var result = splitPath( '/plugin/(?P<plugin_slug>[^/]+)/committers/?' );
 		expect( result ).to.deep.equal([
 			'plugin',

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -120,7 +120,7 @@ describe( 'wp.registerRoute', () => {
 
 		it( 'will parse the route without error but not yield functioning setters', () => {
 			var factory;
-			expect(function() {
+			expect( () => {
 				factory = registerRoute(
 					'mmw/v1',
 					'/users/market=(?P<market>[a-zA-Z0-9-]+)/lat=(?P<lat>[a-z0-9 .\\-]+)/long=(?P<long>[a-z0-9 .\\-]+)'

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -7,32 +7,32 @@ var registerRoute = require( '../../../lib/wp-register-route' );
 var checkMethodSupport = require( '../../../lib/util/check-method-support' );
 var mixins = require( '../../../lib/mixins' );
 
-describe( 'wp.registerRoute', function() {
+describe( 'wp.registerRoute', () => {
 
-	it( 'is a function', function() {
+	it( 'is a function', () => {
 		expect( registerRoute ).to.be.a( 'function' );
 	});
 
-	it( 'returns a function', function() {
+	it( 'returns a function', () => {
 		expect( registerRoute( 'a', 'b' ) ).to.be.a( 'function' );
 	});
 
-	it( 'sets a Ctor property on the returned function', function() {
+	it( 'sets a Ctor property on the returned function', () => {
 		var result = registerRoute( 'a', 'b' );
 		expect( result ).to.have.property( 'Ctor' );
 	});
 
-	it( 'returns a factory that returns Ctor instances', function() {
+	it( 'returns a factory that returns Ctor instances', () => {
 		var result = registerRoute( 'a', 'b' );
 		expect( result() ).to.be.an.instanceOf( result.Ctor );
 	});
 
-	it( 'returns a factory for an object which extends WPRequest', function() {
+	it( 'returns a factory for an object which extends WPRequest', () => {
 		var result = registerRoute( 'a', 'b' );
 		expect( result() ).to.be.an.instanceOf( WPRequest );
 	});
 
-	it( 'factory-generated handlers have all the expected WPRequest methods', function() {
+	it( 'factory-generated handlers have all the expected WPRequest methods', () => {
 		var factory = registerRoute( 'a', 'b' );
 		var handler = factory({
 			endpoint: '/'
@@ -49,35 +49,35 @@ describe( 'wp.registerRoute', function() {
 	});
 
 	// custom route example for wp-api.org
-	describe( 'handler for /author/(?P<id>\\d+)', function() {
+	describe( 'handler for /author/(?P<id>\\d+)', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'myplugin/v1', '/author/(?P<id>\\d+)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		it( 'renders a route prefixed with the provided namespace', function() {
+		it( 'renders a route prefixed with the provided namespace', () => {
 			expect( handler.toString().match( /myplugin\/v1/ ) ).to.be.ok;
 		});
 
-		it( 'sets the /authors/ path part automatically', function() {
+		it( 'sets the /authors/ path part automatically', () => {
 			expect( handler.toString() ).to.equal( '/myplugin/v1/author' );
 		});
 
-		describe( '.id() method', function() {
+		describe( '.id() method', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( handler ).to.have.property( 'id' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( handler.id ).to.be.a( 'function' );
 			});
 
-			it( 'sets the ID component of the path', function() {
+			it( 'sets the ID component of the path', () => {
 				expect( handler.id( 3263827 ).toString() ).to.equal( '/myplugin/v1/author/3263827' );
 			});
 
@@ -86,9 +86,9 @@ describe( 'wp.registerRoute', function() {
 	});
 
 	// Example of a Jetpack route with regexes containing forward slashes
-	describe( 'handler for /jetpack/v4/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)', function() {
+	describe( 'handler for /jetpack/v4/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)', () => {
 
-		it( 'permits setting path parts with forward slashes', function() {
+		it( 'permits setting path parts with forward slashes', () => {
 			var factory = registerRoute( 'jetpack/v4', '/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)' );
 			var handler = factory({
 				endpoint: '/'
@@ -100,9 +100,9 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for /plugin/(?P<plugin_slug>[^/]+)/committers/?)', function() {
+	describe( 'handler for /plugin/(?P<plugin_slug>[^/]+)/committers/?)', () => {
 
-		it( 'will ignore the trailing /? (the ? is intended to mark the / as optional', function() {
+		it( 'will ignore the trailing /? (the ? is intended to mark the / as optional', () => {
 			var factory = registerRoute( 'plugins/v1', '/plugin/(?P<plugin_slug>[^/]+)/committers/?' );
 			var handler = factory({
 				endpoint: '/'
@@ -116,9 +116,9 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for unsupported route definition format', function() {
+	describe( 'handler for unsupported route definition format', () => {
 
-		it( 'will parse the route without error but not yield functioning setters', function() {
+		it( 'will parse the route without error but not yield functioning setters', () => {
 			var factory;
 			expect(function() {
 				factory = registerRoute(
@@ -143,17 +143,17 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for /a/(?P<snake_cased_path_setter>\\d+)', function() {
+	describe( 'handler for /a/(?P<snake_cased_path_setter>\\d+)', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'ns', '/a/(?P<snake_cased_path_setter>\\d+)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		it( 'camelCases the setter name', function() {
+		it( 'camelCases the setter name', () => {
 			expect( handler ).not.to.have.property( 'snake_cased_path_setter' );
 			expect( handler ).to.have.property( 'snakeCasedPathSetter' );
 			expect( handler.snakeCasedPathSetter ).to.be.a( 'function' );
@@ -161,17 +161,17 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for /a/(?P<kebab-cased-path-setter>\\d+)', function() {
+	describe( 'handler for /a/(?P<kebab-cased-path-setter>\\d+)', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'ns', '/a/(?P<kebab-cased-path-setter>\\d+)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		it( 'camelCases the setter name', function() {
+		it( 'camelCases the setter name', () => {
 			expect( handler ).not.to.have.property( 'kebab-cased-path-setter' );
 			expect( handler ).to.have.property( 'kebabCasedPathSetter' );
 			expect( handler.kebabCasedPathSetter ).to.be.a( 'function' );
@@ -179,17 +179,17 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for /a/(?P<camelCasedPathSetter>\\d+)', function() {
+	describe( 'handler for /a/(?P<camelCasedPathSetter>\\d+)', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'ns', '/a/(?P<camelCasedPathSetter>\\d+)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		it( 'does not mutate the setter name', function() {
+		it( 'does not mutate the setter name', () => {
 			expect( handler ).not.to.have.property( 'camelcasedpathsetter' );
 			expect( handler ).to.have.property( 'camelCasedPathSetter' );
 			expect( handler.camelCasedPathSetter ).to.be.a( 'function' );
@@ -197,17 +197,17 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for route with capture group named identically to existing method', function() {
+	describe( 'handler for route with capture group named identically to existing method', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'ns', '/route/(?P<param>)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		it( 'does not overwrite preexisting methods', function() {
+		it( 'does not overwrite preexisting methods', () => {
 			expect( handler.param ).to.equal( WPRequest.prototype.param );
 			expect( handler.param( 'foo', 'bar' ).toString() ).to.equal( '/ns/route?foo=bar' );
 			expect( handler.param( 'foo', 'bar' ).toString() ).not.to.equal( '/ns/route/foo' );
@@ -215,43 +215,43 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for consecutive dynamic route segments', function() {
+	describe( 'handler for consecutive dynamic route segments', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'ns', '/resource/(?P<part1>\\d+)/(?P<part2>\\d+)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		describe( 'part1 method', function() {
+		describe( 'part1 method', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( handler ).to.have.property( 'part1' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( handler.part1 ).to.be.a( 'function' );
 			});
 
-			it( 'sets the part1 component of the path', function() {
+			it( 'sets the part1 component of the path', () => {
 				expect( handler.part1( 12 ).toString() ).to.equal( '/ns/resource/12' );
 			});
 
 		});
 
-		describe( 'part2 method', function() {
+		describe( 'part2 method', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( handler ).to.have.property( 'part2' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( handler.part2 ).to.be.a( 'function' );
 			});
 
-			it( 'sets the part2 component of the path', function() {
+			it( 'sets the part2 component of the path', () => {
 				expect( handler.part1( 12 ).part2( 34 ).toString() ).to.equal( '/ns/resource/12/34' );
 			});
 
@@ -259,10 +259,10 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'parameters', function() {
+	describe( 'parameters', () => {
 		var handler;
 
-		it( 'assign any mixins that match provided parameter names', function() {
+		it( 'assign any mixins that match provided parameter names', () => {
 			var factory = registerRoute( 'a', '/b', {
 				params: [ 'filter', 'author' ]
 			});
@@ -275,7 +275,7 @@ describe( 'wp.registerRoute', function() {
 			expect( handler.author ).to.equal( mixins.author.author );
 		});
 
-		it( 'does nothing if non-string parameters are provided', function() {
+		it( 'does nothing if non-string parameters are provided', () => {
 			var factory1 = registerRoute( 'a', 'b' );
 			var factory2 = registerRoute( 'a', 'b', {
 				params: [ null, function() {} ]
@@ -293,7 +293,7 @@ describe( 'wp.registerRoute', function() {
 			expect( factory1PrototypeMethods ).to.deep.equal( factory2PrototypeMethods );
 		});
 
-		it( 'creates a .param() wrapper for params that do not match existing mixins', function() {
+		it( 'creates a .param() wrapper for params that do not match existing mixins', () => {
 			var factory = registerRoute( 'a', 'b', {
 				params: [ 'customtax', 'someparam' ]
 			});
@@ -311,7 +311,7 @@ describe( 'wp.registerRoute', function() {
 			expect( result.toString() ).to.equal( '/a/b?customtax=techno&someparam%5B%5D=tech&someparam%5B%5D=yes' );
 		});
 
-		it( 'will not overwrite existing methods', function() {
+		it( 'will not overwrite existing methods', () => {
 			var factory = registerRoute( 'myplugin/v1', '/author/(?P<id>\\d+)', {
 				params: [ 'param', 'edit', 'id' ]
 			});
@@ -324,10 +324,10 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'mixins', function() {
+	describe( 'mixins', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'myplugin/v1', '/author/(?P<id>\\d+)', {
 				mixins: {
 					foo: function() {
@@ -343,7 +343,7 @@ describe( 'wp.registerRoute', function() {
 			});
 		});
 
-		it( 'are set on the prototype of the handler constructor', function() {
+		it( 'are set on the prototype of the handler constructor', () => {
 			expect( handler ).to.have.property( 'foo' );
 			expect( handler ).not.to.have.ownProperty( 'foo' );
 			expect( handler.foo ).to.be.a( 'function' );
@@ -352,15 +352,15 @@ describe( 'wp.registerRoute', function() {
 			expect( handler.bar ).to.be.a( 'function' );
 		});
 
-		it( 'can set URL query parameters', function() {
+		it( 'can set URL query parameters', () => {
 			expect( handler.foo().toString() ).to.equal( '/myplugin/v1/author?foo=true' );
 		});
 
-		it( 'can set dynamic URL query parameter values', function() {
+		it( 'can set dynamic URL query parameter values', () => {
 			expect( handler.bar( '1138' ).toString() ).to.equal( '/myplugin/v1/author?bar=1138' );
 		});
 
-		it( 'will not overwrite existing endpoint handler prototype methods', function() {
+		it( 'will not overwrite existing endpoint handler prototype methods', () => {
 			var factory = registerRoute( 'myplugin/v1', '/author/(?P<id>\\d+)', {
 				mixins: {
 					id: function() {
@@ -375,7 +375,7 @@ describe( 'wp.registerRoute', function() {
 			expect( result ).to.equal( '/myplugin/v1/author/7' );
 		});
 
-		it( 'will not overwrite WPRequest default methods', function() {
+		it( 'will not overwrite WPRequest default methods', () => {
 			var factory = registerRoute( 'myplugin/v1', '/author/(?P<id>\\d+)', {
 				mixins: {
 					param: function() {
@@ -391,33 +391,33 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler for multi-capture group route', function() {
+	describe( 'handler for multi-capture group route', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'wp/v2', 'pages/(?P<parent>[\\d]+)/revisions/(?P<id>[\\d]+)' );
 			handler = factory({
 				endpoint: '/'
 			});
 		});
 
-		it( 'sets the first static level of the route automatically', function() {
+		it( 'sets the first static level of the route automatically', () => {
 			expect( handler.toString() ).to.equal( '/wp/v2/pages' );
 		});
 
-		it( 'permits the first dynamic level of the route to be set with .parent', function() {
+		it( 'permits the first dynamic level of the route to be set with .parent', () => {
 			expect( handler.parent( 79 ).toString() ).to.equal( '/wp/v2/pages/79' );
 		});
 
-		it( 'permits the second static level of the route to be set with .revisions', function() {
+		it( 'permits the second static level of the route to be set with .revisions', () => {
 			expect( handler.parent( 79 ).revisions().toString() ).to.equal( '/wp/v2/pages/79/revisions' );
 		});
 
-		it( 'permits the second dynamic level of the route to be set with .id', function() {
+		it( 'permits the second dynamic level of the route to be set with .id', () => {
 			expect( handler.parent( 79 ).revisions().id( 97 ).toString() ).to.equal( '/wp/v2/pages/79/revisions/97' );
 		});
 
-		it( 'throws an error if the parts of the route provided are not contiguous', function() {
+		it( 'throws an error if the parts of the route provided are not contiguous', () => {
 			expect(function() {
 				handler.parent( 101 ).id( 102 ).toString();
 			}).to.throw();
@@ -425,10 +425,10 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler validation', function() {
+	describe( 'handler validation', () => {
 		var handler;
 
-		it( 'can be enforced by providing a regex for a capture group', function() {
+		it( 'can be enforced by providing a regex for a capture group', () => {
 			var factory = registerRoute( 'myplugin', 'one/(?P<a>\\w+_\\d+)' );
 			handler = factory({
 				endpoint: '/'
@@ -439,7 +439,7 @@ describe( 'wp.registerRoute', function() {
 			expect( handler.a( 'foo_100' ).toString() ).to.equal( '/myplugin/one/foo_100' );
 		});
 
-		it( 'can be bypassed if no regex is provided for a capture group', function() {
+		it( 'can be bypassed if no regex is provided for a capture group', () => {
 			var factory = registerRoute( 'myplugin', 'one/(?P<a>)/two/(?P<b>)' );
 			handler = factory({
 				endpoint: '/'
@@ -452,10 +452,10 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'method option:', function() {
+	describe( 'method option:', () => {
 		var handler;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			var factory = registerRoute( 'myplugin', 'one/(?P<a>)/(?P<b>)', {
 				methods: [ 'GET', 'POST' ]
 			});
@@ -464,9 +464,9 @@ describe( 'wp.registerRoute', function() {
 			});
 		});
 
-		describe( 'leaf nodes', function() {
+		describe( 'leaf nodes', () => {
 
-			describe( 'support whitelisted method', function() {
+			describe( 'support whitelisted method', () => {
 
 				[ 'get', 'post' ].forEach(function( method ) {
 					it( method, function() {
@@ -478,7 +478,7 @@ describe( 'wp.registerRoute', function() {
 
 			});
 
-			describe( 'blacklist method', function() {
+			describe( 'blacklist method', () => {
 
 				[ 'delete', 'put' ].forEach(function( method ) {
 					it( method, function() {
@@ -490,13 +490,13 @@ describe( 'wp.registerRoute', function() {
 
 			});
 
-			it( 'support "head" implicitly if "get" is whitelisted', function() {
+			it( 'support "head" implicitly if "get" is whitelisted', () => {
 				expect(function() {
 					checkMethodSupport( 'head', handler.a( 1 ).b( 2 ) );
 				}).not.to.throw();
 			});
 
-			it( 'support "get" implicitly if "head" is whitelisted', function() {
+			it( 'support "get" implicitly if "head" is whitelisted', () => {
 				var factory = registerRoute( 'myplugin', 'one/(?P<a>)/(?P<b>)', {
 					methods: [ 'HEAD' ]
 				});
@@ -510,9 +510,9 @@ describe( 'wp.registerRoute', function() {
 
 		});
 
-		describe( 'non-leaf nodes', function() {
+		describe( 'non-leaf nodes', () => {
 
-			describe( 'support all methods', function() {
+			describe( 'support all methods', () => {
 
 				[ 'get', 'post', 'head', 'put', 'delete' ].forEach(function( method ) {
 					it( method, function() {
@@ -526,9 +526,9 @@ describe( 'wp.registerRoute', function() {
 
 		});
 
-		describe( 'specified as a string', function() {
+		describe( 'specified as a string', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				var factory = registerRoute( 'myplugin', 'one/(?P<a>)/(?P<b>)', {
 					methods: 'POST'
 				});
@@ -537,13 +537,13 @@ describe( 'wp.registerRoute', function() {
 				});
 			});
 
-			it( 'is properly whitelisted', function() {
+			it( 'is properly whitelisted', () => {
 				expect(function() {
 					checkMethodSupport( 'post', handler.a( 1 ).b( 2 ) );
 				}).not.to.throw();
 			});
 
-			describe( 'implicitly blacklists other method', function() {
+			describe( 'implicitly blacklists other method', () => {
 
 				[ 'get', 'head', 'delete', 'put' ].forEach(function( method ) {
 					it( method, function() {
@@ -559,14 +559,14 @@ describe( 'wp.registerRoute', function() {
 
 	});
 
-	describe( 'handler options', function() {
+	describe( 'handler options', () => {
 
-		it( 'can be passed in to the factory method', function() {
+		it( 'can be passed in to the factory method', () => {
 			var factory = registerRoute( 'myplugin', 'myroute' );
 			expect( factory({ endpoint: '/wp-yaml/' }).toString() ).to.equal( '/wp-yaml/myplugin/myroute' );
 		});
 
-		it( 'correctly defaults to the containing object\'s _options, if present', function() {
+		it( 'correctly defaults to the containing object\'s _options, if present', () => {
 			var obj = {
 				factory: registerRoute( 'myplugin', 'myroute' ),
 				_options: {

--- a/tests/unit/route-handlers/comments.js
+++ b/tests/unit/route-handlers/comments.js
@@ -4,11 +4,11 @@ var expect = require( 'chai' ).expect;
 var WPAPI = require( '../../../wpapi' );
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 
-describe( 'wp.comments', function() {
+describe( 'wp.comments', () => {
 	var site;
 	var comments;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({
 			endpoint: '/wp-json',
 			username: 'foouser',
@@ -17,56 +17,56 @@ describe( 'wp.comments', function() {
 		comments = site.comments();
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			comments = site.comments({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( comments._options.endpoint ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should initialize _options to the site defaults', function() {
+		it( 'should initialize _options to the site defaults', () => {
 			expect( comments._options.endpoint ).to.equal( '/wp-json/' );
 			expect( comments._options.username ).to.equal( 'foouser' );
 			expect( comments._options.password ).to.equal( 'barpass' );
 		});
 
-		it( 'should initialize the base path component', function() {
+		it( 'should initialize the base path component', () => {
 			expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments' );
 		});
 
-		it( 'should set a default _supportedMethods array', function() {
+		it( 'should set a default _supportedMethods array', () => {
 			expect( comments ).to.have.property( '_supportedMethods' );
 			expect( comments._supportedMethods ).to.be.an( 'array' );
 		});
 
-		it( 'should inherit CommentsRequest from WPRequest', function() {
+		it( 'should inherit CommentsRequest from WPRequest', () => {
 			expect( comments instanceof WPRequest ).to.be.true;
 		});
 
 	});
 
-	describe( 'path part setters', function() {
+	describe( 'path part setters', () => {
 
-		describe( '.id()', function() {
+		describe( '.id()', () => {
 
-			it( 'provides a method to set the ID', function() {
+			it( 'provides a method to set the ID', () => {
 				expect( comments ).to.have.property( 'id' );
 				expect( comments.id ).to.be.a( 'function' );
 			});
 
-			it( 'should set the ID value in the path', function() {
+			it( 'should set the ID value in the path', () => {
 				comments.id( 314159 );
 				expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/314159' );
 			});
 
-			it( 'accepts ID parameters as strings', function() {
+			it( 'accepts ID parameters as strings', () => {
 				comments.id( '8' );
 				expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/8' );
 			});
 
-			it( 'should update the supported methods when setting ID', function() {
+			it( 'should update the supported methods when setting ID', () => {
 				comments.id( 8 );
 				var _supportedMethods = comments._supportedMethods.sort().join( '|' );
 				expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
@@ -76,47 +76,47 @@ describe( 'wp.comments', function() {
 
 	});
 
-	describe( 'URL Generation', function() {
+	describe( 'URL Generation', () => {
 
-		it( 'should create the URL for retrieving all comments', function() {
+		it( 'should create the URL for retrieving all comments', () => {
 			var path = comments.toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/comments' );
 		});
 
-		it( 'should create the URL for retrieving a specific comment', function() {
+		it( 'should create the URL for retrieving a specific comment', () => {
 			var path = comments.id( 1337 ).toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/comments/1337' );
 		});
 
-		it( 'does not throw an error if a valid numeric ID is specified', function() {
+		it( 'does not throw an error if a valid numeric ID is specified', () => {
 			expect(function numberPassesValidation() {
 				comments.id( 8 );
 				comments.validatePath();
 			}).not.to.throw();
 		});
 
-		it( 'does not throw an error if a valid numeric ID is specified as a string', function() {
+		it( 'does not throw an error if a valid numeric ID is specified as a string', () => {
 			expect( function numberAsStringPassesValidation() {
 				comments.id( '8' );
 				comments.validatePath();
 			}).not.to.throw();
 		});
 
-		it( 'throws an error if a non-integer numeric string ID is specified', function() {
+		it( 'throws an error if a non-integer numeric string ID is specified', () => {
 			expect( function nonIntegerNumberAsStringFailsValidation() {
 				comments.id( 4.019 );
 				comments.validatePath();
 			}).to.throw();
 		});
 
-		it( 'throws an error if a non-numeric string ID is specified', function() {
+		it( 'throws an error if a non-numeric string ID is specified', () => {
 			expect(function stringFailsValidation() {
 				comments.id( 'wombat' );
 				comments.validatePath();
 			}).to.throw();
 		});
 
-		it( 'should restrict path changes to a single instance', function() {
+		it( 'should restrict path changes to a single instance', () => {
 			comments.id( 2 );
 			var newComments = site.comments().id( 3 );
 			expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/2' );

--- a/tests/unit/route-handlers/media.js
+++ b/tests/unit/route-handlers/media.js
@@ -4,11 +4,11 @@ var expect = require( 'chai' ).expect;
 var WPAPI = require( '../../../wpapi' );
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 
-describe( 'wp.media', function() {
+describe( 'wp.media', () => {
 	var site;
 	var media;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({
 			endpoint: '/wp-json',
 			username: 'foouser',
@@ -17,76 +17,76 @@ describe( 'wp.media', function() {
 		media = site.media();
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			media = site.media({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( media._options.endpoint ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should initialize _options to the site defaults', function() {
+		it( 'should initialize _options to the site defaults', () => {
 			expect( media._options.endpoint ).to.equal( '/wp-json/' );
 			expect( media._options.username ).to.equal( 'foouser' );
 			expect( media._options.password ).to.equal( 'barpass' );
 		});
 
-		it( 'should initialize the base path component', function() {
+		it( 'should initialize the base path component', () => {
 			expect( media.toString() ).to.equal( '/wp-json/wp/v2/media' );
 		});
 
-		it( 'should set a default _supportedMethods array', function() {
+		it( 'should set a default _supportedMethods array', () => {
 			expect( media ).to.have.property( '_supportedMethods' );
 			expect( media._supportedMethods ).to.be.an( 'array' );
 		});
 
-		it( 'should inherit MediaRequest from WPRequest', function() {
+		it( 'should inherit MediaRequest from WPRequest', () => {
 			expect( media instanceof WPRequest ).to.be.true;
 		});
 
 	});
 
-	describe( '.id()', function() {
+	describe( '.id()', () => {
 
-		it( 'is defined', function() {
+		it( 'is defined', () => {
 			expect( media ).to.have.property( 'id' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( media.id ).to.be.a( 'function' );
 		});
 
-		it( 'should set the ID value in the path', function() {
+		it( 'should set the ID value in the path', () => {
 			media.id( 8 );
 			expect( media.toString() ).to.equal( '/wp-json/wp/v2/media/8' );
 		});
 
-		it( 'should update the supported methods', function() {
+		it( 'should update the supported methods', () => {
 			media.id( 8 );
 			var _supportedMethods = media._supportedMethods.sort().join( '|' );
 			expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
 		});
 
-		it( 'throws an error on successive calls', function() {
+		it( 'throws an error on successive calls', () => {
 			expect(function successiveCallsThrowsError() {
 				media.id( 8 ).id( 3 );
 			}).to.throw();
 		});
 
-		it( 'passes validation when called with a number', function() {
+		it( 'passes validation when called with a number', () => {
 			expect(function numberPassesValidation() {
 				media.id( 8 )._renderPath();
 			}).not.to.throw();
 		});
 
-		it( 'passes validation when called with a number formatted as a string', function() {
+		it( 'passes validation when called with a number formatted as a string', () => {
 			expect(function numberAsStringPassesValidation() {
 				media.id( '9' )._renderPath();
 			}).not.to.throw();
 		});
 
-		it( 'causes a validation error when called with a non-number', function() {
+		it( 'causes a validation error when called with a non-number', () => {
 			expect(function stringFailsValidation() {
 				media.id( 'wombat' )._renderPath();
 			}).to.throw();
@@ -94,19 +94,19 @@ describe( 'wp.media', function() {
 
 	});
 
-	describe( 'url generation', function() {
+	describe( 'url generation', () => {
 
-		it( 'should create the URL for the media collection', function() {
+		it( 'should create the URL for the media collection', () => {
 			var uri = media.toString();
 			expect( uri ).to.equal( '/wp-json/wp/v2/media' );
 		});
 
-		it( 'can paginate the media collection responses', function() {
+		it( 'can paginate the media collection responses', () => {
 			var uri = media.page( 4 ).toString();
 			expect( uri ).to.equal( '/wp-json/wp/v2/media?page=4' );
 		});
 
-		it( 'should create the URL for a specific media object', function() {
+		it( 'should create the URL for a specific media object', () => {
 			var uri = media.id( 1492 ).toString();
 			expect( uri ).to.equal( '/wp-json/wp/v2/media/1492' );
 		});

--- a/tests/unit/route-handlers/pages.js
+++ b/tests/unit/route-handlers/pages.js
@@ -4,11 +4,11 @@ var expect = require( 'chai' ).expect;
 var WPAPI = require( '../../../wpapi' );
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 
-describe( 'wp.pages', function() {
+describe( 'wp.pages', () => {
 	var site;
 	var pages;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({
 			endpoint: '/wp-json',
 			username: 'foouser',
@@ -17,52 +17,52 @@ describe( 'wp.pages', function() {
 		pages = site.pages();
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			pages = site.pages({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( pages._options.endpoint ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should initialize _options to the site defaults', function() {
+		it( 'should initialize _options to the site defaults', () => {
 			expect( pages._options.endpoint ).to.equal( '/wp-json/' );
 			expect( pages._options.username ).to.equal( 'foouser' );
 			expect( pages._options.password ).to.equal( 'barpass' );
 		});
 
-		it( 'should initialize the base path component', function() {
+		it( 'should initialize the base path component', () => {
 			expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages' );
 		});
 
-		it( 'should set a default _supportedMethods array', function() {
+		it( 'should set a default _supportedMethods array', () => {
 			expect( pages ).to.have.property( '_supportedMethods' );
 			expect( pages._supportedMethods ).to.be.an( 'array' );
 		});
 
-		it( 'should inherit PagesRequest from WPRequest', function() {
+		it( 'should inherit PagesRequest from WPRequest', () => {
 			expect( pages instanceof WPRequest ).to.be.true;
 		});
 
 	});
 
-	describe( 'URL Generation', function() {
+	describe( 'URL Generation', () => {
 
-		it( 'should restrict path changes to a single instance', function() {
+		it( 'should restrict path changes to a single instance', () => {
 			pages.id( 2 );
 			var newPages = site.pages().id( 3 ).revisions();
 			expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages/2' );
 			expect( newPages.toString() ).to.equal( '/wp-json/wp/v2/pages/3/revisions' );
 		});
 
-		describe( 'page collections', function() {
+		describe( 'page collections', () => {
 
-			it( 'should create the URL for retrieving all pages', function() {
+			it( 'should create the URL for retrieving all pages', () => {
 				expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages' );
 			});
 
-			it( 'should provide filtering methods', function() {
+			it( 'should provide filtering methods', () => {
 				expect( pages ).to.have.property( 'slug' );
 				expect( pages.slug ).to.be.a( 'function' );
 				var path = pages.slug( 'some-slug' ).toString();
@@ -71,19 +71,19 @@ describe( 'wp.pages', function() {
 
 		});
 
-		describe( '.id()', function() {
+		describe( '.id()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( pages ).to.have.property( 'id' );
 				expect( pages.id ).to.be.a( 'function' );
 			});
 
-			it( 'should create the URL for retrieving a specific post', function() {
+			it( 'should create the URL for retrieving a specific post', () => {
 				var path = pages.id( 1337 ).toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337' );
 			});
 
-			it( 'should update the supported methods when setting ID', function() {
+			it( 'should update the supported methods when setting ID', () => {
 				pages.id( 8 );
 				var _supportedMethods = pages._supportedMethods.sort().join( '|' );
 				expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
@@ -91,17 +91,17 @@ describe( 'wp.pages', function() {
 
 		});
 
-		describe( '.revisions()', function() {
+		describe( '.revisions()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( pages ).to.have.property( 'revisions' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( pages.revisions ).to.be.a( 'function' );
 			});
 
-			it( 'should create the URL for retrieving the revisions for a specific post', function() {
+			it( 'should create the URL for retrieving the revisions for a specific post', () => {
 				var path = pages.id( 1337 ).revisions().toString();
 				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/revisions' );
 			});

--- a/tests/unit/route-handlers/posts.js
+++ b/tests/unit/route-handlers/posts.js
@@ -4,11 +4,11 @@ var expect = require( 'chai' ).expect;
 var WPAPI = require( '../../../wpapi' );
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 
-describe( 'wp.posts', function() {
+describe( 'wp.posts', () => {
 	var site;
 	var posts;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({
 			endpoint: '/wp-json',
 			username: 'foouser',
@@ -17,56 +17,56 @@ describe( 'wp.posts', function() {
 		posts = site.posts();
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			posts = site.posts({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( posts._options.endpoint ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should initialize _options to the site defaults', function() {
+		it( 'should initialize _options to the site defaults', () => {
 			expect( posts._options.endpoint ).to.equal( '/wp-json/' );
 			expect( posts._options.username ).to.equal( 'foouser' );
 			expect( posts._options.password ).to.equal( 'barpass' );
 		});
 
-		it( 'should initialize the base path component', function() {
+		it( 'should initialize the base path component', () => {
 			expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts' );
 		});
 
-		it( 'should set a default _supportedMethods array', function() {
+		it( 'should set a default _supportedMethods array', () => {
 			expect( posts ).to.have.property( '_supportedMethods' );
 			expect( posts._supportedMethods ).to.be.an( 'array' );
 		});
 
-		it( 'should inherit PostsRequest from WPRequest', function() {
+		it( 'should inherit PostsRequest from WPRequest', () => {
 			expect( posts instanceof WPRequest ).to.be.true;
 		});
 
 	});
 
-	describe( 'path part setters', function() {
+	describe( 'path part setters', () => {
 
-		describe( '.id()', function() {
+		describe( '.id()', () => {
 
-			it( 'provides a method to set the ID', function() {
+			it( 'provides a method to set the ID', () => {
 				expect( posts ).to.have.property( 'id' );
 				expect( posts.id ).to.be.a( 'function' );
 			});
 
-			it( 'should set the ID value in the path', function() {
+			it( 'should set the ID value in the path', () => {
 				posts.id( 314159 );
 				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/314159' );
 			});
 
-			it( 'accepts ID parameters as strings', function() {
+			it( 'accepts ID parameters as strings', () => {
 				posts.id( '8' );
 				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/8' );
 			});
 
-			it( 'should update the supported methods when setting ID', function() {
+			it( 'should update the supported methods when setting ID', () => {
 				posts.id( 8 );
 				var _supportedMethods = posts._supportedMethods.sort().join( '|' );
 				expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
@@ -76,7 +76,7 @@ describe( 'wp.posts', function() {
 
 	});
 
-	it( 'provides expected filter methods', function() {
+	it( 'provides expected filter methods', () => {
 		[
 			'after',
 			'before',
@@ -94,57 +94,57 @@ describe( 'wp.posts', function() {
 		});
 	});
 
-	describe( 'URL Generation', function() {
+	describe( 'URL Generation', () => {
 
-		it( 'should create the URL for retrieving all posts', function() {
+		it( 'should create the URL for retrieving all posts', () => {
 			var path = posts.toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts' );
 		});
 
-		it( 'should create the URL for retrieving a specific post', function() {
+		it( 'should create the URL for retrieving a specific post', () => {
 			var path = posts.id( 1337 ).toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337' );
 		});
 
-		it( 'does not throw an error if a valid numeric ID is specified', function() {
+		it( 'does not throw an error if a valid numeric ID is specified', () => {
 			expect(function numberPassesValidation() {
 				posts.id( 8 );
 				posts.validatePath();
 			}).not.to.throw();
 		});
 
-		it( 'does not throw an error if a valid numeric ID is specified as a string', function() {
+		it( 'does not throw an error if a valid numeric ID is specified as a string', () => {
 			expect( function numberAsStringPassesValidation() {
 				posts.id( '8' );
 				posts.validatePath();
 			}).not.to.throw();
 		});
 
-		it( 'throws an error if a non-integer numeric string ID is specified', function() {
+		it( 'throws an error if a non-integer numeric string ID is specified', () => {
 			expect( function nonIntegerNumberAsStringFailsValidation() {
 				posts.id( 4.019 );
 				posts.validatePath();
 			}).to.throw();
 		});
 
-		it( 'throws an error if a non-numeric string ID is specified', function() {
+		it( 'throws an error if a non-numeric string ID is specified', () => {
 			expect(function stringFailsValidation() {
 				posts.id( 'wombat' );
 				posts.validatePath();
 			}).to.throw();
 		});
 
-		it( 'should create the URL for retrieving the revisions for a specific post', function() {
+		it( 'should create the URL for retrieving the revisions for a specific post', () => {
 			var path = posts.id( 1337 ).revisions().toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/revisions' );
 		});
 
-		it( 'should create the URL for retrieving a specific revision item', function() {
+		it( 'should create the URL for retrieving a specific revision item', () => {
 			var path = posts.id( 1337 ).revisions( 2001 ).toString();
 			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/revisions/2001' );
 		});
 
-		it( 'should restrict path changes to a single instance', function() {
+		it( 'should restrict path changes to a single instance', () => {
 			posts.id( 2 );
 			var newPosts = site.posts().id( 3 ).revisions();
 			expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/2' );

--- a/tests/unit/route-handlers/taxonomies.js
+++ b/tests/unit/route-handlers/taxonomies.js
@@ -4,11 +4,11 @@ var expect = require( 'chai' ).expect;
 var WPAPI = require( '../../../wpapi' );
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 
-describe( 'wp.taxonomies', function() {
+describe( 'wp.taxonomies', () => {
 	var site;
 	var taxonomies;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({
 			endpoint: '/wp-json',
 			username: 'foouser',
@@ -17,41 +17,41 @@ describe( 'wp.taxonomies', function() {
 		taxonomies = site.taxonomies();
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			taxonomies = site.taxonomies({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( taxonomies._options.endpoint ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should initialize _options to the site defaults', function() {
+		it( 'should initialize _options to the site defaults', () => {
 			expect( taxonomies._options.endpoint ).to.equal( '/wp-json/' );
 			expect( taxonomies._options.username ).to.equal( 'foouser' );
 			expect( taxonomies._options.password ).to.equal( 'barpass' );
 		});
 
-		it( 'should initialize the base path component', function() {
+		it( 'should initialize the base path component', () => {
 			expect( taxonomies.toString() ).to.equal( '/wp-json/wp/v2/taxonomies' );
 		});
 
-		it( 'should set a default _supportedMethods array', function() {
+		it( 'should set a default _supportedMethods array', () => {
 			expect( taxonomies ).to.have.property( '_supportedMethods' );
 			expect( taxonomies._supportedMethods ).to.be.an( 'array' );
 		});
 
-		it( 'should inherit TaxonomiesRequest from WPRequest', function() {
+		it( 'should inherit TaxonomiesRequest from WPRequest', () => {
 			expect( taxonomies instanceof WPRequest ).to.be.true;
 		});
 
 	});
 
-	describe( 'path part setters', function() {
+	describe( 'path part setters', () => {
 
-		describe( '.taxonomy()', function() {
+		describe( '.taxonomy()', () => {
 
-			it( 'provides a method to set the taxonomy', function() {
+			it( 'provides a method to set the taxonomy', () => {
 				expect( taxonomies ).to.have.property( 'taxonomy' );
 				expect( taxonomies.taxonomy ).to.be.a( 'function' );
 			});
@@ -60,14 +60,14 @@ describe( 'wp.taxonomies', function() {
 
 	});
 
-	describe( 'URL Generation', function() {
+	describe( 'URL Generation', () => {
 
-		it( 'should create the URL for retrieving all taxonomies', function() {
+		it( 'should create the URL for retrieving all taxonomies', () => {
 			var url = taxonomies.toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies' );
 		});
 
-		it( 'should create the URL for retrieving a specific taxonomy', function() {
+		it( 'should create the URL for retrieving a specific taxonomy', () => {
 			var url = taxonomies.taxonomy( 'category' ).toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies/category' );
 		});

--- a/tests/unit/route-handlers/types.js
+++ b/tests/unit/route-handlers/types.js
@@ -4,11 +4,11 @@ var expect = require( 'chai' ).expect;
 var WPAPI = require( '../../../wpapi' );
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 
-describe( 'wp.types', function() {
+describe( 'wp.types', () => {
 	var site;
 	var types;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({
 			endpoint: '/wp-json',
 			username: 'foouser',
@@ -17,44 +17,44 @@ describe( 'wp.types', function() {
 		types = site.types();
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			types = site.types({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( types._options.endpoint ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should initialize _options to the site defaults', function() {
+		it( 'should initialize _options to the site defaults', () => {
 			expect( types._options.endpoint ).to.equal( '/wp-json/' );
 			expect( types._options.username ).to.equal( 'foouser' );
 			expect( types._options.password ).to.equal( 'barpass' );
 		});
 
-		it( 'should initialize the base path component', function() {
+		it( 'should initialize the base path component', () => {
 			expect( types.toString() ).to.equal( '/wp-json/wp/v2/types' );
 		});
 
-		it( 'should set a default _supportedMethods array', function() {
+		it( 'should set a default _supportedMethods array', () => {
 			expect( types ).to.have.property( '_supportedMethods' );
 			expect( types._supportedMethods ).to.be.an( 'array' );
 		});
 
-		it( 'should inherit PostsRequest from WPRequest', function() {
+		it( 'should inherit PostsRequest from WPRequest', () => {
 			expect( types instanceof WPRequest ).to.be.true;
 		});
 
 	});
 
-	describe( 'URL Generation', function() {
+	describe( 'URL Generation', () => {
 
-		it( 'should create the URL for retrieving all types', function() {
+		it( 'should create the URL for retrieving all types', () => {
 			var url = types.toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/types' );
 		});
 
-		it( 'should create the URL for retrieving a specific term', function() {
+		it( 'should create the URL for retrieving a specific term', () => {
 			var url = types.type( 'some_type' ).toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/types/some_type' );
 		});

--- a/tests/unit/route-handlers/users.js
+++ b/tests/unit/route-handlers/users.js
@@ -4,11 +4,11 @@ var expect = require( 'chai' ).expect;
 var WPAPI = require( '../../../wpapi' );
 var WPRequest = require( '../../../lib/constructors/wp-request' );
 
-describe( 'wp.users', function() {
+describe( 'wp.users', () => {
 	var site;
 	var users;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({
 			endpoint: '/wp-json',
 			username: 'foouser',
@@ -17,75 +17,75 @@ describe( 'wp.users', function() {
 		users = site.users();
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'should set any passed-in options', function() {
+		it( 'should set any passed-in options', () => {
 			users = site.users({
 				endpoint: '/custom-endpoint/'
 			});
 			expect( users._options.endpoint ).to.equal( '/custom-endpoint/' );
 		});
 
-		it( 'should initialize _options to the site defaults', function() {
+		it( 'should initialize _options to the site defaults', () => {
 			expect( users._options.endpoint ).to.equal( '/wp-json/' );
 			expect( users._options.username ).to.equal( 'foouser' );
 			expect( users._options.password ).to.equal( 'barpass' );
 		});
 
-		it( 'should initialize the base path component', function() {
+		it( 'should initialize the base path component', () => {
 			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users' );
 		});
 
-		it( 'should set a default _supportedMethods array', function() {
+		it( 'should set a default _supportedMethods array', () => {
 			expect( users ).to.have.property( '_supportedMethods' );
 			expect( users._supportedMethods ).to.be.an( 'array' );
 		});
 
-		it( 'should inherit UsersRequest from WPRequest', function() {
+		it( 'should inherit UsersRequest from WPRequest', () => {
 			expect( users instanceof WPRequest ).to.be.true;
 		});
 
 	});
 
-	describe( '.me()', function() {
+	describe( '.me()', () => {
 
-		it( 'sets the path to users/me', function() {
+		it( 'sets the path to users/me', () => {
 			users.me();
 			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users/me' );
 		});
 
 	});
 
-	describe( '.id()', function() {
+	describe( '.id()', () => {
 
-		it( 'is defined', function() {
+		it( 'is defined', () => {
 			expect( users ).to.have.property( 'id' );
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( users.id ).to.be.a( 'function' );
 		});
 
-		it( 'sets the path ID to the passed-in value', function() {
+		it( 'sets the path ID to the passed-in value', () => {
 			users.id( 2501 );
 			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users/2501' );
 		});
 
 	});
 
-	describe( 'prototype.toString', function() {
+	describe( 'prototype.toString', () => {
 
-		it( 'should create the URL for retrieving all users', function() {
+		it( 'should create the URL for retrieving all users', () => {
 			var url = users.toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/users' );
 		});
 
-		it( 'should create the URL for retrieving the current user', function() {
+		it( 'should create the URL for retrieving the current user', () => {
 			var url = users.me().toString();
 			expect( url ).to.equal( '/wp-json/wp/v2/users/me' );
 		});
 
-		it( 'should create the URL for retrieving a specific user by ID', function() {
+		it( 'should create the URL for retrieving a specific user by ID', () => {
 			var url = users.id( 1337 ).toString();
 			var _supportedMethods = users._supportedMethods.sort().join( '|' );
 			expect( url ).to.equal( '/wp-json/wp/v2/users/1337' );

--- a/tests/unit/wpapi.js
+++ b/tests/unit/wpapi.js
@@ -21,24 +21,24 @@ var WPRequest = require( '../../lib/constructors/wp-request' );
 // HTTP transport, for stubbing
 var httpTransport = require( '../../lib/http-transport' );
 
-describe( 'WPAPI', function() {
+describe( 'WPAPI', () => {
 
 	var site;
 
-	beforeEach(function() {
+	beforeEach( () => {
 		site = new WPAPI({ endpoint: 'endpoint/url' });
 	});
 
-	describe( 'constructor', function() {
+	describe( 'constructor', () => {
 
-		it( 'enforces new', function() {
+		it( 'enforces new', () => {
 			var site1 = new WPAPI({ endpoint: '/' });
 			expect( site1 instanceof WPAPI ).to.be.true;
 			var site2 = WPAPI({ endpoint: '/' });
 			expect( site2 instanceof WPAPI ).to.be.true;
 		});
 
-		it( 'throws an error if no endpoint is provided', function() {
+		it( 'throws an error if no endpoint is provided', () => {
 			expect(function() {
 				new WPAPI({ endpoint: '/' });
 			}).not.to.throw();
@@ -47,7 +47,7 @@ describe( 'WPAPI', function() {
 			}).to.throw();
 		});
 
-		it( 'throws an error if a non-string endpoint is provided', function() {
+		it( 'throws an error if a non-string endpoint is provided', () => {
 			expect(function() {
 				new WPAPI({ endpoint: 42 });
 			}).to.throw();
@@ -59,7 +59,7 @@ describe( 'WPAPI', function() {
 			}).to.throw();
 		});
 
-		it( 'sets options on an instance variable', function() {
+		it( 'sets options on an instance variable', () => {
 			var site = new WPAPI({
 				endpoint: 'http://some.url.com/wp-json',
 				username: 'fyodor',
@@ -70,7 +70,7 @@ describe( 'WPAPI', function() {
 			expect( site._options.password ).to.equal( 'dostoyevsky' );
 		});
 
-		it( 'activates authentication when credentials are provided', function() {
+		it( 'activates authentication when credentials are provided', () => {
 			var site = new WPAPI({
 				endpoint: 'http://some.url.com/wp-json',
 				username: 'fyodor',
@@ -81,9 +81,9 @@ describe( 'WPAPI', function() {
 			expect( site._options.auth ).to.be.true;
 		});
 
-		describe( 'assigns default HTTP transport', function() {
+		describe( 'assigns default HTTP transport', () => {
 
-			it( 'for GET requests', function() {
+			it( 'for GET requests', () => {
 				sinon.stub( httpTransport, 'get' );
 				var site = new WPAPI({
 					endpoint: 'http://some.url.com/wp-json'
@@ -94,7 +94,7 @@ describe( 'WPAPI', function() {
 				httpTransport.get.restore();
 			});
 
-			it( 'for POST requests', function() {
+			it( 'for POST requests', () => {
 				sinon.stub( httpTransport, 'post' );
 				var site = new WPAPI({
 					endpoint: 'http://some.url.com/wp-json'
@@ -106,7 +106,7 @@ describe( 'WPAPI', function() {
 				httpTransport.post.restore();
 			});
 
-			it( 'for POST requests', function() {
+			it( 'for POST requests', () => {
 				sinon.stub( httpTransport, 'post' );
 				var site = new WPAPI({
 					endpoint: 'http://some.url.com/wp-json'
@@ -118,7 +118,7 @@ describe( 'WPAPI', function() {
 				httpTransport.post.restore();
 			});
 
-			it( 'for PUT requests', function() {
+			it( 'for PUT requests', () => {
 				sinon.stub( httpTransport, 'put' );
 				var site = new WPAPI({
 					endpoint: 'http://some.url.com/wp-json'
@@ -130,7 +130,7 @@ describe( 'WPAPI', function() {
 				httpTransport.put.restore();
 			});
 
-			it( 'for DELETE requests', function() {
+			it( 'for DELETE requests', () => {
 				sinon.stub( httpTransport, 'delete' );
 				var site = new WPAPI({
 					endpoint: 'http://some.url.com/wp-json'
@@ -146,9 +146,9 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( 'custom HTTP transport methods', function() {
+		describe( 'custom HTTP transport methods', () => {
 
-			it( 'can be set for an individual HTTP action', function() {
+			it( 'can be set for an individual HTTP action', () => {
 				sinon.stub( httpTransport, 'get' );
 				var customGet = sinon.stub();
 				var site = new WPAPI({
@@ -164,7 +164,7 @@ describe( 'WPAPI', function() {
 				httpTransport.get.restore();
 			});
 
-			it( 'can extend the default HTTP transport methods', function() {
+			it( 'can extend the default HTTP transport methods', () => {
 				sinon.stub( httpTransport, 'get' );
 				var customGet = sinon.spy(function() {
 					WPAPI.transport.get.apply( null, arguments );
@@ -182,7 +182,7 @@ describe( 'WPAPI', function() {
 				httpTransport.get.restore();
 			});
 
-			it( 'can be set for multiple HTTP actions', function() {
+			it( 'can be set for multiple HTTP actions', () => {
 				sinon.stub( httpTransport, 'post' );
 				sinon.stub( httpTransport, 'put' );
 				var customPost = sinon.stub();
@@ -206,7 +206,7 @@ describe( 'WPAPI', function() {
 				httpTransport.put.restore();
 			});
 
-			it( 'only apply to a specific WPAPI instance', function() {
+			it( 'only apply to a specific WPAPI instance', () => {
 				sinon.stub( httpTransport, 'get' );
 				var customGet = sinon.stub();
 				var site = new WPAPI({
@@ -230,17 +230,17 @@ describe( 'WPAPI', function() {
 
 	});
 
-	describe( '.transport constructor property', function() {
+	describe( '.transport constructor property', () => {
 
-		it( 'is defined', function() {
+		it( 'is defined', () => {
 			expect( WPAPI ).to.have.property( 'transport' );
 		});
 
-		it( 'is an object', function() {
+		it( 'is an object', () => {
 			expect( WPAPI.transport ).to.be.an( 'object' );
 		});
 
-		it( 'has methods for each http transport action', function() {
+		it( 'has methods for each http transport action', () => {
 			expect( WPAPI.transport.delete ).to.be.a( 'function' );
 			expect( WPAPI.transport.get ).to.be.a( 'function' );
 			expect( WPAPI.transport.head ).to.be.a( 'function' );
@@ -248,7 +248,7 @@ describe( 'WPAPI', function() {
 			expect( WPAPI.transport.put ).to.be.a( 'function' );
 		});
 
-		it( 'is frozen (properties cannot be modified directly)', function() {
+		it( 'is frozen (properties cannot be modified directly)', () => {
 			expect(function() {
 				WPAPI.transport.get = function() {};
 			}).to.throw();
@@ -256,20 +256,20 @@ describe( 'WPAPI', function() {
 
 	});
 
-	describe( '.site() constructor method', function() {
+	describe( '.site() constructor method', () => {
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( WPAPI ).to.have.property( 'site' );
 			expect( WPAPI.site ).to.be.a( 'function' );
 		});
 
-		it( 'creates and returns a new WPAPI instance', function() {
+		it( 'creates and returns a new WPAPI instance', () => {
 			var site = WPAPI.site( 'endpoint/url' );
 			expect( site instanceof WPAPI ).to.be.true;
 			expect( site._options.endpoint ).to.equal( 'endpoint/url/' );
 		});
 
-		it( 'can take a routes configuration object to bootstrap the returned instance', function() {
+		it( 'can take a routes configuration object to bootstrap the returned instance', () => {
 			var site = WPAPI.site( 'endpoint/url', {
 				'/wp/v2/posts': {
 					namespace: 'wp/v2',
@@ -292,11 +292,11 @@ describe( 'WPAPI', function() {
 
 	});
 
-	describe( '.discover() constructor method', function() {
+	describe( '.discover() constructor method', () => {
 		var responses;
 		var sinonSandbox;
 
-		beforeEach(function() {
+		beforeEach( () => {
 			responses = {
 				head: {},
 				get: {}
@@ -345,12 +345,12 @@ describe( 'WPAPI', function() {
 			sinonSandbox.restore();
 		});
 
-		it( 'is a function', function() {
+		it( 'is a function', () => {
 			expect( WPAPI ).to.have.property( 'discover' );
 			expect( WPAPI.discover ).to.be.a( 'function' );
 		});
 
-		it( 'throws an error if no API endpoint can be discovered', function() {
+		it( 'throws an error if no API endpoint can be discovered', () => {
 			var url = 'http://we.made.it/to/mozarts/house';
 			httpTransport.head.onFirstCall().returns( Promise.reject() );
 			httpTransport.get.onFirstCall().returns( Promise.reject( 'Some error' ) );
@@ -363,7 +363,7 @@ describe( 'WPAPI', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'discovers the API root with a HEAD request', function() {
+		it( 'discovers the API root with a HEAD request', () => {
 			var url = 'http://mozarts.house';
 			httpTransport.head.returns( Promise.resolve( responses.head.withLink ) );
 			httpTransport.get.returns( Promise.resolve( responses.apiRoot ) );
@@ -378,7 +378,7 @@ describe( 'WPAPI', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'throws an error if HEAD succeeds but no link is present', function() {
+		it( 'throws an error if HEAD succeeds but no link is present', () => {
 			var url = 'http://we.made.it/to/mozarts/house';
 			httpTransport.head.onFirstCall().returns( Promise.resolve( responses.head.withoutLink ) );
 			var prom = WPAPI.discover( url )
@@ -391,7 +391,7 @@ describe( 'WPAPI', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'retries the initial site request as a GET if HEAD fails', function() {
+		it( 'retries the initial site request as a GET if HEAD fails', () => {
 			var url = 'http://mozarts.house';
 			httpTransport.head.returns( Promise.reject() );
 			httpTransport.get.onFirstCall().returns( Promise.resolve( responses.get.withLink ) );
@@ -407,7 +407,7 @@ describe( 'WPAPI', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'throws an error if GET retry succeeds but no link is present', function() {
+		it( 'throws an error if GET retry succeeds but no link is present', () => {
 			var url = 'http://we.made.it/to/mozarts/house';
 			httpTransport.head.returns( Promise.reject() );
 			httpTransport.get.onFirstCall().returns( Promise.resolve( responses.get.withoutLink ) );
@@ -421,7 +421,7 @@ describe( 'WPAPI', function() {
 			return expect( prom ).to.eventually.equal( SUCCESS );
 		});
 
-		it( 'returns WPAPI instance bound to discovered root even when route request errors', function() {
+		it( 'returns WPAPI instance bound to discovered root even when route request errors', () => {
 			var url = 'http://mozarts.house';
 			httpTransport.head.returns( Promise.reject() );
 			httpTransport.get.onFirstCall().returns( Promise.resolve( responses.get.withLink ) );
@@ -441,16 +441,16 @@ describe( 'WPAPI', function() {
 
 	});
 
-	describe( '.prototype', function() {
+	describe( '.prototype', () => {
 
-		describe( '.namespace()', function() {
+		describe( '.namespace()', () => {
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( site ).to.have.property( 'namespace' );
 				expect( site.namespace ).to.be.a( 'function' );
 			});
 
-			it( 'returns a namespace object with relevant endpoint handler methods', function() {
+			it( 'returns a namespace object with relevant endpoint handler methods', () => {
 				var wpV2 = site.namespace( 'wp/v2' );
 				// Spot check
 				expect( wpV2 ).to.be.an( 'object' );
@@ -460,7 +460,7 @@ describe( 'WPAPI', function() {
 				expect( wpV2.comments ).to.be.a( 'function' );
 			});
 
-			it( 'passes options from the parent WPAPI instance to the namespaced handlers', function() {
+			it( 'passes options from the parent WPAPI instance to the namespaced handlers', () => {
 				site.auth({
 					username: 'u',
 					password: 'p'
@@ -473,7 +473,7 @@ describe( 'WPAPI', function() {
 				expect( pages._options.password ).to.equal( 'p' );
 			});
 
-			it( 'permits the namespace to be stored in a variable without disrupting options', function() {
+			it( 'permits the namespace to be stored in a variable without disrupting options', () => {
 				site.auth({
 					username: 'u',
 					password: 'p'
@@ -487,13 +487,13 @@ describe( 'WPAPI', function() {
 				expect( pages._options.password ).to.equal( 'p' );
 			});
 
-			it( 'throws an error when provided no namespace', function() {
+			it( 'throws an error when provided no namespace', () => {
 				expect(function() {
 					site.namespace();
 				}).to.throw();
 			});
 
-			it( 'throws an error when provided an unregistered namespace', function() {
+			it( 'throws an error when provided an unregistered namespace', () => {
 				expect(function() {
 					site.namespace( 'foo/baz' );
 				}).to.throw();
@@ -501,9 +501,9 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( '.bootstrap()', function() {
+		describe( '.bootstrap()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				site.bootstrap({
 					'/myplugin/v1/authors/(?P<name>[\\w-]+)': {
 						namespace: 'myplugin/v1',
@@ -528,16 +528,16 @@ describe( 'WPAPI', function() {
 				});
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( site ).to.have.property( 'bootstrap' );
 				expect( site.bootstrap ).to.be.a( 'function' );
 			});
 
-			it( 'is chainable', function() {
+			it( 'is chainable', () => {
 				expect( site.bootstrap() ).to.equal( site );
 			});
 
-			it( 'creates handlers for all provided route definitions', function() {
+			it( 'creates handlers for all provided route definitions', () => {
 				expect( site.namespace( 'myplugin/v1' ) ).to.be.an( 'object' );
 				expect( site.namespace( 'myplugin/v1' ) ).to.have.property( 'authors' );
 				expect( site.namespace( 'myplugin/v1' ).authors ).to.be.a( 'function' );
@@ -546,14 +546,14 @@ describe( 'WPAPI', function() {
 				expect( site.namespace( 'wp/v2' ).customendpoint ).to.be.a( 'function' );
 			});
 
-			it( 'properly assigns setter methods for detected path parts', function() {
+			it( 'properly assigns setter methods for detected path parts', () => {
 				var thingHandler = site.customendpoint();
 				expect( thingHandler ).to.have.property( 'thing' );
 				expect( thingHandler.thing ).to.be.a( 'function' );
 				expect( thingHandler.thing( 'foobar' ).toString() ).to.equal( 'endpoint/url/wp/v2/customendpoint/foobar' );
 			});
 
-			it( 'assigns any mixins for detected GET arguments for custom namespace handlers', function() {
+			it( 'assigns any mixins for detected GET arguments for custom namespace handlers', () => {
 				var authorsHandler = site.namespace( 'myplugin/v1' ).authors();
 				expect( authorsHandler ).to.have.property( 'name' );
 				expect( authorsHandler ).not.to.have.ownProperty( 'name' );
@@ -564,7 +564,7 @@ describe( 'WPAPI', function() {
 				expect( customEndpoint.parent ).to.be.a( 'function' );
 			});
 
-			it( 'assigns handlers for wp/v2 routes to the instance object itself', function() {
+			it( 'assigns handlers for wp/v2 routes to the instance object itself', () => {
 				expect( site ).to.have.property( 'customendpoint' );
 				expect( site.customendpoint ).to.be.a( 'function' );
 				expect( site.namespace( 'wp/v2' ).customendpoint ).to.equal( site.customendpoint );
@@ -572,21 +572,21 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( '.transport()', function() {
+		describe( '.transport()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( site ).to.have.property( 'transport' );
 			});
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( site.transport ).to.be.a( 'function' );
 			});
 
-			it( 'is chainable', function() {
+			it( 'is chainable', () => {
 				expect( site.transport() ).to.equal( site );
 			});
 
-			it( 'sets transport methods on the instance', function() {
+			it( 'sets transport methods on the instance', () => {
 				sinon.stub( httpTransport, 'get' );
 				var customGet = sinon.stub();
 				site.transport({
@@ -600,7 +600,7 @@ describe( 'WPAPI', function() {
 				httpTransport.get.restore();
 			});
 
-			it( 'does not impact or overwrite unspecified transport methods', function() {
+			it( 'does not impact or overwrite unspecified transport methods', () => {
 				var originalMethods = Object.assign( {}, site._options.transport );
 				site.transport({
 					get: function() {},
@@ -616,26 +616,26 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( '.url()', function() {
+		describe( '.url()', () => {
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( site ).to.have.property( 'url' );
 				expect( site.url ).to.be.a( 'function' );
 			});
 
-			it( 'creates a basic WPRequest object bound to the provided URL', function() {
+			it( 'creates a basic WPRequest object bound to the provided URL', () => {
 				var request = site.url( 'http://some.arbitrary.url' );
 				expect( request instanceof WPRequest ).to.be.true;
 				expect( request._options.endpoint ).to.equal( 'http://some.arbitrary.url' );
 			});
 
-			it( 'maps requests directly onto the provided URL', function() {
+			it( 'maps requests directly onto the provided URL', () => {
 				var request = site.url( 'http://some.url.com/wp-json?filter[name]=some-slug' );
 				var path = request.toString();
 				expect( path ).to.equal( 'http://some.url.com/wp-json?filter[name]=some-slug' );
 			});
 
-			it( 'inherits whitelisted non-endpoint options from the parent WPAPI instance', function() {
+			it( 'inherits whitelisted non-endpoint options from the parent WPAPI instance', () => {
 				var site = new WPAPI({
 					endpoint: 'http://website.com/',
 					identifier: 'some unique value'
@@ -648,33 +648,33 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( '.root()', function() {
+		describe( '.root()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				site = new WPAPI({ endpoint: 'http://my.site.com/wp-json' });
 			});
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( site ).to.have.property( 'root' );
 				expect( site.root ).to.be.a( 'function' );
 			});
 
-			it( 'creates a get request against the root endpoint', function() {
+			it( 'creates a get request against the root endpoint', () => {
 				var request = site.root();
 				expect( request.toString() ).to.equal( 'http://my.site.com/wp-json/' );
 			});
 
-			it( 'takes a "path" argument to query a root-relative path', function() {
+			it( 'takes a "path" argument to query a root-relative path', () => {
 				var request = site.root( 'custom/endpoint' );
 				expect( request.toString() ).to.equal( 'http://my.site.com/wp-json/custom/endpoint' );
 			});
 
-			it( 'creates a WPRequest object', function() {
+			it( 'creates a WPRequest object', () => {
 				var pathRequest = site.root( 'some/collection/endpoint' );
 				expect( pathRequest instanceof WPRequest ).to.be.true;
 			});
 
-			it( 'inherits options from the parent WPAPI instance', function() {
+			it( 'inherits options from the parent WPAPI instance', () => {
 				var site = new WPAPI({
 					endpoint: 'http://cat.website.com/'
 				});
@@ -685,25 +685,25 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( '.auth()', function() {
+		describe( '.auth()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				site = new WPAPI({ endpoint: 'http://my.site.com/wp-json' });
 			});
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( site ).to.have.property( 'auth' );
 				expect( site.auth ).to.be.a( 'function' );
 			});
 
-			it( 'activates authentication for the site', function() {
+			it( 'activates authentication for the site', () => {
 				expect( site._options ).not.to.have.property( 'auth' );
 				site.auth();
 				expect( site._options ).to.have.property( 'auth' );
 				expect( site._options.auth ).to.be.true;
 			});
 
-			it( 'sets the username and password when provided in an object', function() {
+			it( 'sets the username and password when provided in an object', () => {
 				site.auth({
 					username: 'user1',
 					password: 'pass1'
@@ -716,7 +716,7 @@ describe( 'WPAPI', function() {
 				expect( site._options.auth ).to.be.true;
 			});
 
-			it( 'can update previously-set usernames and passwords', function() {
+			it( 'can update previously-set usernames and passwords', () => {
 				site.auth({
 					username: 'user1',
 					password: 'pass1'
@@ -732,7 +732,7 @@ describe( 'WPAPI', function() {
 				expect( site._options.auth ).to.be.true;
 			});
 
-			it( 'sets the nonce when provided in an object', function() {
+			it( 'sets the nonce when provided in an object', () => {
 				site.auth({
 					nonce: 'somenonce'
 				});
@@ -742,7 +742,7 @@ describe( 'WPAPI', function() {
 				expect( site._options.auth ).to.be.true;
 			});
 
-			it( 'can update nonce credentials', function() {
+			it( 'can update nonce credentials', () => {
 				site.auth({
 					nonce: 'somenonce'
 				}).auth({
@@ -754,7 +754,7 @@ describe( 'WPAPI', function() {
 				expect( site._options.auth ).to.be.true;
 			});
 
-			it( 'passes authentication status to all subsequently-instantiated handlers', function() {
+			it( 'passes authentication status to all subsequently-instantiated handlers', () => {
 				site.auth({
 					username: 'user',
 					password: 'pass'
@@ -772,25 +772,25 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( '.setHeaders()', function() {
+		describe( '.setHeaders()', () => {
 
-			beforeEach(function() {
+			beforeEach( () => {
 				site = new WPAPI({ endpoint: 'http://my.site.com/wp-json' });
 			});
 
-			it( 'is defined', function() {
+			it( 'is defined', () => {
 				expect( site ).to.have.property( 'setHeaders' );
 				expect( site.setHeaders ).to.be.a( 'function' );
 			});
 
-			it( 'initializes site-wide headers object if called with no arguments', function() {
+			it( 'initializes site-wide headers object if called with no arguments', () => {
 				expect( site._options ).not.to.have.property( 'headers' );
 				site.setHeaders();
 				expect( site._options ).to.have.property( 'headers' );
 				expect( site._options.headers ).to.deep.equal({});
 			});
 
-			it( 'sets site-wide headers when provided a name-value pair', function() {
+			it( 'sets site-wide headers when provided a name-value pair', () => {
 				site.setHeaders( 'Accept-Language', 'en-US' );
 				expect( site._options ).to.have.property( 'headers' );
 				expect( site._options.headers ).to.deep.equal({
@@ -798,7 +798,7 @@ describe( 'WPAPI', function() {
 				});
 			});
 
-			it( 'sets site-wide headers when provided an object of header name-value pairs', function() {
+			it( 'sets site-wide headers when provided an object of header name-value pairs', () => {
 				site.setHeaders({
 					'Accept-Language': 'en-CA',
 					Authorization: 'Bearer sometoken'
@@ -810,7 +810,7 @@ describe( 'WPAPI', function() {
 				});
 			});
 
-			it( 'passes headers to all subsequently-instantiated handlers', function() {
+			it( 'passes headers to all subsequently-instantiated handlers', () => {
 				site.setHeaders({
 					'Accept-Language': 'en-IL',
 					Authorization: 'Bearer chicagostylepizza'
@@ -827,9 +827,9 @@ describe( 'WPAPI', function() {
 
 		});
 
-		describe( '.registerRoute()', function() {
+		describe( '.registerRoute()', () => {
 
-			it( 'is a function', function() {
+			it( 'is a function', () => {
 				expect( site ).to.have.property( 'registerRoute' );
 				expect( site.registerRoute ).to.be.a( 'function' );
 			});
@@ -838,44 +838,44 @@ describe( 'WPAPI', function() {
 
 	});
 
-	describe( 'instance has endpoint accessors', function() {
+	describe( 'instance has endpoint accessors', () => {
 
-		it( 'for the media endpoint', function() {
+		it( 'for the media endpoint', () => {
 			expect( site ).to.have.property( 'media' );
 			expect( site.media ).to.be.a( 'function' );
 		});
 
-		it( 'for the pages endpoint', function() {
+		it( 'for the pages endpoint', () => {
 			expect( site ).to.have.property( 'pages' );
 			expect( site.pages ).to.be.a( 'function' );
 		});
 
-		it( 'for the posts endpoint', function() {
+		it( 'for the posts endpoint', () => {
 			expect( site ).to.have.property( 'posts' );
 			expect( site.posts ).to.be.a( 'function' );
 		});
 
-		it( 'for the taxonomies endpoint', function() {
+		it( 'for the taxonomies endpoint', () => {
 			expect( site ).to.have.property( 'taxonomies' );
 			expect( site.taxonomies ).to.be.a( 'function' );
 		});
 
-		it( 'for the categories endpoint', function() {
+		it( 'for the categories endpoint', () => {
 			expect( site ).to.have.property( 'categories' );
 			expect( site.categories ).to.be.a( 'function' );
 		});
 
-		it( 'for the tags endpoint', function() {
+		it( 'for the tags endpoint', () => {
 			expect( site ).to.have.property( 'tags' );
 			expect( site.tags ).to.be.a( 'function' );
 		});
 
-		it( 'for the types endpoint', function() {
+		it( 'for the types endpoint', () => {
 			expect( site ).to.have.property( 'types' );
 			expect( site.types ).to.be.a( 'function' );
 		});
 
-		it( 'for the users endpoint', function() {
+		it( 'for the users endpoint', () => {
 			expect( site ).to.have.property( 'users' );
 			expect( site.users ).to.be.a( 'function' );
 		});


### PR DESCRIPTION
- Fixes integration suite error encountered due to core changes in [#42422](https://core.trac.wordpress.org/changeset/42422)
- Adjusts travis configuration to explicitly specify node's current LTS, not just latest stable; and ensure that 6, 8 and 10 all pass. Node 4 is no longer officially supported by this library.
- Switch to fat arrow functions in all test suites