### PR TITLE
Migrate Chai assertions to Jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ documentation/index.html
 
 # Built files (for use in browser)
 browser/
+
+# Consuming applications should maintain their own lockfile.
+package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ New features in this library should be accompanied by unit tests demonstrating t
 
 Our tests are broken down into a unit test suite, and an integration test suite. When you add a feature, you should ensure that your changes pass all tests in both suites. And if you find a bug, a test demonstrating that bug is just as useful as a patch that actually solves the problem!
 
-The unit tests can be run without any additional setup with `npm run test:unit`, but running more comprehensive tests (e.g. `npm test`, `npm run mocha`, etc.) requires additional work as described below in Integration Tests.
+The unit tests can be run without any additional setup with `npm run test:unit`, but running more comprehensive tests (e.g. `npm test`, `npm run test:integration`, etc.) requires additional work as described below in Integration Tests.
 
 ### Integration Tests
 
@@ -18,19 +18,17 @@ In order to run the integration tests you will need to run a specifically-config
 
 ### Adding Tests
 
-Adding new code, or submitting a pull request? If it does something, it should have tests! Under the hood we use [Mocha](visionmedia.github.io/mocha/) to run our tests, and write our assertions using [Chai's "expect" BDD syntax](http://chaijs.com/api/bdd/), *e.g.*:
+Adding new code, or submitting a pull request? If it does something, it should have tests! Under the hood we use [Jest](https://jestjs.io/) to run our tests, and write our assertions using [Jest's "expect" BDD syntax](https://jestjs.io/docs/en/expect), *e.g.*:
 ```javascript
-expect( wp._options.endpoint ).to.equal( 'http://some.url.com/wp-json/' );
+expect( wp._options.endpoint ).toBe( 'http://some.url.com/wp-json/' );
 ```
 
-**If you are uncomfortable or unfamiliar with writing unit tests, you should feel free to submit a pull request without them!** We'll work with you in the PR comments to walk you through how to test the code.
+**If you are uncomfortable or unfamiliar with writing unit tests,** that's fine! You should feel free to submit a pull request without them. We'll work with you in the PR comments to walk you through how to test the code.
 
 #### This Function Is Totally Not A Spy
 
-We use [Sinon.js](sinonjs.org/docs/) for [spying on](sinonjs.org/docs/#spies) and [stubbing](http://sinonjs.org/docs/#stubs) functionality. Sinon assertions should also be written with the BDD style, which is enabled via [sinon-chai](https://www.npmjs.org/package/sinon-chai):
-```javascript
-expect( mockAgent.get ).to.have.been.calledWith( 'url/' );
-```
+When writing unit tests we want to test only a specific piece of logic, without causing side-effects. To prevent our tests from doing things like actually sending real HTTP requests, we use Jest's [spy](https://jestjs.io/docs/en/jest-object.html#jestspyonobject-methodname), [mocking & stubbing](https://jestjs.io/docs/en/mock-functions) functionality.
+
 See the [existing test files](https://github.com/wp-api/node-wpapi/tree/master/tests) for more examples.
 
 ## Best Practices for Commits

--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
     "superagent": "^3.3.1"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
     "combyne": "^2.0.0",
     "eslint": "^4.19.1",
     "grunt": "^1.0.1",
@@ -86,8 +84,6 @@
     "minimist": "^1.2.0",
     "prompt": "^1.0.0",
     "rimraf": "^2.6.1",
-    "sinon": "^1.17.4",
-    "sinon-chai": "^2.8.0",
     "webpack": "^1.13.1"
   }
 }

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
 	'env': {
-		mocha: true,
+		jest: true,
 	},
 };

--- a/tests/helpers/http-test-utils.js
+++ b/tests/helpers/http-test-utils.js
@@ -1,6 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-const expect = chai.expect;
 const fs = require( 'fs' );
 const http = require( 'http' );
 
@@ -34,7 +32,7 @@ const expectFileEqualsURL = ( filePath, url ) => new Promise( ( resolve, reject 
 			const originalFile = fs.readFileSync( filePath );
 
 			const buffersEqual = downloadedImageBuffer.equals( originalFile );
-			expect( buffersEqual ).to.equal( true );
+			expect( buffersEqual ).toBe( true );
 
 			if ( buffersEqual ) {
 				return resolve( true );
@@ -44,14 +42,7 @@ const expectFileEqualsURL = ( filePath, url ) => new Promise( ( resolve, reject 
 	} );
 } );
 
-const rethrowIfChaiError = ( error ) => {
-	if ( error instanceof chai.AssertionError ) {
-		throw error;
-	}
-};
-
 module.exports = {
 	expectStatusCode: expectStatusCode,
 	expectFileEqualsURL: expectFileEqualsURL,
-	rethrowIfChaiError: rethrowIfChaiError,
 };

--- a/tests/integration/autodiscovery.js
+++ b/tests/integration/autodiscovery.js
@@ -1,14 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-chai.use( require( 'sinon-chai' ) );
-const expect = chai.expect;
-const sinon = require( 'sinon' );
 
 const WPAPI = require( '../../' );
 const WPRequest = require( '../../lib/constructors/wp-request.js' );
@@ -18,63 +8,61 @@ const WPRequest = require( '../../lib/constructors/wp-request.js' );
 const getTitles = require( '../helpers/get-rendered-prop' ).bind( null, 'title' );
 const credentials = require( '../helpers/constants' ).credentials;
 
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
+
 // Define some arrays to use ensuring the returned data is what we expect
 // it to be (e.g. an array of the titles from posts on the first page)
 const expectedResults = {
 	firstPostTitle: 'Markup: HTML Tags and Formatting',
 };
 
+const noop = () => {};
+
 describe( 'integration: discover()', () => {
 	let apiPromise;
-	let sinonSandbox;
 
-	beforeEach( () => {
+	beforeAll( () => {
 		apiPromise = WPAPI.discover( 'http://wpapi.local' );
 		// Stub warn and error
-		sinonSandbox = sinon.sandbox.create();
-		sinonSandbox.stub( global.console, 'warn' );
-		sinonSandbox.stub( global.console, 'error' );
-	} );
-
-	afterEach( () => {
-		// Restore sandbox
-		sinonSandbox.restore();
+		jest.spyOn( global.console, 'warn' ).mockImplementation( noop );
+		jest.spyOn( global.console, 'error' ).mockImplementation( noop );
 	} );
 
 	it( 'returns a promise', () => {
 		const Promise = require( 'es6-promise' );
-		expect( apiPromise ).to.be.an.instanceOf( Promise );
+		expect( apiPromise ).toBeInstanceOf( Promise );
 	} );
 
 	it( 'eventually returns a configured WP instance', () => {
 		const prom = apiPromise
 			.then( ( result ) => {
-				expect( result ).to.be.an.instanceOf( WPAPI );
-				expect( result.namespace( 'wp/v2' ) ).to.be.an( 'object' );
-				expect( result.posts ).to.be.a( 'function' );
-				expect( result.posts() ).to.be.an.instanceOf( WPRequest );
+				expect( result ).toBeInstanceOf( WPAPI );
+				expect( typeof result.namespace( 'wp/v2' ) ).toBe( 'object' );
+				expect( typeof result.posts ).toBe( 'function' );
+				expect( result.posts() ).toBeInstanceOf( WPRequest );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'auto-binds to the detected endpoint on the provided site', () => {
 		const prom = apiPromise
 			.then( ( site ) => {
-				expect( site.posts().toString() ).to.equal( 'http://wpapi.local/wp-json/wp/v2/posts' );
+				expect( site.posts().toString() ).toBe( 'http://wpapi.local/wp-json/wp/v2/posts' );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can correctly instantiate requests against the detected and bound site', () => {
 		const prom = apiPromise
 			.then( site => site.posts() )
 			.then( ( posts ) => {
-				expect( getTitles( posts )[ 0 ] ).to.equal( expectedResults.firstPostTitle );
+				expect( getTitles( posts )[ 0 ] ).toBe( expectedResults.firstPostTitle );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	describe( 'can authenticate', () => {
@@ -84,22 +72,22 @@ describe( 'integration: discover()', () => {
 				.then( site => site.auth( credentials ) )
 				.then( site => site.users().me() )
 				.then( ( user ) => {
-					expect( user ).to.be.an( 'object' );
-					expect( user.slug ).to.equal( credentials.username );
+					expect( typeof user ).toBe( 'object' );
+					expect( user.slug ).toBe( credentials.username );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'one-off requests against the detected and bound site', () => {
 			const prom = apiPromise
 				.then( site => site.users().auth( credentials ).me() )
 				.then( ( user ) => {
-					expect( user ).to.be.an( 'object' );
-					expect( user.slug ).to.equal( credentials.username );
+					expect( typeof user ).toBe( 'object' );
+					expect( user.slug ).toBe( credentials.username );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );

--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -1,12 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
 const WPRequest = require( '../../lib/constructors/wp-request.js' );
@@ -14,6 +6,9 @@ const WPRequest = require( '../../lib/constructors/wp-request.js' );
 // Inspecting the names of the returned categories is an easy way to validate
 // that the right page of results was returned
 const getNames = require( '../helpers/get-prop' ).bind( null, 'name' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 // Define some arrays to use ensuring the returned data is what we expect
 // it to be (e.g. an array of the names from categories on the first page)
@@ -66,22 +61,22 @@ describe( 'integration: categories()', () => {
 		const prom = wp.categories()
 			.get()
 			.then( ( categories ) => {
-				expect( categories ).to.be.an( 'array' );
-				expect( categories.length ).to.equal( 10 );
+				expect( Array.isArray( categories ) ).toBe( true );
+				expect( categories.length ).toBe( 10 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'retrieves the first 10 categories by default', () => {
 		const prom = wp.categories()
 			.get()
 			.then( ( categories ) => {
-				expect( categories ).to.be.an( 'array' );
-				expect( categories.length ).to.equal( 10 );
+				expect( Array.isArray( categories ) ).toBe( true );
+				expect( categories.length ).toBe( 10 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	describe( 'paging properties', () => {
@@ -90,55 +85,55 @@ describe( 'integration: categories()', () => {
 			const prom = wp.categories()
 				.get()
 				.then( ( categories ) => {
-					expect( categories ).to.have.property( '_paging' );
-					expect( categories._paging ).to.be.an( 'object' );
+					expect( categories ).toHaveProperty( '_paging' );
+					expect( typeof categories._paging ).toBe( 'object' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of categories', () => {
 			const prom = wp.categories()
 				.get()
 				.then( ( categories ) => {
-					expect( categories._paging ).to.have.property( 'total' );
-					expect( categories._paging.total ).to.equal( '65' );
+					expect( categories._paging ).toHaveProperty( 'total' );
+					expect( categories._paging.total ).toBe( '65' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of pages available', () => {
 			const prom = wp.categories()
 				.get()
 				.then( ( categories ) => {
-					expect( categories._paging ).to.have.property( 'totalPages' );
-					expect( categories._paging.totalPages ).to.equal( '7' );
+					expect( categories._paging ).toHaveProperty( 'totalPages' );
+					expect( categories._paging.totalPages ).toBe( '7' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			const prom = wp.categories()
 				.get()
 				.then( ( categories ) => {
-					expect( categories._paging ).to.have.property( 'next' );
-					expect( categories._paging.next ).to.be.an( 'object' );
-					expect( categories._paging.next ).to.be.an.instanceOf( WPRequest );
-					expect( categories._paging.next._options.endpoint ).to
-						.equal( 'http://wpapi.local/wp-json/wp/v2/categories?page=2' );
+					expect( categories._paging ).toHaveProperty( 'next' );
+					expect( typeof categories._paging.next ).toBe( 'object' );
+					expect( categories._paging.next ).toBeInstanceOf( WPRequest );
+					expect( categories._paging.next._options.endpoint )
+						.toEqual( 'http://wpapi.local/wp-json/wp/v2/categories?page=2' );
 					// Get last page & ensure "next" no longer appears
 					return wp.categories()
 						.page( categories._paging.totalPages )
 						.get()
 						.then( ( categories ) => {
-							expect( categories._paging ).not.to.have.property( 'next' );
-							expect( getNames( categories ) ).to.deep.equal( expectedResults.names.pageLast );
+							expect( categories._paging ).not.toHaveProperty( 'next' );
+							expect( getNames( categories ) ).toEqual( expectedResults.names.pageLast );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the next page of results via .next', () => {
@@ -148,32 +143,32 @@ describe( 'integration: categories()', () => {
 					return categories._paging.next
 						.get()
 						.then( ( categories ) => {
-							expect( categories ).to.be.an( 'array' );
-							expect( categories.length ).to.equal( 10 );
-							expect( getNames( categories ) ).to.deep.equal( expectedResults.names.page2 );
+							expect( Array.isArray( categories ) ).toBe( true );
+							expect( categories.length ).toBe( 10 );
+							expect( getNames( categories ) ).toEqual( expectedResults.names.page2 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			const prom = wp.categories()
 				.get()
 				.then( ( categories ) => {
-					expect( categories._paging ).not.to.have.property( 'prev' );
+					expect( categories._paging ).not.toHaveProperty( 'prev' );
 					return categories._paging.next
 						.get()
 						.then( ( categories ) => {
-							expect( categories._paging ).to.have.property( 'prev' );
-							expect( categories._paging.prev ).to.be.an( 'object' );
-							expect( categories._paging.prev ).to.be.an.instanceOf( WPRequest );
-							expect( categories._paging.prev._options.endpoint ).to
-								.equal( 'http://wpapi.local/wp-json/wp/v2/categories?page=1' );
+							expect( categories._paging ).toHaveProperty( 'prev' );
+							expect( typeof categories._paging.prev ).toBe( 'object' );
+							expect( categories._paging.prev ).toBeInstanceOf( WPRequest );
+							expect( categories._paging.prev._options.endpoint )
+								.toEqual( 'http://wpapi.local/wp-json/wp/v2/categories?page=1' );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the previous page of results via .prev', () => {
@@ -181,17 +176,17 @@ describe( 'integration: categories()', () => {
 				.page( 2 )
 				.get()
 				.then( ( categories ) => {
-					expect( getNames( categories ) ).to.deep.equal( expectedResults.names.page2 );
+					expect( getNames( categories ) ).toEqual( expectedResults.names.page2 );
 					return categories._paging.prev
 						.get()
 						.then( ( categories ) => {
-							expect( categories ).to.be.an( 'array' );
-							expect( categories.length ).to.equal( 10 );
-							expect( getNames( categories ) ).to.deep.equal( expectedResults.names.page1 );
+							expect( Array.isArray( categories ) ).toBe( true );
+							expect( categories.length ).toBe( 10 );
+							expect( getNames( categories ) ).toEqual( expectedResults.names.page1 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -209,18 +204,18 @@ describe( 'integration: categories()', () => {
 					return wp.categories().id( selectedCategory.id );
 				} )
 				.then( ( category ) => {
-					expect( category ).to.be.an( 'object' );
-					expect( category ).to.have.property( 'id' );
-					expect( category.id ).to.equal( selectedCategory.id );
-					expect( category ).to.have.property( 'slug' );
-					expect( category.slug ).to.equal( selectedCategory.slug );
-					expect( category ).to.have.property( 'taxonomy' );
-					expect( category.taxonomy ).to.equal( 'category' );
-					expect( category ).to.have.property( 'parent' );
-					expect( category.parent ).to.equal( 0 );
+					expect( typeof category ).toBe( 'object' );
+					expect( category ).toHaveProperty( 'id' );
+					expect( category.id ).toBe( selectedCategory.id );
+					expect( category ).toHaveProperty( 'slug' );
+					expect( category.slug ).toBe( selectedCategory.slug );
+					expect( category ).toHaveProperty( 'taxonomy' );
+					expect( category.taxonomy ).toBe( 'category' );
+					expect( category ).toHaveProperty( 'parent' );
+					expect( category.parent ).toBe( 0 );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -238,23 +233,23 @@ describe( 'integration: categories()', () => {
 					return wp.categories().search( selectedCategory.slug );
 				} )
 				.then( ( categories ) => {
-					expect( categories ).to.be.an( 'array' );
-					expect( categories.length ).to.equal( 1 );
+					expect( Array.isArray( categories ) ).toBe( true );
+					expect( categories.length ).toBe( 1 );
 					return categories[ 0 ];
 				} )
 				.then( ( category ) => {
-					expect( category ).to.be.an( 'object' );
-					expect( category ).to.have.property( 'id' );
-					expect( category.id ).to.equal( selectedCategory.id );
-					expect( category ).to.have.property( 'slug' );
-					expect( category.slug ).to.equal( selectedCategory.slug );
-					expect( category ).to.have.property( 'taxonomy' );
-					expect( category.taxonomy ).to.equal( 'category' );
-					expect( category ).to.have.property( 'parent' );
-					expect( category.parent ).to.equal( 0 );
+					expect( typeof category ).toBe( 'object' );
+					expect( category ).toHaveProperty( 'id' );
+					expect( category.id ).toBe( selectedCategory.id );
+					expect( category ).toHaveProperty( 'slug' );
+					expect( category.slug ).toBe( selectedCategory.slug );
+					expect( category ).toHaveProperty( 'taxonomy' );
+					expect( category.taxonomy ).toBe( 'category' );
+					expect( category ).toHaveProperty( 'parent' );
+					expect( category.parent ).toBe( 0 );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'returns all categories matching the provided search string', () => {
@@ -262,13 +257,13 @@ describe( 'integration: categories()', () => {
 				.search( 'parent' )
 				.get()
 				.then( ( categories ) => {
-					expect( categories ).to.be.an( 'array' );
-					expect( categories.length ).to.equal( 4 );
+					expect( Array.isArray( categories ) ).toBe( true );
+					expect( categories.length ).toBe( 4 );
 					const slugs = categories.map( cat => cat.slug ).sort().join( ' ' );
-					expect( slugs ).to.equal( 'foo-a-foo-parent foo-parent parent parent-category' );
+					expect( slugs ).toBe( 'foo-a-foo-parent foo-parent parent parent-category' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'can be used to retrieve a category by slug from a set of search results', () => {
@@ -279,15 +274,15 @@ describe( 'integration: categories()', () => {
 				// filtering for taxonomy term collections is reinstated
 				.then( categories => categories.find( cat => cat.slug === 'parent' ) )
 				.then( ( category ) => {
-					expect( category ).to.have.property( 'slug' );
-					expect( category.slug ).to.equal( 'parent' );
-					expect( category ).to.have.property( 'name' );
-					expect( category.name ).to.equal( 'Parent' );
-					expect( category ).to.have.property( 'parent' );
-					expect( category.parent ).to.equal( 0 );
+					expect( category ).toHaveProperty( 'slug' );
+					expect( category.slug ).toBe( 'parent' );
+					expect( category ).toHaveProperty( 'name' );
+					expect( category.name ).toBe( 'Parent' );
+					expect( category ).toHaveProperty( 'parent' );
+					expect( category.parent ).toBe( 0 );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -307,35 +302,35 @@ describe( 'integration: categories()', () => {
 					return wp.categories().parent( parentCat.id );
 				} )
 				.then( ( categories ) => {
-					expect( categories ).to.be.an( 'array' );
-					expect( categories.length ).to.equal( 1 );
+					expect( Array.isArray( categories ) ).toBe( true );
+					expect( categories.length ).toBe( 1 );
 					const category = categories[ 0 ];
-					expect( category ).to.have.property( 'name' );
-					expect( category.name ).to.equal( 'Child 1' );
-					expect( category ).to.have.property( 'parent' );
-					expect( category.parent ).to.equal( parentCat.id );
+					expect( category ).toHaveProperty( 'name' );
+					expect( category.name ).toBe( 'Child 1' );
+					expect( category ).toHaveProperty( 'parent' );
+					expect( category.parent ).toBe( parentCat.id );
 					childCat1 = category;
 					// Go one level deeper
 					return wp.categories().parent( childCat1.id );
 				} )
 				.then( ( categories ) => {
-					expect( categories ).to.be.an( 'array' );
-					expect( categories.length ).to.equal( 1 );
+					expect( Array.isArray( categories ) ).toBe( true );
+					expect( categories.length ).toBe( 1 );
 					const category = categories[ 0 ];
-					expect( category ).to.have.property( 'name' );
-					expect( category.name ).to.equal( 'Child 2' );
-					expect( category ).to.have.property( 'parent' );
-					expect( category.parent ).to.equal( childCat1.id );
+					expect( category ).toHaveProperty( 'name' );
+					expect( category.name ).toBe( 'Child 2' );
+					expect( category ).toHaveProperty( 'parent' );
+					expect( category.parent ).toBe( childCat1.id );
 					childCat2 = category;
 					// Go one level deeper
 					return wp.categories().parent( childCat2.id );
 				} )
 				.then( ( categories ) => {
-					expect( categories ).to.be.an( 'array' );
-					expect( categories.length ).to.equal( 0 );
+					expect( Array.isArray( categories ) ).toBe( true );
+					expect( categories.length ).toBe( 0 );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -360,7 +355,7 @@ describe( 'integration: categories()', () => {
 					return wp.categories().post( postId );
 				} )
 				.then( ( categories ) => {
-					expect( categories.length ).to.equal( postCategories.length );
+					expect( categories.length ).toBe( postCategories.length );
 					categories.forEach( ( cat, idx ) => {
 						[
 							'id',
@@ -368,12 +363,12 @@ describe( 'integration: categories()', () => {
 							'slug',
 							'taxonomy',
 						].forEach( ( prop ) => {
-							expect( cat[ prop ] ).to.equal( postCategories[ idx ][ prop ] );
+							expect( cat[ prop ] ).toBe( postCategories[ idx ][ prop ] );
 						} );
 					} );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );

--- a/tests/integration/comments.js
+++ b/tests/integration/comments.js
@@ -1,16 +1,11 @@
-'use strict';
 /*jshint -W106 */// Disable underscore_case warnings in this file b/c WP uses them
-const chai = require( 'chai' );
-// Variable to use as our 'success token' in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
+'use strict';
 
 const WPAPI = require( '../../' );
 const WPRequest = require( '../../lib/constructors/wp-request.js' );
+
+// Variable to use as our 'success token' in promise assertions
+const SUCCESS = 'success';
 
 // Define some arrays to use ensuring the returned data is what we expect
 // it to be (e.g. an array of the titles from posts on the first page)
@@ -81,21 +76,21 @@ describe( 'integration: comments()', () => {
 		const prom = wp.comments()
 			.get()
 			.then( ( comments ) => {
-				expect( comments ).to.be.an( 'array' );
-				expect( comments.length ).to.equal( 9 );
+				expect( Array.isArray( comments ) ).toBe( true );
+				expect( comments.length ).toBe( 9 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'fetches the first page, omitting a password-protected comment', () => {
 		const prom = wp.comments()
 			.get()
 			.then( ( comments ) => {
-				expect( getPostsAndAuthors( comments ) ).to.deep.equal( expectedResults.postsAndAuthors.page1 );
+				expect( getPostsAndAuthors( comments ) ).toEqual( expectedResults.postsAndAuthors.page1 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'fetches the 10 oldest comments when sorted "asc"', () => {
@@ -103,10 +98,10 @@ describe( 'integration: comments()', () => {
 			.order( 'asc' )
 			.get()
 			.then( ( comments ) => {
-				expect( getPostsAndAuthors( comments ) ).to.deep.equal( expectedResults.postsAndAuthorsAsc.page1 );
+				expect( getPostsAndAuthors( comments ) ).toEqual( expectedResults.postsAndAuthorsAsc.page1 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	describe( 'paging properties', () => {
@@ -115,55 +110,55 @@ describe( 'integration: comments()', () => {
 			const prom = wp.comments()
 				.get()
 				.then( ( posts ) => {
-					expect( posts ).to.have.property( '_paging' );
-					expect( posts._paging ).to.be.an( 'object' );
+					expect( posts ).toHaveProperty( '_paging' );
+					expect( typeof posts._paging ).toBe( 'object' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of posts', () => {
 			const prom = wp.comments()
 				.get()
 				.then( ( posts ) => {
-					expect( posts._paging ).to.have.property( 'total' );
-					expect( posts._paging.total ).to.equal( '25' );
+					expect( posts._paging ).toHaveProperty( 'total' );
+					expect( posts._paging.total ).toBe( '25' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of pages available', () => {
 			const prom = wp.comments()
 				.get()
 				.then( ( posts ) => {
-					expect( posts._paging ).to.have.property( 'totalPages' );
-					expect( posts._paging.totalPages ).to.equal( '3' );
+					expect( posts._paging ).toHaveProperty( 'totalPages' );
+					expect( posts._paging.totalPages ).toBe( '3' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			const prom = wp.comments()
 				.get()
 				.then( ( posts ) => {
-					expect( posts._paging ).to.have.property( 'next' );
-					expect( posts._paging.next ).to.be.an( 'object' );
-					expect( posts._paging.next ).to.be.an.instanceOf( WPRequest );
-					expect( posts._paging.next._options.endpoint ).to
-						.equal( 'http://wpapi.local/wp-json/wp/v2/comments?page=2' );
+					expect( posts._paging ).toHaveProperty( 'next' );
+					expect( typeof posts._paging.next ).toBe( 'object' );
+					expect( posts._paging.next ).toBeInstanceOf( WPRequest );
+					expect( posts._paging.next._options.endpoint )
+						.toEqual( 'http://wpapi.local/wp-json/wp/v2/comments?page=2' );
 					// Get last page & ensure 'next' no longer appears
 					return wp.comments()
 						.page( posts._paging.totalPages )
 						.get()
 						.then( ( posts ) => {
-							expect( posts._paging ).not.to.have.property( 'next' );
-							expect( getPostsAndAuthors( posts ) ).to.deep.equal( expectedResults.postsAndAuthors.page3 );
+							expect( posts._paging ).not.toHaveProperty( 'next' );
+							expect( getPostsAndAuthors( posts ) ).toEqual( expectedResults.postsAndAuthors.page3 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the next page of results via .next', () => {
@@ -173,32 +168,32 @@ describe( 'integration: comments()', () => {
 					return posts._paging.next
 						.get()
 						.then( ( posts ) => {
-							expect( posts ).to.be.an( 'array' );
-							expect( posts.length ).to.equal( 10 );
-							expect( getPostsAndAuthors( posts ) ).to.deep.equal( expectedResults.postsAndAuthors.page2 );
+							expect( Array.isArray( posts ) ).toBe( true );
+							expect( posts.length ).toBe( 10 );
+							expect( getPostsAndAuthors( posts ) ).toEqual( expectedResults.postsAndAuthors.page2 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			const prom = wp.comments()
 				.get()
 				.then( ( posts ) => {
-					expect( posts._paging ).not.to.have.property( 'prev' );
+					expect( posts._paging ).not.toHaveProperty( 'prev' );
 					return posts._paging.next
 						.get()
 						.then( ( posts ) => {
-							expect( posts._paging ).to.have.property( 'prev' );
-							expect( posts._paging.prev ).to.be.an( 'object' );
-							expect( posts._paging.prev ).to.be.an.instanceOf( WPRequest );
-							expect( posts._paging.prev._options.endpoint ).to
-								.equal( 'http://wpapi.local/wp-json/wp/v2/comments?page=1' );
+							expect( posts._paging ).toHaveProperty( 'prev' );
+							expect( typeof posts._paging.prev ).toBe( 'object' );
+							expect( posts._paging.prev ).toBeInstanceOf( WPRequest );
+							expect( posts._paging.prev._options.endpoint )
+								.toEqual( 'http://wpapi.local/wp-json/wp/v2/comments?page=1' );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the previous page of results via .prev', () => {
@@ -206,18 +201,18 @@ describe( 'integration: comments()', () => {
 				.page( 2 )
 				.get()
 				.then( ( posts ) => {
-					expect( getPostsAndAuthors( posts ) ).to.deep.equal( expectedResults.postsAndAuthors.page2 );
+					expect( getPostsAndAuthors( posts ) ).toEqual( expectedResults.postsAndAuthors.page2 );
 					return posts._paging.prev
 						.get()
 						.then( ( posts ) => {
-							expect( posts ).to.be.an( 'array' );
+							expect( Array.isArray( posts ) ).toBe( true );
 							// 9 because one comment is for a password-protected post
-							expect( posts.length ).to.equal( 9 );
-							expect( getPostsAndAuthors( posts ) ).to.deep.equal( expectedResults.postsAndAuthors.page1 );
+							expect( posts.length ).toBe( 9 );
+							expect( getPostsAndAuthors( posts ) ).toEqual( expectedResults.postsAndAuthors.page1 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -243,22 +238,22 @@ describe( 'integration: comments()', () => {
 		it( 'returns an object, not an array', () => {
 			const prom = commentProm
 				.then( ( comment ) => {
-					expect( Array.isArray( comment ) ).to.equal( false );
-					expect( comment ).to.be.an( 'object' );
+					expect( Array.isArray( comment ) ).toBe( false );
+					expect( typeof comment ).toBe( 'object' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'returns the correct comment', () => {
 			const prom = commentProm.then( ( comment ) => {
-				expect( comment.id ).to.equal( commentId );
+				expect( comment.id ).toBe( commentId );
 				[ 'author_name', 'post', 'parent', 'date', 'status' ].forEach( ( prop ) => {
-					expect( comment[ prop ] ).to.equal( commentCollection[4][ prop ] );
+					expect( comment[ prop ] ).toBe( commentCollection[4][ prop ] );
 				} );
 				return SUCCESS;
 			} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -283,17 +278,22 @@ describe( 'integration: comments()', () => {
 		} );
 
 		it( 'returns an array of posts', () => {
-			return expect( commentProm ).to.eventually.be.an( 'array' );
+			const prom = commentProm
+				.then( ( comments ) => {
+					expect( Array.isArray( comments ) ).toBe( true );
+					return SUCCESS;
+				} );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'returns the correct number of comments', () => {
 			const prom = commentProm
 				.then( ( comments ) => {
-					expect( comments.length ).to.equal( 3 );
-					expect( comments.length ).to.equal( pageComments.length );
+					expect( comments.length ).toBe( 3 );
+					expect( comments.length ).toBe( pageComments.length );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'returns the correct comments', () => {
@@ -301,13 +301,13 @@ describe( 'integration: comments()', () => {
 				.then( ( comments ) => {
 					pageComments.forEach( ( comment, i ) => {
 						[ 'id', 'parent', 'author', 'author_name' ].forEach( ( prop ) => {
-							expect( comment[ prop ] ).to.equal( comments[ i ][ prop ] );
+							expect( comment[ prop ] ).toBe( comments[ i ][ prop ] );
 						} );
-						expect( comment.content.rendered ).to.equal( comments[ i ].content.rendered );
+						expect( comment.content.rendered ).toBe( comments[ i ].content.rendered );
 					} );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );

--- a/tests/integration/custom-http-headers.js
+++ b/tests/integration/custom-http-headers.js
@@ -1,12 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
 
@@ -15,6 +7,9 @@ const WPAPI = require( '../../' );
 const getTitles = require( '../helpers/get-rendered-prop' ).bind( null, 'title' );
 const credentials = require( '../helpers/constants' ).credentials;
 const base64credentials = Buffer.from( `${ credentials.username }:${ credentials.password }` ).toString( 'base64' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 describe( 'integration: custom HTTP Headers', () => {
 	let wp;
@@ -33,13 +28,13 @@ describe( 'integration: custom HTTP Headers', () => {
 			.status( [ 'future', 'draft' ] )
 			.get()
 			.then( ( posts ) => {
-				expect( getTitles( posts ) ).to.deep.equal( [
+				expect( getTitles( posts ) ).toEqual( [
 					'Scheduled',
 					'Draft',
 				] );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can be provided at the WPAPI instance level using WPAPI#setHeaders()', () => {
@@ -50,17 +45,17 @@ describe( 'integration: custom HTTP Headers', () => {
 			.status( [ 'future', 'draft' ] )
 			.get()
 			.then( ( posts ) => {
-				expect( getTitles( posts ) ).to.deep.equal( [
+				expect( getTitles( posts ) ).toEqual( [
 					'Scheduled',
 					'Draft',
 				] );
 				return authenticated.users().me();
 			} )
 			.then( ( me ) => {
-				expect( me.slug ).to.equal( 'admin' );
+				expect( me.slug ).toBe( 'admin' );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 } );

--- a/tests/integration/error-states.js
+++ b/tests/integration/error-states.js
@@ -1,14 +1,9 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 describe( 'error states:', () => {
 
@@ -17,12 +12,12 @@ describe( 'error states:', () => {
 		const prom = wp.posts()
 			.get()
 			.catch( ( err ) => {
-				expect( err ).to.be.an.instanceOf( Error );
-				expect( err ).to.have.property( 'status' );
-				expect( err.status ).to.equal( 404 );
+				expect( err ).toBeInstanceOf( Error );
+				expect( err ).toHaveProperty( 'status' );
+				expect( err.status ).toBe( 404 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 } );

--- a/tests/integration/media.js
+++ b/tests/integration/media.js
@@ -213,7 +213,6 @@ describe( 'integration: media()', () => {
 					content: 'Some Content',
 				} )
 				.catch( ( err ) => {
-					// httpTestUtils.rethrowIfChaiError( err );
 					expect( err.code ).toBe( 'rest_cannot_create' );
 					expect( err.data ).toEqual( {
 						status: 401,
@@ -236,7 +235,6 @@ describe( 'integration: media()', () => {
 						} );
 				} )
 				.catch( ( err ) => {
-					// httpTestUtils.rethrowIfChaiError( err );
 					expect( err.code ).toBe( 'rest_cannot_edit' );
 					expect( err.data ).toEqual( {
 						status: 401,
@@ -257,7 +255,6 @@ describe( 'integration: media()', () => {
 					} );
 				} )
 				.catch( ( err ) => {
-					// httpTestUtils.rethrowIfChaiError( err );
 					expect( err.code ).toBe( 'rest_cannot_delete' );
 					expect( err.data ).toEqual( {
 						status: 401,
@@ -328,7 +325,6 @@ describe( 'integration: media()', () => {
 					.delete();
 			} )
 			.catch( ( error ) => {
-				// httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).toBe( 'rest_trash_not_supported' );
 				expect( error.data ).toEqual( {
 					status: 501,
@@ -349,7 +345,6 @@ describe( 'integration: media()', () => {
 				return wp.media().id( id );
 			} )
 			.catch( ( error ) => {
-				// httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).toBe( 'rest_post_invalid_id' );
 				expect( error.data ).toEqual( {
 					status: 404,

--- a/tests/integration/media.js
+++ b/tests/integration/media.js
@@ -1,12 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const path = require( 'path' );
 const _unique = require( 'lodash.uniq' );
@@ -22,6 +14,9 @@ const getTitles = require( '../helpers/get-rendered-prop' ).bind( null, 'title' 
 const credentials = require( '../helpers/constants' ).credentials;
 
 const filePath = path.join( __dirname, 'assets/emilygarfield-untitled.jpg' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 const expectedResults = {
 	titles: {
@@ -79,21 +74,21 @@ describe( 'integration: media()', () => {
 		const prom = wp.media()
 			.get()
 			.then( ( media ) => {
-				expect( media ).to.be.an( 'array' );
-				expect( media.length ).to.equal( 10 );
+				expect( Array.isArray( media ) ).toBe( true );
+				expect( media.length ).toBe( 10 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'fetches the 10 most recent media by default', () => {
 		const prom = wp.media()
 			.get()
 			.then( ( media ) => {
-				expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page1 );
+				expect( getTitles( media ) ).toEqual( expectedResults.titles.page1 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	describe( 'paging properties', () => {
@@ -102,55 +97,55 @@ describe( 'integration: media()', () => {
 			const prom = wp.media()
 				.get()
 				.then( ( media ) => {
-					expect( media ).to.have.property( '_paging' );
-					expect( media._paging ).to.be.an( 'object' );
+					expect( media ).toHaveProperty( '_paging' );
+					expect( typeof media._paging ).toBe( 'object' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of media: use .headers() for coverage reasons', () => {
 			const prom = wp.media()
 				.headers()
 				.then( ( postHeadersResponse ) => {
-					expect( postHeadersResponse ).to.have.property( 'x-wp-total' );
-					expect( postHeadersResponse[ 'x-wp-total' ] ).to.equal( '38' );
+					expect( postHeadersResponse ).toHaveProperty( 'x-wp-total' );
+					expect( postHeadersResponse[ 'x-wp-total' ] ).toBe( '38' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of pages available', () => {
 			const prom = wp.media()
 				.get()
 				.then( ( media ) => {
-					expect( media._paging ).to.have.property( 'totalPages' );
-					expect( media._paging.totalPages ).to.equal( '4' );
+					expect( media._paging ).toHaveProperty( 'totalPages' );
+					expect( media._paging.totalPages ).toBe( '4' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			const prom = wp.media()
 				.get()
 				.then( ( media ) => {
-					expect( media._paging ).to.have.property( 'next' );
-					expect( media._paging.next ).to.be.an( 'object' );
-					expect( media._paging.next ).to.be.an.instanceOf( WPRequest );
-					expect( media._paging.next._options.endpoint ).to
-						.equal( 'http://wpapi.local/wp-json/wp/v2/media?page=2' );
+					expect( media._paging ).toHaveProperty( 'next' );
+					expect( typeof media._paging.next ).toBe( 'object' );
+					expect( media._paging.next ).toBeInstanceOf( WPRequest );
+					expect( media._paging.next._options.endpoint )
+						.toEqual( 'http://wpapi.local/wp-json/wp/v2/media?page=2' );
 					// Get last page & ensure "next" no longer appears
 					return wp.media()
 						.page( media._paging.totalPages )
 						.get()
 						.then( ( media ) => {
-							expect( media._paging ).not.to.have.property( 'next' );
-							expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page4 );
+							expect( media._paging ).not.toHaveProperty( 'next' );
+							expect( getTitles( media ) ).toEqual( expectedResults.titles.page4 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the next page of results via .next', () => {
@@ -160,32 +155,32 @@ describe( 'integration: media()', () => {
 					return media._paging.next
 						.get()
 						.then( ( media ) => {
-							expect( media ).to.be.an( 'array' );
-							expect( media.length ).to.equal( 10 );
-							expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page2 );
+							expect( Array.isArray( media ) ).toBe( true );
+							expect( media.length ).toBe( 10 );
+							expect( getTitles( media ) ).toEqual( expectedResults.titles.page2 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			const prom = wp.media()
 				.get()
 				.then( ( media ) => {
-					expect( media._paging ).not.to.have.property( 'prev' );
+					expect( media._paging ).not.toHaveProperty( 'prev' );
 					return media._paging.next
 						.get()
 						.then( ( media ) => {
-							expect( media._paging ).to.have.property( 'prev' );
-							expect( media._paging.prev ).to.be.an( 'object' );
-							expect( media._paging.prev ).to.be.an.instanceOf( WPRequest );
-							expect( media._paging.prev._options.endpoint ).to
-								.equal( 'http://wpapi.local/wp-json/wp/v2/media?page=1' );
+							expect( media._paging ).toHaveProperty( 'prev' );
+							expect( typeof media._paging.prev ).toBe( 'object' );
+							expect( media._paging.prev ).toBeInstanceOf( WPRequest );
+							expect( media._paging.prev._options.endpoint )
+								.toEqual( 'http://wpapi.local/wp-json/wp/v2/media?page=1' );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the previous page of results via .prev', () => {
@@ -193,17 +188,17 @@ describe( 'integration: media()', () => {
 				.page( 2 )
 				.get()
 				.then( ( media ) => {
-					expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page2 );
+					expect( getTitles( media ) ).toEqual( expectedResults.titles.page2 );
 					return media._paging.prev
 						.get()
 						.then( ( media ) => {
-							expect( media ).to.be.an( 'array' );
-							expect( media.length ).to.equal( 10 );
-							expect( getTitles( media ) ).to.deep.equal( expectedResults.titles.page1 );
+							expect( Array.isArray( media ) ).toBe( true );
+							expect( media.length ).toBe( 10 );
+							expect( getTitles( media ) ).toEqual( expectedResults.titles.page1 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -218,14 +213,14 @@ describe( 'integration: media()', () => {
 					content: 'Some Content',
 				} )
 				.catch( ( err ) => {
-					httpTestUtils.rethrowIfChaiError( err );
-					expect( err.code ).to.equal( 'rest_cannot_create' );
-					expect( err.data ).to.deep.equal( {
+					// httpTestUtils.rethrowIfChaiError( err );
+					expect( err.code ).toBe( 'rest_cannot_create' );
+					expect( err.data ).toEqual( {
 						status: 401,
 					} );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'cannot PUT', () => {
@@ -241,14 +236,14 @@ describe( 'integration: media()', () => {
 						} );
 				} )
 				.catch( ( err ) => {
-					httpTestUtils.rethrowIfChaiError( err );
-					expect( err.code ).to.equal( 'rest_cannot_edit' );
-					expect( err.data ).to.deep.equal( {
+					// httpTestUtils.rethrowIfChaiError( err );
+					expect( err.code ).toBe( 'rest_cannot_edit' );
+					expect( err.data ).toEqual( {
 						status: 401,
 					} );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'cannot DELETE', () => {
@@ -262,14 +257,14 @@ describe( 'integration: media()', () => {
 					} );
 				} )
 				.catch( ( err ) => {
-					httpTestUtils.rethrowIfChaiError( err );
-					expect( err.code ).to.equal( 'rest_cannot_delete' );
-					expect( err.data ).to.deep.equal( {
+					// httpTestUtils.rethrowIfChaiError( err );
+					expect( err.code ).toBe( 'rest_cannot_delete' );
+					expect( err.data ).toEqual( {
 						status: 401,
 					} );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -288,11 +283,11 @@ describe( 'integration: media()', () => {
 			.then( ( createdMedia ) => {
 				id = createdMedia.id;
 				imageUrl = createdMedia.source_url;
-				expect( createdMedia.title.rendered ).to.equal( 'Untitled' );
-				expect( createdMedia.caption.raw ).to.equal( 'A painting from Emily Garfield\'s "Conduits" series' );
+				expect( createdMedia.title.rendered ).toBe( 'Untitled' );
+				expect( createdMedia.caption.raw ).toBe( 'A painting from Emily Garfield\'s "Conduits" series' );
 
 				// File name is correctly applied and image was uploaded to content dir
-				expect( imageUrl ).to.match( /^http:\/\/wpapi.local\/content\/uploads\/.*\/ehg-conduits.jpg$/ );
+				expect( imageUrl ).toMatch( /^http:\/\/wpapi.local\/content\/uploads\/.*\/ehg-conduits.jpg$/ );
 			} )
 			// UPDATE
 			.then( () => authenticated.media()
@@ -303,9 +298,9 @@ describe( 'integration: media()', () => {
 				} )
 			)
 			.then( ( result ) => {
-				expect( result.id ).to.equal( id );
-				expect( result.title.rendered ).to.equal( 'Conduits Series' );
-				expect( result.alt_text ).to.equal( 'A photograph of an abstract painting by Emily Garfield' );
+				expect( result.id ).toBe( id );
+				expect( result.title.rendered ).toBe( 'Conduits Series' );
+				expect( result.alt_text ).toBe( 'A photograph of an abstract painting by Emily Garfield' );
 				return result;
 			} )
 			// READ
@@ -315,7 +310,7 @@ describe( 'integration: media()', () => {
 				const sizeURLs = objectReduce( sizes, ( urls, size ) => urls.concat( size.source_url ), [] );
 
 				// Expect all sizes to have different URLs
-				expect( Object.keys( sizes ).length ).to.equal( _unique( sizeURLs ).length );
+				expect( Object.keys( sizes ).length ).toBe( _unique( sizeURLs ).length );
 				return sizeURLs.reduce( ( previous, sizeURL ) => previous.then( () => (
 					httpTestUtils.expectStatusCode( sizeURL, 200 )
 				) ), Promise.resolve() );
@@ -333,9 +328,9 @@ describe( 'integration: media()', () => {
 					.delete();
 			} )
 			.catch( ( error ) => {
-				httpTestUtils.rethrowIfChaiError( error );
-				expect( error.code ).to.equal( 'rest_trash_not_supported' );
-				expect( error.data ).to.deep.equal( {
+				// httpTestUtils.rethrowIfChaiError( error );
+				expect( error.code ).toBe( 'rest_trash_not_supported' );
+				expect( error.data ).toEqual( {
 					status: 501,
 				} );
 				// Now permanently delete this media
@@ -346,17 +341,17 @@ describe( 'integration: media()', () => {
 					} );
 			} )
 			.then( ( response ) => {
-				expect( response ).to.be.an( 'object' );
+				expect( typeof response ).toBe( 'object' );
 				// DELETE action returns the media object as the .previous property
-				expect( response.previous ).to.be.an( 'object' );
-				expect( response.previous.id ).to.equal( id );
+				expect( typeof response.previous ).toBe( 'object' );
+				expect( response.previous.id ).toBe( id );
 				// Query for the media: expect this to fail, since it has been deleted
 				return wp.media().id( id );
 			} )
 			.catch( ( error ) => {
-				httpTestUtils.rethrowIfChaiError( error );
-				expect( error.code ).to.equal( 'rest_post_invalid_id' );
-				expect( error.data ).to.deep.equal( {
+				// httpTestUtils.rethrowIfChaiError( error );
+				expect( error.code ).toBe( 'rest_post_invalid_id' );
+				expect( error.data ).toEqual( {
 					status: 404,
 				} );
 			} )
@@ -367,7 +362,7 @@ describe( 'integration: media()', () => {
 			.then( () => {
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 } );

--- a/tests/integration/pages.js
+++ b/tests/integration/pages.js
@@ -1,12 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
 const WPRequest = require( '../../lib/constructors/wp-request.js' );
@@ -14,6 +6,9 @@ const WPRequest = require( '../../lib/constructors/wp-request.js' );
 // Inspecting the titles of the returned posts arrays is an easy way to
 // validate that the right page of results was returned
 const getTitles = require( '../helpers/get-rendered-prop' ).bind( null, 'title' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 // Define some arrays to use ensuring the returned data is what we expect
 // it to be (e.g. an array of the titles from pages on the first page)
@@ -57,21 +52,21 @@ describe( 'integration: pages()', () => {
 		const prom = wp.pages()
 			.get()
 			.then( ( pages ) => {
-				expect( pages ).to.be.an( 'array' );
-				expect( pages.length ).to.equal( 10 );
+				expect( Array.isArray( pages ) ).toBe( true );
+				expect( pages.length ).toBe( 10 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'fetches the 10 most recent pages by default', () => {
 		const prom = wp.pages()
 			.get()
 			.then( ( pages ) => {
-				expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page1 );
+				expect( getTitles( pages ) ).toEqual( expectedResults.titles.page1 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	describe( 'paging properties', () => {
@@ -80,55 +75,55 @@ describe( 'integration: pages()', () => {
 			const prom = wp.pages()
 				.get()
 				.then( ( pages ) => {
-					expect( pages ).to.have.property( '_paging' );
-					expect( pages._paging ).to.be.an( 'object' );
+					expect( pages ).toHaveProperty( '_paging' );
+					expect( typeof pages._paging ).toBe( 'object' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of pages', () => {
 			const prom = wp.pages()
 				.get()
 				.then( ( pages ) => {
-					expect( pages._paging ).to.have.property( 'total' );
-					expect( pages._paging.total ).to.equal( '18' );
+					expect( pages._paging ).toHaveProperty( 'total' );
+					expect( pages._paging.total ).toBe( '18' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of pages available', () => {
 			const prom = wp.pages()
 				.get()
 				.then( ( pages ) => {
-					expect( pages._paging ).to.have.property( 'totalPages' );
-					expect( pages._paging.totalPages ).to.equal( '2' );
+					expect( pages._paging ).toHaveProperty( 'totalPages' );
+					expect( pages._paging.totalPages ).toBe( '2' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			const prom = wp.pages()
 				.get()
 				.then( ( pages ) => {
-					expect( pages._paging ).to.have.property( 'next' );
-					expect( pages._paging.next ).to.be.an( 'object' );
-					expect( pages._paging.next ).to.be.an.instanceOf( WPRequest );
-					expect( pages._paging.next._options.endpoint ).to
-						.equal( 'http://wpapi.local/wp-json/wp/v2/pages?page=2' );
+					expect( pages._paging ).toHaveProperty( 'next' );
+					expect( typeof pages._paging.next ).toBe( 'object' );
+					expect( pages._paging.next ).toBeInstanceOf( WPRequest );
+					expect( pages._paging.next._options.endpoint )
+						.toEqual( 'http://wpapi.local/wp-json/wp/v2/pages?page=2' );
 					// Get last page & ensure "next" no longer appears
 					return wp.pages()
 						.page( pages._paging.totalPages )
 						.get()
 						.then( ( pages ) => {
-							expect( pages._paging ).not.to.have.property( 'next' );
-							expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page2 );
+							expect( pages._paging ).not.toHaveProperty( 'next' );
+							expect( getTitles( pages ) ).toEqual( expectedResults.titles.page2 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the next page of results via .next', () => {
@@ -136,30 +131,30 @@ describe( 'integration: pages()', () => {
 				.get()
 				.then( pages => pages._paging.next.get() )
 				.then( ( pages ) => {
-					expect( pages ).to.be.an( 'array' );
-					expect( pages.length ).to.equal( 8 );
-					expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page2 );
+					expect( Array.isArray( pages ) ).toBe( true );
+					expect( pages.length ).toBe( 8 );
+					expect( getTitles( pages ) ).toEqual( expectedResults.titles.page2 );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			const prom = wp.pages()
 				.get()
 				.then( ( pages ) => {
-					expect( pages._paging ).not.to.have.property( 'prev' );
+					expect( pages._paging ).not.toHaveProperty( 'prev' );
 					return pages._paging.next.get();
 				} )
 				.then( ( pages ) => {
-					expect( pages._paging ).to.have.property( 'prev' );
-					expect( pages._paging.prev ).to.be.an( 'object' );
-					expect( pages._paging.prev ).to.be.an.instanceOf( WPRequest );
-					expect( pages._paging.prev._options.endpoint ).to
-						.equal( 'http://wpapi.local/wp-json/wp/v2/pages?page=1' );
+					expect( pages._paging ).toHaveProperty( 'prev' );
+					expect( typeof pages._paging.prev ).toBe( 'object' );
+					expect( pages._paging.prev ).toBeInstanceOf( WPRequest );
+					expect( pages._paging.prev._options.endpoint )
+						.toEqual( 'http://wpapi.local/wp-json/wp/v2/pages?page=1' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the previous page of results via .prev', () => {
@@ -167,16 +162,16 @@ describe( 'integration: pages()', () => {
 				.page( 2 )
 				.get()
 				.then( ( pages ) => {
-					expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page2 );
+					expect( getTitles( pages ) ).toEqual( expectedResults.titles.page2 );
 					return pages._paging.prev.get();
 				} )
 				.then( ( pages ) => {
-					expect( pages ).to.be.an( 'array' );
-					expect( pages.length ).to.equal( 10 );
-					expect( getTitles( pages ) ).to.deep.equal( expectedResults.titles.page1 );
+					expect( Array.isArray( pages ) ).toBe( true );
+					expect( pages.length ).toBe( 10 );
+					expect( getTitles( pages ) ).toEqual( expectedResults.titles.page1 );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -190,13 +185,13 @@ describe( 'integration: pages()', () => {
 					.slug( 'clearing-floats' )
 					.get()
 					.then( ( pages ) => {
-						expect( pages.length ).to.equal( 1 );
-						expect( getTitles( pages ) ).to.deep.equal( [
+						expect( pages.length ).toBe( 1 );
+						expect( getTitles( pages ) ).toEqual( [
 							'Clearing Floats',
 						] );
 						return SUCCESS;
 					} );
-				return expect( prom ).to.eventually.equal( SUCCESS );
+				return expect( prom ).resolves.toBe( SUCCESS );
 			} );
 
 		} );

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -649,7 +649,6 @@ describe( 'integration: posts()', () => {
 				return wp.posts().id( id );
 			} )
 			.catch( ( error ) => {
-				// httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).toBe( 'rest_forbidden' );
 				expect( error.data ).toEqual( {
 					status: 401,
@@ -671,7 +670,6 @@ describe( 'integration: posts()', () => {
 				return authenticated.posts().id( id );
 			} )
 			.catch( ( error ) => {
-				// httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).toBe( 'rest_post_invalid_id' );
 				expect( error.data ).toEqual( {
 					status: 404,
@@ -785,7 +783,6 @@ describe( 'integration: posts()', () => {
 			// Query for the media, with auth: expect this to fail, since it is gone
 			.then( () => authenticated.media().id( mediaId ) )
 			.catch( ( error ) => {
-				// httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).toBe( 'rest_post_invalid_id' );
 				expect( error.data ).toEqual( {
 					status: 404,
@@ -801,7 +798,6 @@ describe( 'integration: posts()', () => {
 			// Query for the post, with auth: expect this to fail, since it is gone
 			.then( () => authenticated.posts().id( id ) )
 			.catch( ( error ) => {
-				// httpTestUtils.rethrowIfChaiError( error );
 				expect( error.code ).toBe( 'rest_post_invalid_id' );
 				expect( error.data ).toEqual( {
 					status: 404,

--- a/tests/integration/settings.js
+++ b/tests/integration/settings.js
@@ -1,16 +1,11 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
 
 const credentials = require( '../helpers/constants' ).credentials;
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 describe( 'integration: settings()', () => {
 	let wp;
@@ -29,23 +24,23 @@ describe( 'integration: settings()', () => {
 		const prom = wp.settings()
 			.get()
 			.catch( ( err ) => {
-				expect( err.code ).to.equal( 'rest_forbidden' );
-				expect( err.data ).to.deep.equal( {
+				expect( err.code ).toBe( 'rest_forbidden' );
+				expect( err.data ).toEqual( {
 					status: 401,
 				} );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can be used to retrieve a list of site settings when authenticated', () => {
 		const prom = authenticated.settings()
 			.get()
 			.then( ( settings ) => {
-				expect( settings ).to.be.an( 'object' );
+				expect( typeof settings ).toBe( 'object' );
 
 				// Validate existence of all expected keys
-				expect( Object.keys( settings ).sort() ).to.deep.equal( [
+				expect( Object.keys( settings ).sort() ).toEqual( [
 					'date_format',
 					'default_category',
 					'default_comment_status',
@@ -64,20 +59,20 @@ describe( 'integration: settings()', () => {
 				] );
 
 				// Spot check specific values
-				expect( settings.title ).to.equal( 'WP-API Testbed' );
-				expect( settings.description ).to.equal( 'Just another WordPress site' );
-				expect( settings.posts_per_page ).to.equal( 10 );
+				expect( settings.title ).toBe( 'WP-API Testbed' );
+				expect( settings.description ).toBe( 'Just another WordPress site' );
+				expect( settings.posts_per_page ).toBe( 10 );
 
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can be used to update settings', () => {
 		const prom = authenticated.settings()
 			.get()
 			.then( ( settings ) => {
-				expect( settings.description ).to.equal( 'Just another WordPress site' );
+				expect( settings.description ).toBe( 'Just another WordPress site' );
 				return authenticated.settings()
 					.update( {
 						description: 'It\'s amazing what you\'ll find face to face',
@@ -86,7 +81,7 @@ describe( 'integration: settings()', () => {
 			// Initialize new request to see if changes persisted
 			.then( () => authenticated.settings().get() )
 			.then( ( settings ) => {
-				expect( settings.description ).to.equal( 'It&#039;s amazing what you&#039;ll find face to face' );
+				expect( settings.description ).toBe( 'It&#039;s amazing what you&#039;ll find face to face' );
 				// Reset to original value
 				return authenticated.settings()
 					.update( {
@@ -96,10 +91,10 @@ describe( 'integration: settings()', () => {
 			// Request one final time to validate value has been set back
 			.then( () => authenticated.settings().get() )
 			.then( ( settings ) => {
-				expect( settings.description ).to.equal( 'Just another WordPress site' );
+				expect( settings.description ).toBe( 'Just another WordPress site' );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 } );

--- a/tests/integration/tags.js
+++ b/tests/integration/tags.js
@@ -1,12 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
 const WPRequest = require( '../../lib/constructors/wp-request.js' );
@@ -14,6 +6,9 @@ const WPRequest = require( '../../lib/constructors/wp-request.js' );
 // Inspecting the names of the returned terms is an easy way to validate
 // that the right page of results was returned
 const getNames = require( '../helpers/get-prop' ).bind( null, 'name' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 // Define some arrays to use ensuring the returned data is what we expect
 // it to be (e.g. an array of the names from tags on the first page)
@@ -71,22 +66,22 @@ describe( 'integration: tags()', () => {
 		const prom = wp.tags()
 			.get()
 			.then( ( tags ) => {
-				expect( tags ).to.be.an( 'array' );
-				expect( tags.length ).to.equal( 10 );
+				expect( Array.isArray( tags ) ).toBe( true );
+				expect( tags.length ).toBe( 10 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'retrieves the first 10 tags by default', () => {
 		const prom = wp.tags()
 			.get()
 			.then( ( tags ) => {
-				expect( tags ).to.be.an( 'array' );
-				expect( tags.length ).to.equal( 10 );
+				expect( Array.isArray( tags ) ).toBe( true );
+				expect( tags.length ).toBe( 10 );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	describe( 'paging properties', () => {
@@ -95,54 +90,54 @@ describe( 'integration: tags()', () => {
 			const prom = wp.tags()
 				.get()
 				.then( ( tags ) => {
-					expect( tags ).to.have.property( '_paging' );
-					expect( tags._paging ).to.be.an( 'object' );
+					expect( tags ).toHaveProperty( '_paging' );
+					expect( typeof tags._paging ).toBe( 'object' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of tags', () => {
 			const prom = wp.tags()
 				.get()
 				.then( ( tags ) => {
-					expect( tags._paging ).to.have.property( 'total' );
-					expect( tags._paging.total ).to.equal( '110' );
+					expect( tags._paging ).toHaveProperty( 'total' );
+					expect( tags._paging.total ).toBe( '110' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'include the total number of pages available', () => {
 			const prom = wp.tags()
 				.get()
 				.then( ( tags ) => {
-					expect( tags._paging ).to.have.property( 'totalPages' );
-					expect( tags._paging.totalPages ).to.equal( '11' );
+					expect( tags._paging ).toHaveProperty( 'totalPages' );
+					expect( tags._paging.totalPages ).toBe( '11' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the next page as .next', () => {
 			const prom = wp.tags()
 				.get()
 				.then( ( tags ) => {
-					expect( tags._paging ).to.have.property( 'next' );
-					expect( tags._paging.next ).to.be.an( 'object' );
-					expect( tags._paging.next ).to.be.an.instanceOf( WPRequest );
-					expect( tags._paging.next._options.endpoint ).to
-						.equal( 'http://wpapi.local/wp-json/wp/v2/tags?page=2' );
+					expect( tags._paging ).toHaveProperty( 'next' );
+					expect( typeof tags._paging.next ).toBe( 'object' );
+					expect( tags._paging.next ).toBeInstanceOf( WPRequest );
+					expect( tags._paging.next._options.endpoint )
+						.toEqual( 'http://wpapi.local/wp-json/wp/v2/tags?page=2' );
 					// Get last page & ensure "next" no longer appears
 					return wp.tags().page( tags._paging.totalPages )
 						.get()
 						.then( ( tags ) => {
-							expect( tags._paging ).not.to.have.property( 'next' );
-							expect( getNames( tags ) ).to.deep.equal( expectedResults.names.pageLast );
+							expect( tags._paging ).not.toHaveProperty( 'next' );
+							expect( getNames( tags ) ).toEqual( expectedResults.names.pageLast );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the next page of results via .next', () => {
@@ -152,32 +147,32 @@ describe( 'integration: tags()', () => {
 					return tags._paging.next
 						.get()
 						.then( ( tags ) => {
-							expect( tags ).to.be.an( 'array' );
-							expect( tags.length ).to.equal( 10 );
-							expect( getNames( tags ) ).to.deep.equal( expectedResults.names.page2 );
+							expect( Array.isArray( tags ) ).toBe( true );
+							expect( tags.length ).toBe( 10 );
+							expect( getNames( tags ) ).toEqual( expectedResults.names.page2 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'provides a bound WPRequest for the previous page as .prev', () => {
 			const prom = wp.tags()
 				.get()
 				.then( ( tags ) => {
-					expect( tags._paging ).not.to.have.property( 'prev' );
+					expect( tags._paging ).not.toHaveProperty( 'prev' );
 					return tags._paging.next
 						.get()
 						.then( ( tags ) => {
-							expect( tags._paging ).to.have.property( 'prev' );
-							expect( tags._paging.prev ).to.be.an( 'object' );
-							expect( tags._paging.prev ).to.be.an.instanceOf( WPRequest );
-							expect( tags._paging.prev._options.endpoint ).to
-								.equal( 'http://wpapi.local/wp-json/wp/v2/tags?page=1' );
+							expect( tags._paging ).toHaveProperty( 'prev' );
+							expect( typeof tags._paging.prev ).toBe( 'object' );
+							expect( tags._paging.prev ).toBeInstanceOf( WPRequest );
+							expect( tags._paging.prev._options.endpoint )
+								.toEqual( 'http://wpapi.local/wp-json/wp/v2/tags?page=1' );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'allows access to the previous page of results via .prev', () => {
@@ -185,17 +180,17 @@ describe( 'integration: tags()', () => {
 				.page( 2 )
 				.get()
 				.then( ( tags ) => {
-					expect( getNames( tags ) ).to.deep.equal( expectedResults.names.page2 );
+					expect( getNames( tags ) ).toEqual( expectedResults.names.page2 );
 					return tags._paging.prev
 						.get()
 						.then( ( tags ) => {
-							expect( tags ).to.be.an( 'array' );
-							expect( tags.length ).to.equal( 10 );
-							expect( getNames( tags ) ).to.deep.equal( expectedResults.names.page1 );
+							expect( Array.isArray( tags ) ).toBe( true );
+							expect( tags.length ).toBe( 10 );
+							expect( getNames( tags ) ).toEqual( expectedResults.names.page1 );
 							return SUCCESS;
 						} );
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -213,17 +208,17 @@ describe( 'integration: tags()', () => {
 					return wp.tags().id( selectedTag.id );
 				} )
 				.then( ( tag ) => {
-					expect( tag ).to.be.an( 'object' );
-					expect( tag ).to.have.property( 'id' );
-					expect( tag.id ).to.equal( selectedTag.id );
-					expect( tag ).to.have.property( 'slug' );
-					expect( tag.slug ).to.equal( selectedTag.slug );
-					expect( tag ).to.have.property( 'taxonomy' );
-					expect( tag.taxonomy ).to.equal( 'post_tag' );
-					expect( tag ).not.to.have.property( 'parent' );
+					expect( typeof tag ).toBe( 'object' );
+					expect( tag ).toHaveProperty( 'id' );
+					expect( tag.id ).toBe( selectedTag.id );
+					expect( tag ).toHaveProperty( 'slug' );
+					expect( tag.slug ).toBe( selectedTag.slug );
+					expect( tag ).toHaveProperty( 'taxonomy' );
+					expect( tag.taxonomy ).toBe( 'post_tag' );
+					expect( tag ).not.toHaveProperty( 'parent' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -241,22 +236,22 @@ describe( 'integration: tags()', () => {
 					return wp.tags().search( selectedTag.slug );
 				} )
 				.then( ( tags ) => {
-					expect( tags ).to.be.an( 'array' );
-					expect( tags.length ).to.equal( 1 );
+					expect( Array.isArray( tags ) ).toBe( true );
+					expect( tags.length ).toBe( 1 );
 					return tags[ 0 ];
 				} )
 				.then( ( tag ) => {
-					expect( tag ).to.be.an( 'object' );
-					expect( tag ).to.have.property( 'id' );
-					expect( tag.id ).to.equal( selectedTag.id );
-					expect( tag ).to.have.property( 'slug' );
-					expect( tag.slug ).to.equal( selectedTag.slug );
-					expect( tag ).to.have.property( 'taxonomy' );
-					expect( tag.taxonomy ).to.equal( 'post_tag' );
-					expect( tag ).not.to.have.property( 'parent' );
+					expect( typeof tag ).toBe( 'object' );
+					expect( tag ).toHaveProperty( 'id' );
+					expect( tag.id ).toBe( selectedTag.id );
+					expect( tag ).toHaveProperty( 'slug' );
+					expect( tag.slug ).toBe( selectedTag.slug );
+					expect( tag ).toHaveProperty( 'taxonomy' );
+					expect( tag.taxonomy ).toBe( 'post_tag' );
+					expect( tag ).not.toHaveProperty( 'parent' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'returns all tags matching the provided search string', () => {
@@ -264,13 +259,13 @@ describe( 'integration: tags()', () => {
 				.search( 'post' )
 				.get()
 				.then( ( tags ) => {
-					expect( tags ).to.be.an( 'array' );
-					expect( tags.length ).to.equal( 2 );
+					expect( Array.isArray( tags ) ).toBe( true );
+					expect( tags.length ).toBe( 2 );
 					const slugs = tags.map( tag => tag.slug ).sort().join( ' ' );
-					expect( slugs ).to.equal( 'post post-formats' );
+					expect( slugs ).toBe( 'post post-formats' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'can be used to retrieve a tag by slug from a set of search results', () => {
@@ -281,14 +276,14 @@ describe( 'integration: tags()', () => {
 				// filtering for taxonomy term collections is reinstated
 				.then( tags => tags.find( tag => tag.slug === 'post' ) )
 				.then( ( tag ) => {
-					expect( tag ).to.have.property( 'slug' );
-					expect( tag.slug ).to.equal( 'post' );
-					expect( tag ).to.have.property( 'name' );
-					expect( tag.name ).to.equal( 'post' );
-					expect( tag ).not.to.have.property( 'parent' );
+					expect( tag ).toHaveProperty( 'slug' );
+					expect( tag.slug ).toBe( 'post' );
+					expect( tag ).toHaveProperty( 'name' );
+					expect( tag.name ).toBe( 'post' );
+					expect( tag ).not.toHaveProperty( 'parent' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );

--- a/tests/integration/taxonomies.js
+++ b/tests/integration/taxonomies.js
@@ -1,14 +1,9 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 describe( 'integration: taxonomies()', () => {
 	let wp;
@@ -23,14 +18,14 @@ describe( 'integration: taxonomies()', () => {
 		const prom = wp.taxonomies()
 			.get()
 			.then( ( taxonomies ) => {
-				expect( taxonomies ).to.be.an( 'object' );
-				expect( taxonomies ).to.have.property( 'category' );
-				expect( taxonomies.category ).to.be.an( 'object' );
-				expect( taxonomies ).to.have.property( 'post_tag' );
-				expect( taxonomies.post_tag ).to.be.an( 'object' );
+				expect( typeof taxonomies ).toBe( 'object' );
+				expect( taxonomies ).toHaveProperty( 'category' );
+				expect( typeof taxonomies.category ).toBe( 'object' );
+				expect( taxonomies ).toHaveProperty( 'post_tag' );
+				expect( typeof taxonomies.post_tag ).toBe( 'object' );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can be chained with a taxonomy() call to fetch the category taxonomy', () => {
@@ -38,14 +33,14 @@ describe( 'integration: taxonomies()', () => {
 			.taxonomy( 'category' )
 			.get()
 			.then( ( category ) => {
-				expect( category ).to.be.an( 'object' );
-				expect( category ).to.have.property( 'slug' );
-				expect( category.slug ).to.equal( 'category' );
-				expect( category ).to.have.property( 'hierarchical' );
-				expect( category.hierarchical ).to.equal( true );
+				expect( typeof category ).toBe( 'object' );
+				expect( category ).toHaveProperty( 'slug' );
+				expect( category.slug ).toBe( 'category' );
+				expect( category ).toHaveProperty( 'hierarchical' );
+				expect( category.hierarchical ).toBe( true );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can be chained with a taxonomy() call to fetch the post_tag taxonomy', () => {
@@ -53,14 +48,14 @@ describe( 'integration: taxonomies()', () => {
 			.taxonomy( 'post_tag' )
 			.get()
 			.then( ( tag ) => {
-				expect( tag ).to.be.an( 'object' );
-				expect( tag ).to.have.property( 'slug' );
-				expect( tag.slug ).to.equal( 'post_tag' );
-				expect( tag ).to.have.property( 'hierarchical' );
-				expect( tag.hierarchical ).to.equal( false );
+				expect( typeof tag ).toBe( 'object' );
+				expect( tag ).toHaveProperty( 'slug' );
+				expect( tag.slug ).toBe( 'post_tag' );
+				expect( tag ).toHaveProperty( 'hierarchical' );
+				expect( tag.hierarchical ).toBe( false );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 } );

--- a/tests/integration/types.js
+++ b/tests/integration/types.js
@@ -1,14 +1,9 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-const expect = chai.expect;
 
 const WPAPI = require( '../../' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 describe( 'integration: types()', () => {
 	let wp;
@@ -23,16 +18,16 @@ describe( 'integration: types()', () => {
 		const prom = wp.types()
 			.get()
 			.then( ( types ) => {
-				expect( types ).to.be.an( 'object' );
-				expect( types ).to.have.property( 'post' );
-				expect( types.post ).to.be.an( 'object' );
-				expect( types ).to.have.property( 'page' );
-				expect( types.page ).to.be.an( 'object' );
-				expect( types ).to.have.property( 'attachment' );
-				expect( types.attachment ).to.be.an( 'object' );
+				expect( typeof types ).toBe( 'object' );
+				expect( types ).toHaveProperty( 'post' );
+				expect( typeof types.post ).toBe( 'object' );
+				expect( types ).toHaveProperty( 'page' );
+				expect( typeof types.page ).toBe( 'object' );
+				expect( types ).toHaveProperty( 'attachment' );
+				expect( typeof types.attachment ).toBe( 'object' );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can be chained with a type() call to fetch the "post" type', () => {
@@ -40,14 +35,14 @@ describe( 'integration: types()', () => {
 			.type( 'post' )
 			.get()
 			.then( ( post ) => {
-				expect( post ).to.be.an( 'object' );
-				expect( post ).to.have.property( 'slug' );
-				expect( post.slug ).to.equal( 'post' );
-				expect( post ).to.have.property( 'hierarchical' );
-				expect( post.hierarchical ).to.equal( false );
+				expect( typeof post ).toBe( 'object' );
+				expect( post ).toHaveProperty( 'slug' );
+				expect( post.slug ).toBe( 'post' );
+				expect( post ).toHaveProperty( 'hierarchical' );
+				expect( post.hierarchical ).toBe( false );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 	it( 'can be chained with a type() call to fetch the page type', () => {
@@ -55,14 +50,14 @@ describe( 'integration: types()', () => {
 			.type( 'page' )
 			.get()
 			.then( ( page ) => {
-				expect( page ).to.be.an( 'object' );
-				expect( page ).to.have.property( 'slug' );
-				expect( page.slug ).to.equal( 'page' );
-				expect( page ).to.have.property( 'hierarchical' );
-				expect( page.hierarchical ).to.equal( true );
+				expect( typeof page ).toBe( 'object' );
+				expect( page ).toHaveProperty( 'slug' );
+				expect( page.slug ).toBe( 'page' );
+				expect( page ).toHaveProperty( 'hierarchical' );
+				expect( page.hierarchical ).toBe( true );
 				return SUCCESS;
 			} );
-		return expect( prom ).to.eventually.equal( SUCCESS );
+		return expect( prom ).resolves.toBe( SUCCESS );
 	} );
 
 } );

--- a/tests/unit/build/scripts/simplify-object.js
+++ b/tests/unit/build/scripts/simplify-object.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const simplifyObject = require( '../../../../build/scripts/simplify-object' );
 
@@ -8,29 +7,29 @@ const fullPostsCollectionRouteDefinition = require( './posts-collection-route-de
 describe( 'simplifyObject', () => {
 
 	it( 'is a function', () => {
-		expect( simplifyObject ).to.be.a( 'function' );
+		expect( typeof simplifyObject ).toBe( 'function' );
 	} );
 
 	it( 'passes through strings without modification', () => {
-		expect( simplifyObject( 'foo' ) ).to.be.a( 'string' );
-		expect( simplifyObject( 'foo' ) ).to.equal( 'foo' );
+		expect( typeof simplifyObject( 'foo' ) ).toBe( 'string' );
+		expect( simplifyObject( 'foo' ) ).toBe( 'foo' );
 	} );
 
 	it( 'passes through numbers without modification', () => {
-		expect( simplifyObject( 7 ) ).to.be.a( 'number' );
-		expect( simplifyObject( 7 ) ).to.equal( 7 );
+		expect( typeof simplifyObject( 7 ) ).toBe( 'number' );
+		expect( simplifyObject( 7 ) ).toBe( 7 );
 	} );
 
 	it( 'passes through booleans without modification', () => {
-		expect( simplifyObject( true ) ).to.be.a( 'boolean' );
-		expect( simplifyObject( true ) ).to.equal( true );
+		expect( typeof simplifyObject( true ) ).toBe( 'boolean' );
+		expect( simplifyObject( true ) ).toBe( true );
 	} );
 
 	it( 'passes through arrays of simple values without modification', () => {
-		expect( simplifyObject( [] ) ).to.be.an( 'array' );
-		expect( simplifyObject( [ 1, 2, 3 ] ) ).to.deep.equal( [ 1, 2, 3 ] );
-		expect( simplifyObject( [ 'a', 'b', 'c' ] ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
-		expect( simplifyObject( [ true, false ] ) ).to.deep.equal( [ true, false ] );
+		expect( Array.isArray( simplifyObject( [] ) ) ).toBe( true );
+		expect( simplifyObject( [ 1, 2, 3 ] ) ).toEqual( [ 1, 2, 3 ] );
+		expect( simplifyObject( [ 'a', 'b', 'c' ] ) ).toEqual( [ 'a', 'b', 'c' ] );
+		expect( simplifyObject( [ true, false ] ) ).toEqual( [ true, false ] );
 	} );
 
 	it( 'passes through most objects without modification', () => {
@@ -43,7 +42,7 @@ describe( 'simplifyObject', () => {
 				} ],
 				nr: 7,
 			},
-		} ) ).to.deep.equal( {
+		} ) ).toEqual( {
 			some: 'set',
 			of: 'basic',
 			nested: {
@@ -61,7 +60,7 @@ describe( 'simplifyObject', () => {
 			_links: {
 				prop: 'within it',
 			},
-		} ) ).to.deep.equal( {
+		} ) ).toEqual( {
 			some: 'object with a',
 		} );
 	} );
@@ -75,7 +74,7 @@ describe( 'simplifyObject', () => {
 					go: 'here',
 				},
 			},
-		} ) ).to.deep.equal( {
+		} ) ).toEqual( {
 			args: {
 				context: {},
 			},
@@ -83,7 +82,7 @@ describe( 'simplifyObject', () => {
 	} );
 
 	it( 'properly transforms a full route definition object', () => {
-		expect( simplifyObject( fullPostsCollectionRouteDefinition ) ).to.deep.equal( {
+		expect( simplifyObject( fullPostsCollectionRouteDefinition ) ).toEqual( {
 			namespace: 'wp/v2',
 			methods: [ 'GET', 'POST' ],
 			endpoints: [ {

--- a/tests/unit/lib/autodiscovery.js
+++ b/tests/unit/lib/autodiscovery.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const autodiscovery = require( '../../../lib/autodiscovery' );
 
@@ -13,7 +12,7 @@ describe( 'autodiscovery helper methods', () => {
 		} );
 
 		it( 'is a function', () => {
-			expect( locateAPIRootHeader ).to.be.a( 'function' );
+			expect( typeof locateAPIRootHeader ).toBe( 'function' );
 		} );
 
 		it( 'throws an error if no link header is found', () => {
@@ -21,7 +20,7 @@ describe( 'autodiscovery helper methods', () => {
 				locateAPIRootHeader( {
 					headers: {},
 				} );
-			} ).to.throw( 'No header link found with rel="https://api.w.org/"' );
+			} ).toThrow( 'No header link found with rel="https://api.w.org/"' );
 		} );
 
 		it( 'parsed and returns the header with the rel for the REST API endpoint', () => {
@@ -30,7 +29,7 @@ describe( 'autodiscovery helper methods', () => {
 					link: '<http://wpapi.local/wp-json/>; rel="https://api.w.org/"',
 				},
 			} );
-			expect( result ).to.equal( 'http://wpapi.local/wp-json/' );
+			expect( result ).toBe( 'http://wpapi.local/wp-json/' );
 		} );
 
 	} );

--- a/tests/unit/lib/constructors/wp-request.js
+++ b/tests/unit/lib/constructors/wp-request.js
@@ -1,8 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-const expect = chai.expect;
-chai.use( require( 'sinon-chai' ) );
-const sinon = require( 'sinon' );
 
 const WPRequest = require( '../../../../lib/constructors/wp-request' );
 const filterMixins = require( '../../../../lib/mixins/filters' );
@@ -21,19 +17,19 @@ describe( 'WPRequest', () => {
 	describe( 'constructor', () => {
 
 		it( 'should create a WPRequest instance', () => {
-			expect( request instanceof WPRequest ).to.be.true;
+			expect( request instanceof WPRequest ).toBe( true );
 		} );
 
 		it( 'should set any passed-in options', () => {
 			request = new WPRequest( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( request.toString() ).to.equal( '/custom-endpoint/' );
+			expect( request.toString() ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should define a _supportedMethods array', () => {
 			const _supportedMethods = request._supportedMethods.sort().join( '|' );
-			expect( _supportedMethods ).to.equal( 'delete|get|head|post|put' );
+			expect( _supportedMethods ).toBe( 'delete|get|head|post|put' );
 		} );
 
 	} );
@@ -55,8 +51,8 @@ describe( 'WPRequest', () => {
 			};
 			const query = request._renderQuery();
 			// Filters should be in alpha order, to support caching requests
-			expect( query ).to
-				.equal( '?filter%5Bcustom_tax%5D=7&filter%5Btag%5D=clouds%2Bislands' );
+			expect( query )
+				.toBe( '?filter%5Bcustom_tax%5D=7&filter%5Btag%5D=clouds%2Bislands' );
 		} );
 
 		it( 'lower-cases taxonomy terms', () => {
@@ -64,7 +60,7 @@ describe( 'WPRequest', () => {
 				tag: [ 'Diamond-Dust' ],
 			};
 			const query = request._renderQuery();
-			expect( query ).to.equal( '?filter%5Btag%5D=diamond-dust' );
+			expect( query ).toBe( '?filter%5Btag%5D=diamond-dust' );
 		} );
 
 		it( 'properly parses regular filters', () => {
@@ -73,15 +69,15 @@ describe( 'WPRequest', () => {
 				s: 'Some search string',
 			};
 			const query = request._renderQuery();
-			expect( query ).to
-				.equal( '?filter%5Bpost_status%5D=publish&filter%5Bs%5D=Some%20search%20string' );
+			expect( query )
+				.toBe( '?filter%5Bpost_status%5D=publish&filter%5Bs%5D=Some%20search%20string' );
 		} );
 
 		it( 'properly parses array filters', () => {
 			request._filters = { post__in: [ 0, 1 ] };
 			const query = request._renderQuery();
-			expect( query ).to
-				.equal( '?filter%5Bpost__in%5D%5B%5D=0&filter%5Bpost__in%5D%5B%5D=1' );
+			expect( query )
+				.toBe( '?filter%5Bpost__in%5D%5B%5D=0&filter%5Bpost__in%5D%5B%5D=1' );
 		} );
 
 		it( 'correctly merges taxonomy and regular filters & renders them in order', () => {
@@ -93,7 +89,7 @@ describe( 'WPRequest', () => {
 			};
 			const query = request._renderQuery();
 			// Filters should be in alpha order, to support caching requests
-			expect( query ).to.equal( '?filter%5Bcat%5D=7%2B10&filter%5Bname%5D=some-slug' );
+			expect( query ).toBe( '?filter%5Bcat%5D=7%2B10&filter%5Bname%5D=some-slug' );
 		} );
 
 	} );
@@ -101,7 +97,7 @@ describe( 'WPRequest', () => {
 	describe( '.checkMethodSupport()', () => {
 
 		it( 'should return true when called with a supported method', () => {
-			expect( checkMethodSupport( 'get', request ) ).to.equal( true );
+			expect( checkMethodSupport( 'get', request ) ).toBe( true );
 		} );
 
 		it( 'should throw an error when called with an unsupported method', () => {
@@ -109,7 +105,7 @@ describe( 'WPRequest', () => {
 
 			expect( () => {
 				checkMethodSupport( 'post', request );
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 	} );
@@ -117,28 +113,28 @@ describe( 'WPRequest', () => {
 	describe( '.namespace()', () => {
 
 		it( 'is defined', () => {
-			expect( request ).to.have.property( 'namespace' );
-			expect( request.namespace ).to.be.a( 'function' );
+			expect( request ).toHaveProperty( 'namespace' );
+			expect( typeof request.namespace ).toBe( 'function' );
 		} );
 
 		it( 'sets a value that is prepended to the path', () => {
 			request.namespace( 'ns' );
-			expect( request._renderPath() ).to.equal( 'ns' );
+			expect( request._renderPath() ).toBe( 'ns' );
 		} );
 
 		it( 'can accept & set a namespace in the (:domain/:version) format', () => {
 			request.namespace( 'ns/v3' );
-			expect( request._renderPath() ).to.equal( 'ns/v3' );
+			expect( request._renderPath() ).toBe( 'ns/v3' );
 		} );
 
 		it( 'can be removed (to use the legacy api v1) with an empty string', () => {
 			request.namespace( 'windows/xp' ).namespace( '' );
-			expect( request._renderPath() ).to.equal( '' );
+			expect( request._renderPath() ).toBe( '' );
 		} );
 
 		it( 'can be removed (to use the legacy api v1) by omitting arguments', () => {
 			request.namespace( 'wordpress/95' ).namespace();
-			expect( request._renderPath() ).to.equal( '' );
+			expect( request._renderPath() ).toBe( '' );
 		} );
 
 	} );
@@ -146,51 +142,51 @@ describe( 'WPRequest', () => {
 	describe( '.param()', () => {
 
 		it( 'method exists', () => {
-			expect( request ).to.have.property( 'param' );
-			expect( request.param ).to.be.a( 'function' );
+			expect( request ).toHaveProperty( 'param' );
+			expect( typeof request.param ).toBe( 'function' );
 		} );
 
 		it( 'will have no effect if called without any arguments', () => {
 			request.param();
-			expect( request._renderQuery() ).to.equal( '' );
+			expect( request._renderQuery() ).toBe( '' );
 		} );
 
 		it( 'will set a query parameter value', () => {
 			request.param( 'key', 'value' );
-			expect( request._renderQuery() ).to.equal( '?key=value' );
+			expect( request._renderQuery() ).toBe( '?key=value' );
 		} );
 
 		it( 'will unset a query parameter value if called with empty string', () => {
 			request.param( 'key', 'value' );
-			expect( request._renderQuery() ).to.equal( '?key=value' );
+			expect( request._renderQuery() ).toBe( '?key=value' );
 			request.param( 'key', 'value' );
 			request.param( 'key', '' );
-			expect( request._renderQuery() ).to.equal( '' );
+			expect( request._renderQuery() ).toBe( '' );
 		} );
 
 		it( 'will unset a query parameter value if called with null', () => {
 			request.param( 'key', 'value' );
-			expect( request._renderQuery() ).to.equal( '?key=value' );
+			expect( request._renderQuery() ).toBe( '?key=value' );
 			request.param( 'key', 'value' );
 			request.param( 'key', null );
-			expect( request._renderQuery() ).to.equal( '' );
+			expect( request._renderQuery() ).toBe( '' );
 		} );
 
 		it( 'will have no effect if called with no value', () => {
 			request.param( 'key' );
-			expect( request._renderQuery() ).to.equal( '' );
+			expect( request._renderQuery() ).toBe( '' );
 		} );
 
 		it( 'will have no effect if called with an empty object', () => {
 			request.param( {} );
-			expect( request._renderQuery() ).to.equal( '' );
+			expect( request._renderQuery() ).toBe( '' );
 		} );
 
 		it( 'should set the internal _params hash', () => {
 			request.param( 'type', 'some_cpt' );
-			expect( request._renderQuery() ).to.equal( '?type=some_cpt' );
+			expect( request._renderQuery() ).toBe( '?type=some_cpt' );
 			request.param( 'context', 'edit' );
-			expect( request._renderQuery() ).to.equal( '?context=edit&type=some_cpt' );
+			expect( request._renderQuery() ).toBe( '?context=edit&type=some_cpt' );
 		} );
 
 		it( 'should set multiple parameters by passing a hash object', () => {
@@ -198,12 +194,12 @@ describe( 'WPRequest', () => {
 				page: 309,
 				context: 'view',
 			} );
-			expect( request._renderQuery() ).to.equal( '?context=view&page=309' );
+			expect( request._renderQuery() ).toBe( '?context=view&page=309' );
 		} );
 
 		it( 'should de-dupe & sort array values', () => {
 			request.param( 'type', [ 'post', 'page', 'post', 'page', 'cpt_item' ] );
-			expect( request._renderQuery() ).to.equal( '?type%5B%5D=cpt_item&type%5B%5D=page&type%5B%5D=post' );
+			expect( request._renderQuery() ).toBe( '?type%5B%5D=cpt_item&type%5B%5D=page&type%5B%5D=post' );
 		} );
 
 	} );
@@ -229,32 +225,31 @@ describe( 'WPRequest', () => {
 			} );
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'context' );
-				expect( request.context ).to.be.a( 'function' );
+				expect( request ).toHaveProperty( 'context' );
+				expect( typeof request.context ).toBe( 'function' );
 			} );
 
 			it( 'wraps .param()', () => {
-				sinon.stub( request, 'param' );
+				jest.spyOn( request, 'param' );
 				request.context( 'view' );
-				expect( request.param ).to.have.been.calledWith( 'context', 'view' );
+				expect( request.param ).toHaveBeenCalledWith( 'context', 'view' );
 			} );
 
 			it( 'should map to the "context=VALUE" query parameter', () => {
 				const path = request.context( 'edit' ).toString();
-				expect( path ).to.equal( '/?context=edit' );
+				expect( path ).toBe( '/?context=edit' );
 			} );
 
 			it( 'should replace values when called multiple times', () => {
 				const path = request.context( 'edit' ).context( 'view' ).toString();
-				expect( path ).to.equal( '/?context=view' );
+				expect( path ).toBe( '/?context=view' );
 			} );
 
 			it( 'should provide a .edit() shortcut for .context( "edit" )', () => {
-				sinon.spy( request, 'context' );
+				jest.spyOn( request, 'context' );
 				request.edit();
-				expect( request.context ).to.have.been.calledWith( 'edit' );
-				expect( request.toString() ).to.equal( '/?context=edit' );
-				request.context.restore();
+				expect( request.context ).toHaveBeenCalledWith( 'edit' );
+				expect( request.toString() ).toBe( '/?context=edit' );
 			} );
 
 		} );
@@ -262,20 +257,20 @@ describe( 'WPRequest', () => {
 		describe( '.embed()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'embed' );
+				expect( request ).toHaveProperty( 'embed' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.embed ).to.be.a( 'function' );
+				expect( typeof request.embed ).toBe( 'function' );
 			} );
 
 			it( 'should set the "_embed" parameter', () => {
 				request.embed();
-				expect( request._params._embed ).to.equal( true );
+				expect( request._params._embed ).toBe( true );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.embed() ).to.equal( request );
+				expect( request.embed() ).toBe( request );
 			} );
 
 		} );
@@ -283,30 +278,30 @@ describe( 'WPRequest', () => {
 		describe( '.page()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'page' );
+				expect( request ).toHaveProperty( 'page' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.page ).to.be.a( 'function' );
+				expect( typeof request.page ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.page() ).to.equal( request );
+				expect( request.page() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.page();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "page" query parameter when provided a value', () => {
 				const result = request.page( 7 );
-				expect( getQueryStr( result ) ).to.equal( 'page=7' );
+				expect( getQueryStr( result ) ).toBe( 'page=7' );
 			} );
 
 			it( 'should be chainable and replace values when called multiple times', () => {
 				const result = request.page( 71 ).page( 2 );
-				expect( getQueryStr( result ) ).to.equal( 'page=2' );
+				expect( getQueryStr( result ) ).toBe( 'page=2' );
 			} );
 
 		} );
@@ -314,30 +309,30 @@ describe( 'WPRequest', () => {
 		describe( '.perPage()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'perPage' );
+				expect( request ).toHaveProperty( 'perPage' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.perPage ).to.be.a( 'function' );
+				expect( typeof request.perPage ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.perPage() ).to.equal( request );
+				expect( request.perPage() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.perPage();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "per_page" query parameter when provided a value', () => {
 				const result = request.perPage( 7 );
-				expect( getQueryStr( result ) ).to.equal( 'per_page=7' );
+				expect( getQueryStr( result ) ).toBe( 'per_page=7' );
 			} );
 
 			it( 'should be chainable and replace values when called multiple times', () => {
 				const result = request.perPage( 71 ).perPage( 2 );
-				expect( getQueryStr( result ) ).to.equal( 'per_page=2' );
+				expect( getQueryStr( result ) ).toBe( 'per_page=2' );
 			} );
 
 		} );
@@ -345,30 +340,30 @@ describe( 'WPRequest', () => {
 		describe( '.offset()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'offset' );
+				expect( request ).toHaveProperty( 'offset' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.offset ).to.be.a( 'function' );
+				expect( typeof request.offset ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.offset() ).to.equal( request );
+				expect( request.offset() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.offset();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "offset" query parameter when provided a value', () => {
 				const result = request.offset( 7 );
-				expect( getQueryStr( result ) ).to.equal( 'offset=7' );
+				expect( getQueryStr( result ) ).toBe( 'offset=7' );
 			} );
 
 			it( 'should be chainable and replace values when called multiple times', () => {
 				const result = request.offset( 71 ).offset( 2 );
-				expect( getQueryStr( result ) ).to.equal( 'offset=2' );
+				expect( getQueryStr( result ) ).toBe( 'offset=2' );
 			} );
 
 		} );
@@ -376,30 +371,30 @@ describe( 'WPRequest', () => {
 		describe( '.order()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'order' );
+				expect( request ).toHaveProperty( 'order' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.order ).to.be.a( 'function' );
+				expect( typeof request.order ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.order() ).to.equal( request );
+				expect( request.order() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.order();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "order" query parameter when provided a value', () => {
 				const result = request.order( 'asc' );
-				expect( getQueryStr( result ) ).to.equal( 'order=asc' );
+				expect( getQueryStr( result ) ).toBe( 'order=asc' );
 			} );
 
 			it( 'should be chainable and replace values when called multiple times', () => {
 				const result = request.order( 'asc' ).order( 'desc' );
-				expect( getQueryStr( result ) ).to.equal( 'order=desc' );
+				expect( getQueryStr( result ) ).toBe( 'order=desc' );
 			} );
 
 		} );
@@ -407,30 +402,30 @@ describe( 'WPRequest', () => {
 		describe( '.orderby()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'orderby' );
+				expect( request ).toHaveProperty( 'orderby' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.orderby ).to.be.a( 'function' );
+				expect( typeof request.orderby ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.orderby() ).to.equal( request );
+				expect( request.orderby() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.orderby();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "orderby" query parameter when provided a value', () => {
 				const result = request.orderby( 'title' );
-				expect( getQueryStr( result ) ).to.equal( 'orderby=title' );
+				expect( getQueryStr( result ) ).toBe( 'orderby=title' );
 			} );
 
 			it( 'should be chainable and replace values when called multiple times', () => {
 				const result = request.orderby( 'title' ).orderby( 'slug' );
-				expect( getQueryStr( result ) ).to.equal( 'orderby=slug' );
+				expect( getQueryStr( result ) ).toBe( 'orderby=slug' );
 			} );
 
 		} );
@@ -438,30 +433,30 @@ describe( 'WPRequest', () => {
 		describe( '.search()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'search' );
+				expect( request ).toHaveProperty( 'search' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.search ).to.be.a( 'function' );
+				expect( typeof request.search ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.search() ).to.equal( request );
+				expect( request.search() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.search();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "search" query parameter when provided a value', () => {
 				const result = request.search( 'my search string' );
-				expect( getQueryStr( result ) ).to.equal( 'search=my search string' );
+				expect( getQueryStr( result ) ).toBe( 'search=my search string' );
 			} );
 
 			it( 'overwrites previously-set values on subsequent calls', () => {
 				const result = request.search( 'query' ).search( 'newquery' );
-				expect( getQueryStr( result ) ).to.equal( 'search=newquery' );
+				expect( getQueryStr( result ) ).toBe( 'search=newquery' );
 			} );
 
 		} );
@@ -469,35 +464,35 @@ describe( 'WPRequest', () => {
 		describe( '.include()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'include' );
+				expect( request ).toHaveProperty( 'include' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.include ).to.be.a( 'function' );
+				expect( typeof request.include ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.include() ).to.equal( request );
+				expect( request.include() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.include();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "include" query parameter when provided a value', () => {
 				const result = request.include( 7 );
-				expect( getQueryStr( result ) ).to.equal( 'include=7' );
+				expect( getQueryStr( result ) ).toBe( 'include=7' );
 			} );
 
 			it( 'can set an array of "include" values', () => {
 				const result = request.include( [ 7, 41, 98 ] );
-				expect( getQueryStr( result ) ).to.equal( 'include[]=41&include[]=7&include[]=98' );
+				expect( getQueryStr( result ) ).toBe( 'include[]=41&include[]=7&include[]=98' );
 			} );
 
 			it( 'should be chainable and replace values when called multiple times', () => {
 				const result = request.include( 71 ).include( 2 );
-				expect( getQueryStr( result ) ).to.equal( 'include=2' );
+				expect( getQueryStr( result ) ).toBe( 'include=2' );
 			} );
 
 		} );
@@ -505,35 +500,35 @@ describe( 'WPRequest', () => {
 		describe( '.exclude()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'exclude' );
+				expect( request ).toHaveProperty( 'exclude' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.exclude ).to.be.a( 'function' );
+				expect( typeof request.exclude ).toBe( 'function' );
 			} );
 
 			it( 'should be chainable', () => {
-				expect( request.exclude() ).to.equal( request );
+				expect( request.exclude() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.exclude();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "exclude" query parameter when provided a value', () => {
 				const result = request.exclude( 7 );
-				expect( getQueryStr( result ) ).to.equal( 'exclude=7' );
+				expect( getQueryStr( result ) ).toBe( 'exclude=7' );
 			} );
 
 			it( 'can set an array of "exclude" values', () => {
 				const result = request.exclude( [ 7, 41, 98 ] );
-				expect( getQueryStr( result ) ).to.equal( 'exclude[]=41&exclude[]=7&exclude[]=98' );
+				expect( getQueryStr( result ) ).toBe( 'exclude[]=41&exclude[]=7&exclude[]=98' );
 			} );
 
 			it( 'should be chainable and replace values when called multiple times', () => {
 				const result = request.exclude( 71 ).exclude( 2 );
-				expect( getQueryStr( result ) ).to.equal( 'exclude=2' );
+				expect( getQueryStr( result ) ).toBe( 'exclude=2' );
 			} );
 
 		} );
@@ -541,25 +536,25 @@ describe( 'WPRequest', () => {
 		describe( '.slug()', () => {
 
 			it( 'is defined', () => {
-				expect( request ).to.have.property( 'slug' );
+				expect( request ).toHaveProperty( 'slug' );
 			} );
 
 			it( 'is a function', () => {
-				expect( request.slug ).to.be.a( 'function' );
+				expect( typeof request.slug ).toBe( 'function' );
 			} );
 
 			it( 'supports chaining', () => {
-				expect( request.slug() ).to.equal( request );
+				expect( request.slug() ).toBe( request );
 			} );
 
 			it( 'has no effect when called with no argument', () => {
 				const result = request.slug();
-				expect( getQueryStr( result ) ).to.equal( '' );
+				expect( getQueryStr( result ) ).toBe( '' );
 			} );
 
 			it( 'sets the "slug" query parameter when provided a value', () => {
 				const result = request.slug( 'bran-van' );
-				expect( getQueryStr( result ) ).to.equal( 'slug=bran-van' );
+				expect( getQueryStr( result ) ).toBe( 'slug=bran-van' );
 			} );
 
 		} );
@@ -569,54 +564,54 @@ describe( 'WPRequest', () => {
 	describe( '.auth()', () => {
 
 		it( 'is defined', () => {
-			expect( request ).to.have.property( 'auth' );
-			expect( request.auth ).to.be.a( 'function' );
+			expect( request ).toHaveProperty( 'auth' );
+			expect( typeof request.auth ).toBe( 'function' );
 		} );
 
 		it( 'activates authentication for the request', () => {
-			expect( request._options ).not.to.have.property( 'auth' );
+			expect( request._options ).not.toHaveProperty( 'auth' );
 			request.auth();
-			expect( request._options ).to.have.property( 'auth' );
-			expect( request._options.auth ).to.be.true;
+			expect( request._options ).toHaveProperty( 'auth' );
+			expect( request._options.auth ).toBe( true );
 		} );
 
 		it( 'sets the username and password when provided in an object', () => {
-			expect( request._options ).not.to.have.property( 'username' );
-			expect( request._options ).not.to.have.property( 'password' );
+			expect( request._options ).not.toHaveProperty( 'username' );
+			expect( request._options ).not.toHaveProperty( 'password' );
 			request.auth( {
 				username: 'user',
 				password: 'pass',
 			} );
-			expect( request._options ).to.have.property( 'username' );
-			expect( request._options ).to.have.property( 'password' );
-			expect( request._options.username ).to.equal( 'user' );
-			expect( request._options.password ).to.equal( 'pass' );
-			expect( request._options ).to.have.property( 'auth' );
-			expect( request._options.auth ).to.be.true;
+			expect( request._options ).toHaveProperty( 'username' );
+			expect( request._options ).toHaveProperty( 'password' );
+			expect( request._options.username ).toBe( 'user' );
+			expect( request._options.password ).toBe( 'pass' );
+			expect( request._options ).toHaveProperty( 'auth' );
+			expect( request._options.auth ).toBe( true );
 		} );
 
 		it( 'does not set username/password if they are not provided as string values', () => {
-			expect( request._options ).not.to.have.property( 'username' );
-			expect( request._options ).not.to.have.property( 'password' );
+			expect( request._options ).not.toHaveProperty( 'username' );
+			expect( request._options ).not.toHaveProperty( 'password' );
 			request.auth( {
 				username: 123,
 				password: false,
 			} );
-			expect( request._options ).not.to.have.property( 'username' );
-			expect( request._options ).not.to.have.property( 'password' );
-			expect( request._options ).to.have.property( 'auth' );
-			expect( request._options.auth ).to.be.true;
+			expect( request._options ).not.toHaveProperty( 'username' );
+			expect( request._options ).not.toHaveProperty( 'password' );
+			expect( request._options ).toHaveProperty( 'auth' );
+			expect( request._options.auth ).toBe( true );
 		} );
 
 		it( 'sets the nonce when provided in an object', () => {
-			expect( request._options ).not.to.have.property( 'nonce' );
+			expect( request._options ).not.toHaveProperty( 'nonce' );
 			request.auth( {
 				nonce: 'nonceynonce',
 			} );
-			expect( request._options ).to.have.property( 'nonce' );
-			expect( request._options.nonce ).to.equal( 'nonceynonce' );
-			expect( request._options ).to.have.property( 'auth' );
-			expect( request._options.auth ).to.be.true;
+			expect( request._options ).toHaveProperty( 'nonce' );
+			expect( request._options.nonce ).toBe( 'nonceynonce' );
+			expect( request._options ).toHaveProperty( 'auth' );
+			expect( request._options.auth ).toBe( true );
 		} );
 
 		it( 'can update nonce credentials', () => {
@@ -625,10 +620,10 @@ describe( 'WPRequest', () => {
 			} ).auth( {
 				nonce: 'refreshednonce',
 			} );
-			expect( request._options ).to.have.property( 'nonce' );
-			expect( request._options.nonce ).to.equal( 'refreshednonce' );
-			expect( request._options ).to.have.property( 'auth' );
-			expect( request._options.auth ).to.be.true;
+			expect( request._options ).toHaveProperty( 'nonce' );
+			expect( request._options.nonce ).toBe( 'refreshednonce' );
+			expect( request._options ).toHaveProperty( 'auth' );
+			expect( request._options.auth ).toBe( true );
 		} );
 
 	} ); // auth
@@ -636,38 +631,38 @@ describe( 'WPRequest', () => {
 	describe( '.file()', () => {
 
 		it( 'method exists', () => {
-			expect( request ).to.have.property( 'file' );
-			expect( request.file ).to.be.a( 'function' );
+			expect( request ).toHaveProperty( 'file' );
+			expect( typeof request.file ).toBe( 'function' );
 		} );
 
 		it( 'will have no effect if called without any arguments', () => {
 			request.file();
-			expect( request._attachment ).to.be.undefined;
+			expect( request._attachment ).toBeUndefined();
 		} );
 
 		it( 'will set a file path to upload', () => {
 			request.file( '/some/file.jpg' );
-			expect( request._attachment ).to.equal( '/some/file.jpg' );
+			expect( request._attachment ).toBe( '/some/file.jpg' );
 		} );
 
 		it( 'will replace previously-set file paths if called multiple times', () => {
 			request.file( '/some/file.jpg' ).file( '/some/other/file.jpg' );
-			expect( request._attachment ).to.equal( '/some/other/file.jpg' );
+			expect( request._attachment ).toBe( '/some/other/file.jpg' );
 		} );
 
 		it( 'will clear out previously-set paths if called again without any arguments', () => {
 			request.file( '/some/file.jpg' ).file();
-			expect( request._attachment ).to.be.undefined;
+			expect( request._attachment ).toBeUndefined();
 		} );
 
 		it( 'will set an attachment name to use for the provided file', () => {
 			request.file( '/some/file.jpg', 'cat_picture.jpg' );
-			expect( request._attachmentName ).to.equal( 'cat_picture.jpg' );
+			expect( request._attachmentName ).toBe( 'cat_picture.jpg' );
 		} );
 
 		it( 'will clear out previously-set name if called again without a name', () => {
 			request.file( '/some/file.jpg', 'cat_picture.jpg' ).file( '/some/other/file.jpg' );
-			expect( request._attachmentName ).to.be.undefined;
+			expect( request._attachmentName ).toBeUndefined();
 		} );
 
 	} );
@@ -675,18 +670,18 @@ describe( 'WPRequest', () => {
 	describe( '.setHeaders()', () => {
 
 		it( 'method exists', () => {
-			expect( request ).to.have.property( 'setHeaders' );
-			expect( request.setHeaders ).to.be.a( 'function' );
+			expect( request ).toHaveProperty( 'setHeaders' );
+			expect( typeof request.setHeaders ).toBe( 'function' );
 		} );
 
 		it( 'will have no effect if called without any arguments', () => {
 			request.setHeaders();
-			expect( request._options.headers ).to.deep.equal( {} );
+			expect( request._options.headers ).toEqual( {} );
 		} );
 
 		it( 'will set a header key/value pair', () => {
 			request.setHeaders( 'Authorization', 'Bearer sometoken' );
-			expect( request._options.headers ).to.deep.equal( {
+			expect( request._options.headers ).toEqual( {
 				Authorization: 'Bearer sometoken',
 			} );
 		} );
@@ -695,7 +690,7 @@ describe( 'WPRequest', () => {
 			request
 				.setHeaders( 'Authorization', 'Bearer sometoken' )
 				.setHeaders( 'Authorization', 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==' );
-			expect( request._options.headers ).to.deep.equal( {
+			expect( request._options.headers ).toEqual( {
 				Authorization: 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==',
 			} );
 		} );
@@ -704,7 +699,7 @@ describe( 'WPRequest', () => {
 			request
 				.setHeaders( 'Accept-Language', 'en-US' )
 				.setHeaders( 'Authorization', 'Bearer sometoken' );
-			expect( request._options.headers ).to.deep.equal( {
+			expect( request._options.headers ).toEqual( {
 				'Accept-Language': 'en-US',
 				Authorization: 'Bearer sometoken',
 			} );
@@ -715,7 +710,7 @@ describe( 'WPRequest', () => {
 				'Accept-Language': 'en-US',
 				Authorization: 'Bearer sometoken',
 			} );
-			expect( request._options.headers ).to.deep.equal( {
+			expect( request._options.headers ).toEqual( {
 				'Accept-Language': 'en-US',
 				Authorization: 'Bearer sometoken',
 			} );
@@ -731,7 +726,7 @@ describe( 'WPRequest', () => {
 					'Accept-Language': 'pt-BR',
 					Authorization: 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==',
 				} );
-			expect( request._options.headers ).to.deep.equal( {
+			expect( request._options.headers ).toEqual( {
 				'Accept-Language': 'pt-BR',
 				Authorization: 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==',
 			} );
@@ -744,7 +739,7 @@ describe( 'WPRequest', () => {
 					'Accept-Language': 'pt-BR',
 				},
 			} );
-			expect( request._options.headers ).to.deep.equal( {
+			expect( request._options.headers ).toEqual( {
 				'Accept-Language': 'pt-BR',
 			} );
 		} );
@@ -761,12 +756,12 @@ describe( 'WPRequest', () => {
 
 		it( 'renders the URL to a string', () => {
 			const str = request.param( 'a', 7 ).param( 'b', [ 1, 2 ] ).toString();
-			expect( str ).to.equal( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
+			expect( str ).toBe( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
 		} );
 
 		it( 'exhibits normal toString() behavior via coercion', () => {
 			const str = '' + request.param( 'a', 7 ).param( 'b', [ 1, 2 ] );
-			expect( str ).to.equal( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
+			expect( str ).toBe( 'http://blogoblog.com/wp-json?a=7&b%5B%5D=1&b%5B%5D=2' );
 		} );
 
 		it( 'correctly merges query strings for "plain permalinks" endpoints', () => {
@@ -774,7 +769,7 @@ describe( 'WPRequest', () => {
 				endpoint: 'https://blogoblog.com?rest_route=/',
 			} );
 			const str = request.param( 'a', 7 ).param( 'b', [ 1, 2 ] ).toString();
-			expect( str ).to.equal( 'https://blogoblog.com?rest_route=/&a=7&b%5B%5D=1&b%5B%5D=2' );
+			expect( str ).toBe( 'https://blogoblog.com?rest_route=/&a=7&b%5B%5D=1&b%5B%5D=2' );
 		} );
 
 	} );
@@ -782,36 +777,36 @@ describe( 'WPRequest', () => {
 	describe( '.setPathPart()', () => {
 
 		it( 'is defined', () => {
-			expect( request ).to.have.property( 'setPathPart' );
+			expect( request ).toHaveProperty( 'setPathPart' );
 		} );
 
 		it( 'is a function', () => {
-			expect( request.setPathPart ).to.be.a( 'function' );
+			expect( typeof request.setPathPart ).toBe( 'function' );
 		} );
 
 		it( 'is chainable', () => {
-			expect( request.setPathPart() ).to.equal( request );
+			expect( request.setPathPart() ).toBe( request );
 		} );
 
 		it( 'sets a path part', () => {
 			request.setPathPart( 0, 'foo' );
-			expect( request.toString() ).to.equal( '/foo' );
+			expect( request.toString() ).toBe( '/foo' );
 		} );
 
 		it( 'sets multiple path parts', () => {
 			request.setPathPart( 0, 'foo' ).setPathPart( 1, 'bar' );
-			expect( request.toString() ).to.equal( '/foo/bar' );
+			expect( request.toString() ).toBe( '/foo/bar' );
 		} );
 
 		it( 'sets multiple non-consecutive path parts', () => {
 			request.setPathPart( 0, 'foo' ).setPathPart( 2, 'baz' );
-			expect( request.toString() ).to.equal( '/foo/baz' );
+			expect( request.toString() ).toBe( '/foo/baz' );
 		} );
 
 		it( 'throws an error if called multiple times for the same level', () => {
 			expect( () => {
 				request.setPathPart( 0, 'foo' ).setPathPart( 0, 'bar' );
-			} ).to.throw( 'Cannot overwrite value foo' );
+			} ).toThrow( 'Cannot overwrite value foo' );
 		} );
 
 	} );
@@ -819,22 +814,21 @@ describe( 'WPRequest', () => {
 	describe( '.validatePath()', () => {
 
 		it( 'is defined', () => {
-			expect( request ).to.have.property( 'validatePath' );
+			expect( request ).toHaveProperty( 'validatePath' );
 		} );
 
 		it( 'is a function', () => {
-			expect( request.validatePath ).to.be.a( 'function' );
+			expect( typeof request.validatePath ).toBe( 'function' );
 		} );
 
 		it( 'is chainable', () => {
-			expect( request.validatePath() ).to.equal( request );
+			expect( request.validatePath() ).toBe( request );
 		} );
 
 		it( 'is called by toString()', () => {
-			sinon.spy( request, 'validatePath' );
+			jest.spyOn( request, 'validatePath' );
 			request.toString();
-			expect( request.validatePath ).to.have.been.called;
-			request.validatePath.restore();
+			expect( request.validatePath ).toHaveBeenCalled();
 		} );
 
 		it( 'allows any sequence of path parts if no _levels are specified', () => {
@@ -845,8 +839,8 @@ describe( 'WPRequest', () => {
 					.setPathPart( 4, 'bar' )
 					.setPathPart( 2, 'baz' )
 					.validatePath();
-			} ).not.to.throw();
-			expect( request.toString() ).to.equal( '/foo/baz/bar' );
+			} ).not.toThrow();
+			expect( request.toString() ).toBe( '/foo/baz/bar' );
 		} );
 
 		it( 'allows omitted _levels so long as there are no gaps', () => {
@@ -856,8 +850,8 @@ describe( 'WPRequest', () => {
 			};
 			expect( () => {
 				request.setPathPart( 0, 'posts' ).validatePath();
-			} ).not.to.throw();
-			expect( request.toString() ).to.equal( '/posts' );
+			} ).not.toThrow();
+			expect( request.toString() ).toBe( '/posts' );
 		} );
 
 		it( 'allows any value for a level if no validate function is specified', () => {
@@ -866,8 +860,8 @@ describe( 'WPRequest', () => {
 			};
 			expect( () => {
 				request.setPathPart( 0, 'foo' ).validatePath();
-			} ).not.to.throw();
-			expect( request.toString() ).to.equal( '/foo' );
+			} ).not.toThrow();
+			expect( request.toString() ).toBe( '/foo' );
 		} );
 
 		it( 'requires a level to conform to a validate function, when provided', () => {
@@ -879,7 +873,7 @@ describe( 'WPRequest', () => {
 			};
 			expect( () => {
 				request.setPathPart( 0, 'foo' ).validatePath();
-			} ).to.throw( 'foo does not match (?P<id>[\\d]+)' );
+			} ).toThrow( 'foo does not match (?P<id>[\\d]+)' );
 		} );
 
 		it( 'allows any value for a level that passes a validate function, when provided', () => {
@@ -891,8 +885,8 @@ describe( 'WPRequest', () => {
 			};
 			expect( () => {
 				request.setPathPart( 0, '42' ).validatePath();
-			} ).not.to.throw();
-			expect( request.toString() ).to.equal( '/42' );
+			} ).not.toThrow();
+			expect( request.toString() ).toBe( '/42' );
 		} );
 
 		it( 'requires a level to conform to any of several validate functions when provided', () => {
@@ -910,7 +904,7 @@ describe( 'WPRequest', () => {
 			};
 			expect( () => {
 				request.setPathPart( 0, 'foo' ).validatePath();
-			} ).to.throw( 'foo does not match any of (?P<id>[\\d]+), posts, pages' );
+			} ).toThrow( 'foo does not match any of (?P<id>[\\d]+), posts, pages' );
 		} );
 
 		it( 'allows any value for a level that passes any of the available validate functions', () => {
@@ -928,8 +922,8 @@ describe( 'WPRequest', () => {
 			};
 			expect( () => {
 				request.setPathPart( 0, 'posts' ).validatePath();
-			} ).not.to.throw();
-			expect( request.toString() ).to.equal( '/posts' );
+			} ).not.toThrow();
+			expect( request.toString() ).toBe( '/posts' );
 		} );
 
 		it( 'catches missing path parts if _levels are specified', () => {
@@ -940,7 +934,7 @@ describe( 'WPRequest', () => {
 			};
 			expect( () => {
 				request.setPathPart( 1, 'revisions' ).validatePath();
-			} ).to.throw( 'Incomplete URL! Missing component: / ??? /revisions' );
+			} ).toThrow( 'Incomplete URL! Missing component: / ??? /revisions' );
 		} );
 
 	} );

--- a/tests/unit/lib/mixins/filters.js
+++ b/tests/unit/lib/mixins/filters.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const inherit = require( 'util' ).inherits;
 
@@ -34,45 +33,45 @@ describe( 'mixins: filter', () => {
 		} );
 
 		it( 'mixin method is defined', () => {
-			expect( filterMixins ).to.have.property( 'filter' );
+			expect( filterMixins ).toHaveProperty( 'filter' );
 		} );
 
 		it( 'is a function', () => {
-			expect( filterMixins.filter ).to.be.a( 'function' );
+			expect( typeof filterMixins.filter ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.filter() ).to.equal( req );
+			expect( req.filter() ).toBe( req );
 		} );
 
 		it( 'will nave no effect if called with no filter value', () => {
 			const result = req.filter( 'a' );
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'sets the filter query parameter on a request instance', () => {
 			const result = req.filter( 'a', 'b' );
-			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b' );
+			expect( getQueryStr( result ) ).toBe( 'filter[a]=b' );
 		} );
 
 		it( 'can set multiple filters on the request', () => {
 			const result = req.filter( 'a', 'b' ).filter( 'c', 'd' );
-			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b&filter[c]=d' );
+			expect( getQueryStr( result ) ).toBe( 'filter[a]=b&filter[c]=d' );
 		} );
 
 		it( 'will overwrite previously-set filter values', () => {
 			const result = req.filter( 'a', 'b' ).filter( 'a', 'd' );
-			expect( getQueryStr( result ) ).to.equal( 'filter[a]=d' );
+			expect( getQueryStr( result ) ).toBe( 'filter[a]=d' );
 		} );
 
 		it( 'will unset a filter if called with an empty string', () => {
 			const result = req.filter( 'a', 'b' ).filter( 'a', '' );
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'will unset a filter if called with null', () => {
 			const result = req.filter( 'a', 'b' ).filter( 'a', null );
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'can set multiple filters in one call when passed an object', () => {
@@ -81,7 +80,7 @@ describe( 'mixins: filter', () => {
 				c: 'd',
 				e: 'f',
 			} );
-			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b&filter[c]=d&filter[e]=f' );
+			expect( getQueryStr( result ) ).toBe( 'filter[a]=b&filter[c]=d&filter[e]=f' );
 		} );
 
 		it( 'can set multiple filters on the request when passed an object', () => {
@@ -93,7 +92,7 @@ describe( 'mixins: filter', () => {
 				.filter( {
 					e: 'f',
 				} );
-			expect( getQueryStr( result ) ).to.equal( 'filter[a]=b&filter[c]=d&filter[e]=f' );
+			expect( getQueryStr( result ) ).toBe( 'filter[a]=b&filter[c]=d&filter[e]=f' );
 		} );
 
 		it( 'will overwrite multiple previously-set filter values when passed an object', () => {
@@ -108,7 +107,7 @@ describe( 'mixins: filter', () => {
 					c: 'h',
 					i: 'j',
 				} );
-			expect( getQueryStr( result ) ).to.equal( 'filter[a]=g&filter[c]=h&filter[e]=f&filter[i]=j' );
+			expect( getQueryStr( result ) ).toBe( 'filter[a]=g&filter[c]=h&filter[e]=f&filter[i]=j' );
 		} );
 
 	} );
@@ -120,64 +119,64 @@ describe( 'mixins: filter', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( filterMixins ).to.have.property( 'taxonomy' );
+			expect( filterMixins ).toHaveProperty( 'taxonomy' );
 		} );
 
 		it( 'is a function', () => {
-			expect( filterMixins.taxonomy ).to.be.a( 'function' );
+			expect( typeof filterMixins.taxonomy ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.taxonomy( 'tag', 'foo' ) ).to.equal( req );
+			expect( req.taxonomy( 'tag', 'foo' ) ).toBe( req );
 		} );
 
 		describe( 'argument type check errors', () => {
 
 			it( 'errors if no term is provided', () => {
-				expect( () => { req.taxonomy( 'tag' ); } ).to.throw();
+				expect( () => { req.taxonomy( 'tag' ); } ).toThrow();
 			} );
 
 			it( 'does not error if the term is a string', () => {
-				expect( () => { req.taxonomy( 'tag', 'cat' ); } ).not.to.throw();
+				expect( () => { req.taxonomy( 'tag', 'cat' ); } ).not.toThrow();
 			} );
 
 			it( 'does not error if the term is an array of strings', () => {
-				expect( () => { req.taxonomy( 'tag', [ 'cat', 'dog' ] ); } ).not.to.throw();
+				expect( () => { req.taxonomy( 'tag', [ 'cat', 'dog' ] ); } ).not.toThrow();
 			} );
 
 			it( 'does not error if term is a number', () => {
-				expect( () => { req.taxonomy( 'cat', 7 ); } ).not.to.throw();
+				expect( () => { req.taxonomy( 'cat', 7 ); } ).not.toThrow();
 			} );
 
 			it( 'does not error if term is an array of numbers', () => {
-				expect( () => { req.taxonomy( 'cat', [ 7, 11 ] ); } ).not.to.throw();
+				expect( () => { req.taxonomy( 'cat', [ 7, 11 ] ); } ).not.toThrow();
 			} );
 
 			it( 'errors if the term is null', () => {
-				expect( () => { req.taxonomy( 'tag', null ); } ).to.throw();
+				expect( () => { req.taxonomy( 'tag', null ); } ).toThrow();
 			} );
 
 			it( 'errors if the term is a boolean', () => {
-				expect( () => { req.taxonomy( 'tag', true ); } ).to.throw();
-				expect( () => { req.taxonomy( 'tag', false ); } ).to.throw();
+				expect( () => { req.taxonomy( 'tag', true ); } ).toThrow();
+				expect( () => { req.taxonomy( 'tag', false ); } ).toThrow();
 			} );
 
 			it( 'errors if the term is a Date', () => {
-				expect( () => { req.taxonomy( 'tag', new Date() ); } ).to.throw();
+				expect( () => { req.taxonomy( 'tag', new Date() ); } ).toThrow();
 			} );
 
 			it( 'errors if the term is an object', () => {
-				expect( () => { req.taxonomy( 'tag', {} ); } ).to.throw();
+				expect( () => { req.taxonomy( 'tag', {} ); } ).toThrow();
 			} );
 
 			it( 'errors if the term is an array of types other than strings or numbers', () => {
-				expect( () => { req.taxonomy( 'tag', [ null ] ); } ).to.throw();
+				expect( () => { req.taxonomy( 'tag', [ null ] ); } ).toThrow();
 			} );
 
 			it( 'errors if the term is not all strings or numbers', () => {
-				expect( () => { req.taxonomy( 'tag', [ 'cat', null ] ); } ).to.throw();
-				expect( () => { req.taxonomy( 'cat', [ 7, null ] ); } ).to.throw();
-				expect( () => { req.taxonomy( 'cat', [ 'foo', 7 ] ); } ).to.throw();
+				expect( () => { req.taxonomy( 'tag', [ 'cat', null ] ); } ).toThrow();
+				expect( () => { req.taxonomy( 'cat', [ 7, null ] ); } ).toThrow();
+				expect( () => { req.taxonomy( 'cat', [ 'foo', 7 ] ); } ).toThrow();
 			} );
 
 		} );
@@ -186,17 +185,17 @@ describe( 'mixins: filter', () => {
 
 			it( 'sets the "category_name" filter for categories where the term is a string', () => {
 				const result = req.taxonomy( 'category', 'str' );
-				expect( getQueryStr( result ) ).to.equal( 'filter[category_name]=str' );
+				expect( getQueryStr( result ) ).toBe( 'filter[category_name]=str' );
 			} );
 
 			it( 'sets the "cat" filter for categories where the term is a number', () => {
 				const result = req.taxonomy( 'category', 7 );
-				expect( getQueryStr( result ) ).to.equal( 'filter[cat]=7' );
+				expect( getQueryStr( result ) ).toBe( 'filter[cat]=7' );
 			} );
 
 			it( 'sets the "tag" filter if the taxonomy is "post_tag"', () => {
 				const result = req.taxonomy( 'post_tag', 'sometag' );
-				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=sometag' );
+				expect( getQueryStr( result ) ).toBe( 'filter[tag]=sometag' );
 			} );
 
 		} );
@@ -205,7 +204,7 @@ describe( 'mixins: filter', () => {
 
 			it( 'de-duplicates taxonomy terms (will only set a term once)', () => {
 				const result = req.taxonomy( 'tag', 'cat' ).taxonomy( 'tag', 'cat' );
-				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=cat' );
+				expect( getQueryStr( result ) ).toBe( 'filter[tag]=cat' );
 			} );
 
 			it( 'de-dupes the taxonomy list when called with an array', () => {
@@ -217,7 +216,7 @@ describe( 'mixins: filter', () => {
 					'lorde',
 					'clean-bandit',
 				] );
-				expect( req._taxonomyFilters ).to.deep.equal( {
+				expect( req._taxonomyFilters ).toEqual( {
 					tag: [ 'alunageorge', 'clean-bandit', 'disclosure', 'lorde' ],
 				} );
 			} );
@@ -225,24 +224,24 @@ describe( 'mixins: filter', () => {
 			it( 'supports setting an array of string terms', () => {
 				// TODO: Multiple terms may be deprecated by API!
 				const result = req.taxonomy( 'tag', [ 'a', 'b' ] );
-				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=a+b' );
+				expect( getQueryStr( result ) ).toBe( 'filter[tag]=a+b' );
 			} );
 
 			it( 'supports setting an array of numeric terms', () => {
 				// TODO: Multiple terms may be deprecated by API!
 				const result = req.taxonomy( 'tag', [ 1, 2 ] );
-				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=1+2' );
+				expect( getQueryStr( result ) ).toBe( 'filter[tag]=1+2' );
 			} );
 
 			it( 'does not overwrite previously-specified terms on subsequent calls', () => {
 				// TODO: Multiple terms may be deprecated by API!
 				const result = req.taxonomy( 'tag', 'a' ).taxonomy( 'tag', [ 'b' ] );
-				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=a+b' );
+				expect( getQueryStr( result ) ).toBe( 'filter[tag]=a+b' );
 			} );
 
 			it( 'sorts provided terms', () => {
 				const result = req.taxonomy( 'tag', 'z' ).taxonomy( 'tag', 'a' );
-				expect( getQueryStr( result ) ).to.equal( 'filter[tag]=a+z' );
+				expect( getQueryStr( result ) ).toBe( 'filter[tag]=a+z' );
 			} );
 
 		} );
@@ -256,20 +255,20 @@ describe( 'mixins: filter', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( filterMixins ).to.have.property( 'path' );
+			expect( filterMixins ).toHaveProperty( 'path' );
 		} );
 
 		it( 'is a function', () => {
-			expect( filterMixins.path ).to.be.a( 'function' );
+			expect( typeof filterMixins.path ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.path( 'tag', 'foo' ) ).to.equal( req );
+			expect( req.path( 'tag', 'foo' ) ).toBe( req );
 		} );
 
 		it( 'should create the URL for retrieving a post by path', () => {
 			const path = req.path( 'nested/page' );
-			expect( getQueryStr( path ) ).to.equal( 'filter[pagename]=nested/page' );
+			expect( getQueryStr( path ) ).toBe( 'filter[pagename]=nested/page' );
 		} );
 
 	} );
@@ -285,27 +284,27 @@ describe( 'mixins: filter', () => {
 			} );
 
 			it( 'mixin is defined', () => {
-				expect( filterMixins ).to.have.property( 'year' );
+				expect( filterMixins ).toHaveProperty( 'year' );
 			} );
 
 			it( 'is a function', () => {
-				expect( filterMixins.year ).to.be.a( 'function' );
+				expect( typeof filterMixins.year ).toBe( 'function' );
 			} );
 
 			it( 'supports chaining', () => {
-				expect( req.year( 'foo' ) ).to.equal( req );
+				expect( req.year( 'foo' ) ).toBe( req );
 			} );
 
 			it( 'is an alias for .filter( "year", ... )', () => {
 				Req.prototype.filter = filterMixins.filter;
 				const result1 = ( new Req() ).year( '2015' );
 				const result2 = ( new Req() ).filter( 'year', '2015' );
-				expect( getQueryStr( result1 ) ).to.equal( getQueryStr( result2 ) );
+				expect( getQueryStr( result1 ) ).toBe( getQueryStr( result2 ) );
 			} );
 
 			it( 'sets the "year" filter', () => {
 				const result = req.year( 'str' );
-				expect( getQueryStr( result ) ).to.equal( 'filter[year]=str' );
+				expect( getQueryStr( result ) ).toBe( 'filter[year]=str' );
 			} );
 
 		} );
@@ -319,42 +318,42 @@ describe( 'mixins: filter', () => {
 			} );
 
 			it( 'mixin is defined', () => {
-				expect( filterMixins ).to.have.property( 'month' );
+				expect( filterMixins ).toHaveProperty( 'month' );
 			} );
 
 			it( 'is a function', () => {
-				expect( filterMixins.month ).to.be.a( 'function' );
+				expect( typeof filterMixins.month ).toBe( 'function' );
 			} );
 
 			it( 'supports chaining', () => {
-				expect( req.month( 'foo' ) ).to.equal( req );
+				expect( req.month( 'foo' ) ).toBe( req );
 			} );
 
 			it( 'is an alias for .filter( "monthnum", ... )', () => {
 				Req.prototype.filter = filterMixins.filter;
 				const result1 = ( new Req() ).month( 7 );
 				const result2 = ( new Req() ).filter( 'monthnum', 7 );
-				expect( getQueryStr( result1 ) ).to.equal( getQueryStr( result2 ) );
+				expect( getQueryStr( result1 ) ).toBe( getQueryStr( result2 ) );
 			} );
 
 			it( 'sets the "monthnum" filter', () => {
 				const result = req.month( 1 );
-				expect( getQueryStr( result ) ).to.equal( 'filter[monthnum]=1' );
+				expect( getQueryStr( result ) ).toBe( 'filter[monthnum]=1' );
 			} );
 
 			it( 'converts named months into their numeric monthnum equivalent', () => {
 				const result = req.month( 'March' );
-				expect( getQueryStr( result ) ).to.equal( 'filter[monthnum]=3' );
+				expect( getQueryStr( result ) ).toBe( 'filter[monthnum]=3' );
 			} );
 
 			it( 'returns without setting any filter if an invalid month string is provided', () => {
 				const result = req.month( 'Not a month' ).toString();
-				expect( result.match( /filter/ ) ).to.equal( null );
+				expect( result.match( /filter/ ) ).toBe( null );
 			} );
 
 			it( 'returns without setting any filter if an invalid argument is provided', () => {
 				const result = req.month( [ 'arrrr', 'i', 'be', 'an', 'array!' ] ).toString();
-				expect( result.match( /filter/ ) ).to.equal( null );
+				expect( result.match( /filter/ ) ).toBe( null );
 			} );
 
 		} );
@@ -368,27 +367,27 @@ describe( 'mixins: filter', () => {
 			} );
 
 			it( 'mixin is defined', () => {
-				expect( filterMixins ).to.have.property( 'day' );
+				expect( filterMixins ).toHaveProperty( 'day' );
 			} );
 
 			it( 'is a function', () => {
-				expect( filterMixins.day ).to.be.a( 'function' );
+				expect( typeof filterMixins.day ).toBe( 'function' );
 			} );
 
 			it( 'supports chaining', () => {
-				expect( req.day( 'foo' ) ).to.equal( req );
+				expect( req.day( 'foo' ) ).toBe( req );
 			} );
 
 			it( 'is an alias for .filter( "day", ... )', () => {
 				Req.prototype.filter = filterMixins.filter;
 				const result1 = ( new Req() ).day( '2015' );
 				const result2 = ( new Req() ).filter( 'day', '2015' );
-				expect( getQueryStr( result1 ) ).to.equal( getQueryStr( result2 ) );
+				expect( getQueryStr( result1 ) ).toBe( getQueryStr( result2 ) );
 			} );
 
 			it( 'sets the "day" filter', () => {
 				const result = req.day( 'str' );
-				expect( getQueryStr( result ) ).to.equal( 'filter[day]=str' );
+				expect( getQueryStr( result ) ).toBe( 'filter[day]=str' );
 			} );
 
 		} );

--- a/tests/unit/lib/mixins/parameters.js
+++ b/tests/unit/lib/mixins/parameters.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const inherit = require( 'util' ).inherits;
 
@@ -36,33 +35,33 @@ describe( 'mixins: parameters', () => {
 			} );
 
 			it( 'mixin method is defined', () => {
-				expect( parameterMixins ).to.have.property( 'before' );
+				expect( parameterMixins ).toHaveProperty( 'before' );
 			} );
 
 			it( 'is a function', () => {
-				expect( parameterMixins.before ).to.be.a( 'function' );
+				expect( typeof parameterMixins.before ).toBe( 'function' );
 			} );
 
 			it( 'supports chaining', () => {
-				expect( req.before( '1933-11-01' ) ).to.equal( req );
+				expect( req.before( '1933-11-01' ) ).toBe( req );
 			} );
 
 			it( 'throws an error when called with a missing or invalid time', () => {
 				expect( () => {
 					req.before();
-				} ).to.throw( 'Invalid time value' );
+				} ).toThrow( 'Invalid time value' );
 			} );
 
 			it( 'sets the "before" query parameter as an ISO 8601 Date', () => {
 				const result = req.before( '2016-07-01' );
-				expect( getQueryStr( result ) ).to.equal( 'before=2016-07-01T00:00:00.000Z' );
+				expect( getQueryStr( result ) ).toBe( 'before=2016-07-01T00:00:00.000Z' );
 			} );
 
 			it( 'sets the "before" query parameter when provided a Date object', () => {
 				const date = new Date( 1986, 2, 22 );
 				const result = req.before( date );
 				// use .match and regex to avoid time zone-induced false negatives
-				expect( getQueryStr( result ) ).to.match( /^before=1986-03-22T\d{2}:\d{2}:\d{2}.\d{3}Z$/ );
+				expect( getQueryStr( result ) ).toMatch( /^before=1986-03-22T\d{2}:\d{2}:\d{2}.\d{3}Z$/ );
 			} );
 
 		} );
@@ -74,33 +73,33 @@ describe( 'mixins: parameters', () => {
 			} );
 
 			it( 'mixin method is defined', () => {
-				expect( parameterMixins ).to.have.property( 'after' );
+				expect( parameterMixins ).toHaveProperty( 'after' );
 			} );
 
 			it( 'is a function', () => {
-				expect( parameterMixins.after ).to.be.a( 'function' );
+				expect( typeof parameterMixins.after ).toBe( 'function' );
 			} );
 
 			it( 'supports chaining', () => {
-				expect( req.after( '1992-04-22' ) ).to.equal( req );
+				expect( req.after( '1992-04-22' ) ).toBe( req );
 			} );
 
 			it( 'throws an error when called with a missing or invalid time', () => {
 				expect( () => {
 					req.after();
-				} ).to.throw( 'Invalid time value' );
+				} ).toThrow( 'Invalid time value' );
 			} );
 
 			it( 'sets the "after" query parameter when provided a value', () => {
 				const result = req.after( '2016-03-22' );
-				expect( getQueryStr( result ) ).to.equal( 'after=2016-03-22T00:00:00.000Z' );
+				expect( getQueryStr( result ) ).toBe( 'after=2016-03-22T00:00:00.000Z' );
 			} );
 
 			it( 'sets the "after" query parameter when provided a Date object', () => {
 				const date = new Date( 1987, 11, 7 );
 				const result = req.after( date );
 				// use .match and regex to avoid time zone-induced false negatives
-				expect( getQueryStr( result ) ).to.match( /^after=1987-12-07T\d{2}:\d{2}:\d{2}.\d{3}Z$/ );
+				expect( getQueryStr( result ) ).toMatch( /^after=1987-12-07T\d{2}:\d{2}:\d{2}.\d{3}Z$/ );
 			} );
 
 		} );
@@ -114,65 +113,65 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin method is defined', () => {
-			expect( parameterMixins ).to.have.property( 'author' );
+			expect( parameterMixins ).toHaveProperty( 'author' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.author ).to.be.a( 'function' );
+			expect( typeof parameterMixins.author ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.author( 1 ) ).to.equal( req );
+			expect( req.author( 1 ) ).toBe( req );
 		} );
 
 		it( 'has no effect when called with no argument', () => {
 			const result = req.author();
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'throws an error when called with a non-string, non-numeric value', () => {
-			expect( () => { req.author( {} ); } ).to.throw();
+			expect( () => { req.author( {} ); } ).toThrow();
 		} );
 
 		it( 'sets the "author" query parameter when provided a numeric value', () => {
 			const result = req.author( 1138 );
-			expect( getQueryStr( result ) ).to.equal( 'author=1138' );
+			expect( getQueryStr( result ) ).toBe( 'author=1138' );
 		} );
 
 		it( 'sets the "author_name" filter when provided a string value', () => {
 			const result = req.author( 'jamesagarfield' );
-			expect( getQueryStr( result ) ).to.equal( 'filter[author_name]=jamesagarfield' );
+			expect( getQueryStr( result ) ).toBe( 'filter[author_name]=jamesagarfield' );
 		} );
 
 		it( 'is chainable, and replaces author_name values on subsequent calls', () => {
 			const result = req.author( 'fforde' ).author( 'bronte' );
-			expect( result ).to.equal( req );
-			expect( getQueryStr( result ) ).to.equal( 'filter[author_name]=bronte' );
+			expect( result ).toBe( req );
+			expect( getQueryStr( result ) ).toBe( 'filter[author_name]=bronte' );
 		} );
 
 		it( 'is chainable, and replaces author ID values on subsequent calls', () => {
 			const result = req.author( 1847 );
-			expect( getQueryStr( result ) ).to.equal( 'author=1847' );
+			expect( getQueryStr( result ) ).toBe( 'author=1847' );
 		} );
 
 		it( 'unsets author when called with an empty string', () => {
 			const result = req.author( 'jorge-luis-borges' ).author( '' );
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'unsets author when called with null', () => {
 			const result = req.author( 7 ).author( null );
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'unsets author parameter when called with author name string', () => {
 			const result = req.author( 7 ).author( 'haruki-murakami' );
-			expect( getQueryStr( result ) ).to.equal( 'filter[author_name]=haruki-murakami' );
+			expect( getQueryStr( result ) ).toBe( 'filter[author_name]=haruki-murakami' );
 		} );
 
 		it( 'unsets author name filter when called with numeric author id', () => {
 			const result = req.author( 'haruki-murakami' ).author( 7 );
-			expect( getQueryStr( result ) ).to.equal( 'author=7' );
+			expect( getQueryStr( result ) ).toBe( 'author=7' );
 		} );
 
 	} );
@@ -184,35 +183,35 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin method is defined', () => {
-			expect( parameterMixins ).to.have.property( 'parent' );
+			expect( parameterMixins ).toHaveProperty( 'parent' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.parent ).to.be.a( 'function' );
+			expect( typeof parameterMixins.parent ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.parent() ).to.equal( req );
+			expect( req.parent() ).toBe( req );
 		} );
 
 		it( 'has no effect when called with no argument', () => {
 			const result = req.parent();
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'sets the "parent" query parameter when provided a value', () => {
 			const result = req.parent( 42 );
-			expect( getQueryStr( result ) ).to.equal( 'parent=42' );
+			expect( getQueryStr( result ) ).toBe( 'parent=42' );
 		} );
 
 		it( 'replaces values on subsequent calls', () => {
 			const result = req.parent( 42 ).parent( 2501 );
-			expect( getQueryStr( result ) ).to.equal( 'parent=2501' );
+			expect( getQueryStr( result ) ).toBe( 'parent=2501' );
 		} );
 
 		it( 'can pass an array of parent values', () => {
 			const result = req.parent( [ 42, 2501 ] );
-			expect( getQueryStr( result ) ).to.equal( 'parent[]=2501&parent[]=42' );
+			expect( getQueryStr( result ) ).toBe( 'parent[]=2501&parent[]=42' );
 		} );
 
 	} );
@@ -224,30 +223,30 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin method is defined', () => {
-			expect( parameterMixins ).to.have.property( 'post' );
+			expect( parameterMixins ).toHaveProperty( 'post' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.post ).to.be.a( 'function' );
+			expect( typeof parameterMixins.post ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.post() ).to.equal( req );
+			expect( req.post() ).toBe( req );
 		} );
 
 		it( 'has no effect when called with no argument', () => {
 			const result = req.post();
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'sets the "post" query parameter when provided a value', () => {
 			const result = req.post( 3263827 );
-			expect( getQueryStr( result ) ).to.equal( 'post=3263827' );
+			expect( getQueryStr( result ) ).toBe( 'post=3263827' );
 		} );
 
 		it( 'overwrites previously-set values on subsequent calls', () => {
 			const result = req.post( 1138 ).post( 2501 );
-			expect( getQueryStr( result ) ).to.equal( 'post=2501' );
+			expect( getQueryStr( result ) ).toBe( 'post=2501' );
 		} );
 
 	} );
@@ -259,30 +258,30 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin method is defined', () => {
-			expect( parameterMixins ).to.have.property( 'password' );
+			expect( parameterMixins ).toHaveProperty( 'password' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.password ).to.be.a( 'function' );
+			expect( typeof parameterMixins.password ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.password() ).to.equal( req );
+			expect( req.password() ).toBe( req );
 		} );
 
 		it( 'has no effect when called with no argument', () => {
 			const result = req.password();
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'sets the "password" query parameter when provided a value', () => {
 			const result = req.password( 'correct horse battery staple' );
-			expect( getQueryStr( result ) ).to.equal( 'password=correct horse battery staple' );
+			expect( getQueryStr( result ) ).toBe( 'password=correct horse battery staple' );
 		} );
 
 		it( 'overwrites previously-set values on subsequent calls', () => {
 			const result = req.password( 'correct horse' ).password( 'battery staple' );
-			expect( getQueryStr( result ) ).to.equal( 'password=battery staple' );
+			expect( getQueryStr( result ) ).toBe( 'password=battery staple' );
 		} );
 
 	} );
@@ -294,25 +293,25 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin method is defined', () => {
-			expect( parameterMixins ).to.have.property( 'status' );
+			expect( parameterMixins ).toHaveProperty( 'status' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.status ).to.be.a( 'function' );
+			expect( typeof parameterMixins.status ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.status( 'publish' ) ).to.equal( req );
+			expect( req.status( 'publish' ) ).toBe( req );
 		} );
 
 		it( 'sets the "status" query parameter when provided a value', () => {
 			const result = req.status( 'future' );
-			expect( getQueryStr( result ) ).to.equal( 'status=future' );
+			expect( getQueryStr( result ) ).toBe( 'status=future' );
 		} );
 
 		it( 'sets an array of "status" query values when provided an array of strings', () => {
 			const result = req.status( [ 'future', 'draft' ] );
-			expect( getQueryStr( result ) ).to.equal( 'status[]=draft&status[]=future' );
+			expect( getQueryStr( result ) ).toBe( 'status[]=draft&status[]=future' );
 		} );
 
 	} );
@@ -324,30 +323,30 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin method is defined', () => {
-			expect( parameterMixins ).to.have.property( 'sticky' );
+			expect( parameterMixins ).toHaveProperty( 'sticky' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.sticky ).to.be.a( 'function' );
+			expect( typeof parameterMixins.sticky ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.sticky() ).to.equal( req );
+			expect( req.sticky() ).toBe( req );
 		} );
 
 		it( 'has no effect when called with no argument', () => {
 			const result = req.sticky();
-			expect( getQueryStr( result ) ).to.equal( '' );
+			expect( getQueryStr( result ) ).toBe( '' );
 		} );
 
 		it( 'sets the "sticky" query parameter when provided a value', () => {
 			const result = req.sticky( true );
-			expect( getQueryStr( result ) ).to.equal( 'sticky=true' );
+			expect( getQueryStr( result ) ).toBe( 'sticky=true' );
 		} );
 
 		it( 'overwrites previously-set values on subsequent calls', () => {
 			const result = req.sticky( 1 ).sticky( 0 );
-			expect( getQueryStr( result ) ).to.equal( 'sticky=0' );
+			expect( getQueryStr( result ) ).toBe( 'sticky=0' );
 		} );
 
 	} );
@@ -359,25 +358,25 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( parameterMixins ).to.have.property( 'categories' );
+			expect( parameterMixins ).toHaveProperty( 'categories' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.categories ).to.be.a( 'function' );
+			expect( typeof parameterMixins.categories ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.categories( 7 ) ).to.equal( req );
+			expect( req.categories( 7 ) ).toBe( req );
 		} );
 
 		it( 'sets the "categories" parameter for a single category ID', () => {
 			const result = req.categories( 7 );
-			expect( getQueryStr( result ) ).to.equal( 'categories=7' );
+			expect( getQueryStr( result ) ).toBe( 'categories=7' );
 		} );
 
 		it( 'sets the "categories" parameter for multiple category IDs', () => {
 			const result = req.categories( [ 7, 13 ] );
-			expect( getQueryStr( result ) ).to.equal( 'categories[]=13&categories[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'categories[]=13&categories[]=7' );
 		} );
 
 	} );
@@ -389,30 +388,30 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( parameterMixins ).to.have.property( 'category' );
+			expect( parameterMixins ).toHaveProperty( 'category' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.category ).to.be.a( 'function' );
+			expect( typeof parameterMixins.category ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.category( 'foo' ) ).to.equal( req );
+			expect( req.category( 'foo' ) ).toBe( req );
 		} );
 
 		it( 'sets the "categories" parameter for a single category ID', () => {
 			const result = req.category( 7 );
-			expect( getQueryStr( result ) ).to.equal( 'categories=7' );
+			expect( getQueryStr( result ) ).toBe( 'categories=7' );
 		} );
 
 		it( 'sets the "categories" parameter for multiple category IDs', () => {
 			const result = req.category( [ 7, 13 ] );
-			expect( getQueryStr( result ) ).to.equal( 'categories[]=13&categories[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'categories[]=13&categories[]=7' );
 		} );
 
 		it( 'sets the "category_name" filter for categories where the term is a string [DEPRECATED]', () => {
 			const result = req.category( 'fiction' );
-			expect( getQueryStr( result ) ).to.equal( 'filter[category_name]=fiction' );
+			expect( getQueryStr( result ) ).toBe( 'filter[category_name]=fiction' );
 		} );
 
 	} );
@@ -424,25 +423,25 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( parameterMixins ).to.have.property( 'excludeCategories' );
+			expect( parameterMixins ).toHaveProperty( 'excludeCategories' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.excludeCategories ).to.be.a( 'function' );
+			expect( typeof parameterMixins.excludeCategories ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.excludeCategories( 7 ) ).to.equal( req );
+			expect( req.excludeCategories( 7 ) ).toBe( req );
 		} );
 
 		it( 'sets the "categories_exclude" parameter for a single category ID', () => {
 			const result = req.excludeCategories( 7 );
-			expect( getQueryStr( result ) ).to.equal( 'categories_exclude=7' );
+			expect( getQueryStr( result ) ).toBe( 'categories_exclude=7' );
 		} );
 
 		it( 'sets the "categories_exclude" parameter for multiple category IDs', () => {
 			const result = req.excludeCategories( [ 7, 13 ] );
-			expect( getQueryStr( result ) ).to.equal( 'categories_exclude[]=13&categories_exclude[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'categories_exclude[]=13&categories_exclude[]=7' );
 		} );
 
 	} );
@@ -454,30 +453,30 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( parameterMixins ).to.have.property( 'tags' );
+			expect( parameterMixins ).toHaveProperty( 'tags' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.tags ).to.be.a( 'function' );
+			expect( typeof parameterMixins.tags ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.tags( 7 ) ).to.equal( req );
+			expect( req.tags( 7 ) ).toBe( req );
 		} );
 
 		it( 'sets the "tags" parameter for a single category ID', () => {
 			const result = req.tags( 7 );
-			expect( getQueryStr( result ) ).to.equal( 'tags=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags=7' );
 		} );
 
 		it( 'sets the "tags" parameter for multiple category IDs', () => {
 			const result = req.tags( [ 7, 13 ] );
-			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags[]=13&tags[]=7' );
 		} );
 
 		it( 'sets the "tags" parameter for multiple category IDs provided as numeric strings', () => {
 			const result = req.tags( [ '7', '13' ] );
-			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags[]=13&tags[]=7' );
 		} );
 
 	} );
@@ -489,35 +488,35 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( parameterMixins ).to.have.property( 'tag' );
+			expect( parameterMixins ).toHaveProperty( 'tag' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.tag ).to.be.a( 'function' );
+			expect( typeof parameterMixins.tag ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.tag( 7 ) ).to.equal( req );
+			expect( req.tag( 7 ) ).toBe( req );
 		} );
 
 		it( 'sets the "tag" parameter for a single category ID', () => {
 			const result = req.tag( 7 );
-			expect( getQueryStr( result ) ).to.equal( 'tags=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags=7' );
 		} );
 
 		it( 'sets the "tags" parameter for multiple category IDs', () => {
 			const result = req.tag( [ 7, 13 ] );
-			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags[]=13&tags[]=7' );
 		} );
 
 		it( 'sets the "tags" parameter for multiple category IDs provided as numeric strings', () => {
 			const result = req.tag( [ '7', '13' ] );
-			expect( getQueryStr( result ) ).to.equal( 'tags[]=13&tags[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags[]=13&tags[]=7' );
 		} );
 
 		it( 'sets the "tag" filter when the term is a string [DEPRECATED]', () => {
 			const result = req.tag( 'bagpipe-techno' );
-			expect( getQueryStr( result ) ).to.equal( 'filter[tag]=bagpipe-techno' );
+			expect( getQueryStr( result ) ).toBe( 'filter[tag]=bagpipe-techno' );
 		} );
 
 	} );
@@ -529,30 +528,30 @@ describe( 'mixins: parameters', () => {
 		} );
 
 		it( 'mixin is defined', () => {
-			expect( parameterMixins ).to.have.property( 'excludeTags' );
+			expect( parameterMixins ).toHaveProperty( 'excludeTags' );
 		} );
 
 		it( 'is a function', () => {
-			expect( parameterMixins.excludeTags ).to.be.a( 'function' );
+			expect( typeof parameterMixins.excludeTags ).toBe( 'function' );
 		} );
 
 		it( 'supports chaining', () => {
-			expect( req.excludeTags( 7 ) ).to.equal( req );
+			expect( req.excludeTags( 7 ) ).toBe( req );
 		} );
 
 		it( 'sets the "tags_exclude" parameter for a single category ID', () => {
 			const result = req.excludeTags( 7 );
-			expect( getQueryStr( result ) ).to.equal( 'tags_exclude=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags_exclude=7' );
 		} );
 
 		it( 'sets the "tags_exclude" parameter for multiple category IDs', () => {
 			const result = req.excludeTags( [ 7, 13 ] );
-			expect( getQueryStr( result ) ).to.equal( 'tags_exclude[]=13&tags_exclude[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags_exclude[]=13&tags_exclude[]=7' );
 		} );
 
 		it( 'sets the "tags_exclude" parameter for multiple category IDs provided as numeric strings', () => {
 			const result = req.excludeTags( [ '7', '13' ] );
-			expect( getQueryStr( result ) ).to.equal( 'tags_exclude[]=13&tags_exclude[]=7' );
+			expect( getQueryStr( result ) ).toBe( 'tags_exclude[]=13&tags_exclude[]=7' );
 		} );
 
 	} );

--- a/tests/unit/lib/route-tree.js
+++ b/tests/unit/lib/route-tree.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const routeTree = require( '../../../lib/route-tree' );
 const defaultRoutes = require( '../../../lib/data/default-routes.json' );
@@ -15,21 +14,21 @@ describe( 'route-tree utility', () => {
 
 		it( 'returns an object keyed by API namespace', () => {
 			const keys = Object.keys( tree ).sort();
-			expect( keys.length ).to.equal( 2 );
-			expect( keys ).to.deep.equal( [ 'oembed/1.0', 'wp/v2' ] );
+			expect( keys.length ).toBe( 2 );
+			expect( keys ).toEqual( [ 'oembed/1.0', 'wp/v2' ] );
 		} );
 
 		it( 'includes objects for all default wp/v2 routes', () => {
 			const routes = Object.keys( tree[ 'wp/v2' ] ).sort();
-			expect( routes ).to.have.length( 11 );
-			expect( routes.join( ',' ) ).to
-				.equal( 'categories,comments,media,pages,posts,settings,statuses,tags,taxonomies,types,users' );
+			expect( routes.length ).toBe( 11 );
+			expect( routes.join( ',' ) )
+				.toBe( 'categories,comments,media,pages,posts,settings,statuses,tags,taxonomies,types,users' );
 		} );
 
 		it( 'includes objects for all default oembed/1.0 routes', () => {
 			const routes = Object.keys( tree[ 'oembed/1.0' ] ).sort();
-			expect( routes ).to.have.length( 1 );
-			expect( routes.join( ',' ) ).to.equal( 'embed' );
+			expect( routes.length ).toBe( 1 );
+			expect( routes.join( ',' ) ).toBe( 'embed' );
 		} );
 
 		// Inspect the .posts tree as a smoke test for whether parsing the API
@@ -42,14 +41,14 @@ describe( 'route-tree utility', () => {
 			} );
 
 			it( 'includes a ._getArgs property', () => {
-				expect( posts ).to.have.property( '_getArgs' );
-				expect( posts._getArgs ).to.be.an( 'object' );
+				expect( posts ).toHaveProperty( '_getArgs' );
+				expect( typeof posts._getArgs ).toBe( 'object' );
 			} );
 
 			it( '._getArgs specifies a list of supported parameters', () => {
-				expect( posts ).to.have.property( '_getArgs' );
-				expect( posts._getArgs ).to.be.an( 'object' );
-				expect( posts._getArgs ).to.deep.equal( {
+				expect( posts ).toHaveProperty( '_getArgs' );
+				expect( typeof posts._getArgs ).toBe( 'object' );
+				expect( posts._getArgs ).toEqual( {
 					context: {},
 					page: {},
 					per_page: {},
@@ -75,26 +74,26 @@ describe( 'route-tree utility', () => {
 			} );
 
 			it( 'includes a .posts property', () => {
-				expect( posts ).to.have.property( 'posts' );
-				expect( posts.posts ).to.be.an( 'object' );
+				expect( posts ).toHaveProperty( 'posts' );
+				expect( typeof posts.posts ).toBe( 'object' );
 			} );
 
 			// This is a decidedly incomplete smoke test...
 			// But if this fails, so will everything else!
 			it( '.posts defines the top level of a route tree', () => {
 				const routeTree = posts.posts;
-				expect( routeTree ).to.have.property( 'level' );
-				expect( routeTree.level ).to.equal( 0 );
-				expect( routeTree ).to.have.property( 'methods' );
-				expect( routeTree.methods.sort().join( '|' ) ).to.equal( 'get|head|post' );
-				expect( routeTree ).to.have.property( 'namedGroup' );
-				expect( routeTree.namedGroup ).to.equal( false );
-				expect( routeTree ).to.have.property( 'names' );
-				expect( routeTree.names ).to.deep.equal( [ 'posts' ] );
-				expect( routeTree ).to.have.property( 'validate' );
-				expect( routeTree.validate ).to.be.a( 'function' );
-				expect( routeTree ).to.have.property( 'children' );
-				expect( routeTree.children ).to.be.an( 'object' );
+				expect( routeTree ).toHaveProperty( 'level' );
+				expect( routeTree.level ).toBe( 0 );
+				expect( routeTree ).toHaveProperty( 'methods' );
+				expect( routeTree.methods.sort().join( '|' ) ).toBe( 'get|head|post' );
+				expect( routeTree ).toHaveProperty( 'namedGroup' );
+				expect( routeTree.namedGroup ).toBe( false );
+				expect( routeTree ).toHaveProperty( 'names' );
+				expect( routeTree.names ).toEqual( [ 'posts' ] );
+				expect( routeTree ).toHaveProperty( 'validate' );
+				expect( typeof routeTree.validate ).toBe( 'function' );
+				expect( routeTree ).toHaveProperty( 'children' );
+				expect( typeof routeTree.children ).toBe( 'object' );
 			} );
 
 		} );

--- a/tests/unit/lib/util/apply-mixin.js
+++ b/tests/unit/lib/util/apply-mixin.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const applyMixin = require( '../../../../lib/util/apply-mixin' );
 
@@ -11,17 +10,17 @@ describe( 'applyMixin utility', () => {
 	} );
 
 	it( 'is a function', () => {
-		expect( applyMixin ).to.be.a( 'function' );
+		expect( typeof applyMixin ).toBe( 'function' );
 	} );
 
 	it( 'returns nothing', () => {
-		expect( applyMixin() ).to.be.undefined;
+		expect( applyMixin() ).toBeUndefined();
 	} );
 
 	it( 'assigns a method to the provided object', () => {
 		const bar = () => {};
 		applyMixin( obj, 'foo', bar );
-		expect( obj ).to.deep.equal( {
+		expect( obj ).toEqual( {
 			foo: bar,
 		} );
 	} );
@@ -29,14 +28,14 @@ describe( 'applyMixin utility', () => {
 	it( 'does not mutate the object if the specified key exists already', () => {
 		obj.foo = 'bar';
 		applyMixin( obj, 'foo', () => {} );
-		expect( obj ).to.deep.equal( {
+		expect( obj ).toEqual( {
 			foo: 'bar',
 		} );
 	} );
 
 	it( 'does not mutate the object if third arg is not a function', () => {
 		applyMixin( obj, 'key', 'not a function' );
-		expect( obj ).to.deep.equal( {} );
+		expect( obj ).toEqual( {} );
 	} );
 
 } );

--- a/tests/unit/lib/util/argument-is-numeric.js
+++ b/tests/unit/lib/util/argument-is-numeric.js
@@ -1,64 +1,63 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const argumentIsNumeric = require( '../../../../lib/util/argument-is-numeric' );
 
 describe( 'argumentIsNumeric utility', () => {
 
 	it( 'is a function', () => {
-		expect( argumentIsNumeric ).to.be.a( 'function' );
+		expect( typeof argumentIsNumeric ).toBe( 'function' );
 	} );
 
 	it( 'returns true if provided an integer', () => {
 		const result = argumentIsNumeric( 7 );
-		expect( result ).to.equal( true );
+		expect( result ).toBe( true );
 	} );
 
 	it( 'returns true if provided an integer string', () => {
 		const result = argumentIsNumeric( '2501' );
-		expect( result ).to.equal( true );
+		expect( result ).toBe( true );
 	} );
 
 	it( 'returns true if provided an array of integers', () => {
 		const result = argumentIsNumeric( [ 1, 3, 5, 8, 13 ] );
-		expect( result ).to.equal( true );
+		expect( result ).toBe( true );
 	} );
 
 	it( 'returns true if provided an array of integer strings', () => {
 		const result = argumentIsNumeric( [ '1', '3', '5', '8', '13' ] );
-		expect( result ).to.equal( true );
+		expect( result ).toBe( true );
 	} );
 
 	it( 'returns true if provided a mixed array of integers and integer strings', () => {
 		const result = argumentIsNumeric( [ 1, '3', 5, '8', 13 ] );
-		expect( result ).to.equal( true );
+		expect( result ).toBe( true );
 	} );
 
 	it( 'returns false if provided a non-integer string', () => {
 		const result = argumentIsNumeric( 'WordPress' );
-		expect( result ).to.equal( false );
+		expect( result ).toBe( false );
 	} );
 
 	it( 'returns false if provided a non-integer numeric string value', () => {
 		const result = argumentIsNumeric( '3.14159' );
-		expect( result ).to.equal( false );
+		expect( result ).toBe( false );
 	} );
 
 	it( 'returns false if provided an array that contains any non-numeric string', () => {
 		const result = argumentIsNumeric( [ 1, 3, 5, 'Eight' ] );
-		expect( result ).to.equal( false );
+		expect( result ).toBe( false );
 	} );
 
 	it( 'returns false if provided an array of strings', () => {
 		const result = argumentIsNumeric( [ 'One', 'Three' ] );
-		expect( result ).to.equal( false );
+		expect( result ).toBe( false );
 	} );
 
 	it( 'returns false if provided a non-string, non-integer, non-array value', () => {
-		expect( argumentIsNumeric( {} ) ).to.equal( false );
-		expect( argumentIsNumeric( null ) ).to.equal( false );
-		expect( argumentIsNumeric( /foo/ ) ).to.equal( false );
-		expect( argumentIsNumeric( false ) ).to.equal( false );
+		expect( argumentIsNumeric( {} ) ).toBe( false );
+		expect( argumentIsNumeric( null ) ).toBe( false );
+		expect( argumentIsNumeric( /foo/ ) ).toBe( false );
+		expect( argumentIsNumeric( false ) ).toBe( false );
 	} );
 
 } );

--- a/tests/unit/lib/util/ensure.js
+++ b/tests/unit/lib/util/ensure.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const ensure = require( '../../../../lib/util/ensure' );
 
@@ -11,37 +10,37 @@ describe( 'ensure utility', () => {
 	} );
 
 	it( 'is defined', () => {
-		expect( ensure ).to.exist;
+		expect( ensure ).toBeDefined();
 	} );
 
 	it( 'is a function', () => {
-		expect( ensure ).to.be.a( 'function' );
+		expect( typeof ensure ).toBe( 'function' );
 	} );
 
 	it( 'sets a default property value on an object', () => {
-		expect( obj ).not.to.have.property( 'foo' );
+		expect( obj ).not.toHaveProperty( 'foo' );
 		ensure( obj, 'foo', 'bar' );
-		expect( obj ).to.have.property( 'foo' );
-		expect( obj.foo ).to.be.a( 'string' );
-		expect( obj.foo ).to.equal( 'bar' );
+		expect( obj ).toHaveProperty( 'foo' );
+		expect( typeof obj.foo ).toBe( 'string' );
+		expect( obj.foo ).toBe( 'bar' );
 	} );
 
 	it( 'will not overwrite an existing value on an object', () => {
 		obj.foo = 'baz';
-		expect( obj ).to.have.property( 'foo' );
+		expect( obj ).toHaveProperty( 'foo' );
 		ensure( obj, 'foo', 'bar' );
-		expect( obj ).to.have.property( 'foo' );
-		expect( obj.foo ).to.be.a( 'string' );
-		expect( obj.foo ).to.equal( 'baz' );
+		expect( obj ).toHaveProperty( 'foo' );
+		expect( typeof obj.foo ).toBe( 'string' );
+		expect( obj.foo ).toBe( 'baz' );
 	} );
 
 	it( 'will not overwrite a falsy value on an object', () => {
 		obj.foo = 0;
-		expect( obj ).to.have.property( 'foo' );
+		expect( obj ).toHaveProperty( 'foo' );
 		ensure( obj, 'foo', 'bar' );
-		expect( obj ).to.have.property( 'foo' );
-		expect( obj.foo ).to.be.a( 'number' );
-		expect( obj.foo ).to.equal( 0 );
+		expect( obj ).toHaveProperty( 'foo' );
+		expect( typeof obj.foo ).toBe( 'number' );
+		expect( obj.foo ).toBe( 0 );
 	} );
 
 } );

--- a/tests/unit/lib/util/is-empty-object.js
+++ b/tests/unit/lib/util/is-empty-object.js
@@ -1,55 +1,54 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const isEmptyObject = require( '../../../../lib/util/is-empty-object' );
 
 describe( 'isEmptyObject utility', () => {
 
 	it( 'is defined', () => {
-		expect( isEmptyObject ).to.exist;
+		expect( isEmptyObject ).toBeDefined();
 	} );
 
 	it( 'is a function', () => {
-		expect( isEmptyObject ).to.be.a( 'function' );
+		expect( typeof isEmptyObject ).toBe( 'function' );
 	} );
 
 	it( 'returns true if passed an empty object', () => {
-		expect( isEmptyObject( {} ) ).to.equal( true );
+		expect( isEmptyObject( {} ) ).toBe( true );
 	} );
 
 	it( 'returns true if passed a constructed object with no instance properties', () => {
 		function Ctor() {}
 		Ctor.prototype.prop = 'val';
-		expect( isEmptyObject( new Ctor() ) ).to.equal( true );
+		expect( isEmptyObject( new Ctor() ) ).toBe( true );
 	} );
 
 	it( 'returns false if passed an object with own properties', () => {
-		expect( isEmptyObject( { prop: 'value' } ) ).to.equal( false );
+		expect( isEmptyObject( { prop: 'value' } ) ).toBe( false );
 	} );
 
 	it( 'returns false if passed a constructed object with instance properties', () => {
 		function Ctor() {
 			this.prop = 'val';
 		}
-		expect( isEmptyObject( new Ctor() ) ).to.equal( false );
+		expect( isEmptyObject( new Ctor() ) ).toBe( false );
 	} );
 
 	it( 'returns false if passed a string', () => {
-		expect( isEmptyObject( '{}' ) ).to.equal( false );
+		expect( isEmptyObject( '{}' ) ).toBe( false );
 	} );
 
 	it( 'returns false if passed an empty array', () => {
-		expect( isEmptyObject( [] ) ).to.equal( false );
+		expect( isEmptyObject( [] ) ).toBe( false );
 	} );
 
 	it( 'returns false if passed a boolean', () => {
-		expect( isEmptyObject( true ) ).to.equal( false );
-		expect( isEmptyObject( false ) ).to.equal( false );
+		expect( isEmptyObject( true ) ).toBe( false );
+		expect( isEmptyObject( false ) ).toBe( false );
 	} );
 
 	it( 'returns false if passed a number', () => {
-		expect( isEmptyObject( 0 ) ).to.equal( false );
-		expect( isEmptyObject( 1337 ) ).to.equal( false );
+		expect( isEmptyObject( 0 ) ).toBe( false );
+		expect( isEmptyObject( 1337 ) ).toBe( false );
 	} );
 
 } );

--- a/tests/unit/lib/util/key-val-to-obj.js
+++ b/tests/unit/lib/util/key-val-to-obj.js
@@ -1,26 +1,25 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const keyValToObj = require( '../../../../lib/util/key-val-to-obj' );
 
 describe( 'keyValToObj utility', () => {
 
 	it( 'is defined', () => {
-		expect( keyValToObj ).to.exist;
+		expect( keyValToObj ).toBeDefined();
 	} );
 
 	it( 'is a function', () => {
-		expect( keyValToObj ).to.be.a( 'function' );
+		expect( typeof keyValToObj ).toBe( 'function' );
 	} );
 
 	it( 'returns an object', () => {
-		expect( keyValToObj() ).to.be.an( 'object' );
+		expect( typeof keyValToObj() ).toBe( 'object' );
 	} );
 
 	it( 'sets the specified value at the provided key on the returned object', () => {
 		const result = keyValToObj( 'propName', 123456 );
-		expect( result ).to.have.property( 'propName' );
-		expect( result ).to.deep.equal( {
+		expect( result ).toHaveProperty( 'propName' );
+		expect( result ).toEqual( {
 			propName: 123456,
 		} );
 	} );
@@ -28,9 +27,9 @@ describe( 'keyValToObj utility', () => {
 	it( 'can be used to set an array, and sets values by reference', () => {
 		const arr = [ 'mimsy', 'borogoves', 'outgrabe' ];
 		const result = keyValToObj( 'words', arr );
-		expect( result ).to.have.property( 'words' );
-		expect( result.words ).to.equal( arr );
-		expect( result ).to.deep.equal( {
+		expect( result ).toHaveProperty( 'words' );
+		expect( result.words ).toBe( arr );
+		expect( result ).toEqual( {
 			words: [ 'mimsy', 'borogoves', 'outgrabe' ],
 		} );
 	} );

--- a/tests/unit/lib/util/named-group-regexp.js
+++ b/tests/unit/lib/util/named-group-regexp.js
@@ -1,50 +1,49 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const namedGroupRE = require( '../../../../lib/util/named-group-regexp' ).namedGroupRE;
 
 describe( 'named PCRE group RegExp', () => {
 
 	it( 'is a regular expression', () => {
-		expect( namedGroupRE ).to.be.an.instanceof( RegExp );
+		expect( namedGroupRE ).toBeInstanceOf( RegExp );
 	} );
 
 	it( 'will not match an arbitrary string', () => {
 		const pathComponent = 'author';
 		const result = pathComponent.match( namedGroupRE );
-		expect( result ).to.be.null;
+		expect( result ).toBeNull();
 	} );
 
 	it( 'identifies the name and RE pattern for a PCRE named group', () => {
 		const pathComponent = '(?P<parent>[\\d]+)';
 		const result = pathComponent.match( namedGroupRE );
-		expect( result ).not.to.be.null;
-		expect( result[ 1 ] ).to.equal( 'parent' );
-		expect( result[ 2 ] ).to.equal( '[\\d]+' );
+		expect( result ).not.toBeNull();
+		expect( result[ 1 ] ).toBe( 'parent' );
+		expect( result[ 2 ] ).toBe( '[\\d]+' );
 	} );
 
 	it( 'identifies the name and RE pattern for another group', () => {
 		const pathComponent = '(?P<id>\\d+)';
 		const result = pathComponent.match( namedGroupRE );
-		expect( result ).not.to.be.null;
-		expect( result[ 1 ] ).to.equal( 'id' );
-		expect( result[ 2 ] ).to.equal( '\\d+' );
+		expect( result ).not.toBeNull();
+		expect( result[ 1 ] ).toBe( 'id' );
+		expect( result[ 2 ] ).toBe( '\\d+' );
 	} );
 
 	it( 'identifies RE patterns including forward slashes', () => {
 		const pathComponent = '(?P<plugin>[a-z\\/\\.\\-_]+)';
 		const result = pathComponent.match( namedGroupRE );
-		expect( result ).not.to.be.null;
-		expect( result[ 1 ] ).to.equal( 'plugin' );
-		expect( result[ 2 ] ).to.equal( '[a-z\\/\\.\\-_]+' );
+		expect( result ).not.toBeNull();
+		expect( result[ 1 ] ).toBe( 'plugin' );
+		expect( result[ 2 ] ).toBe( '[a-z\\/\\.\\-_]+' );
 	} );
 
 	it( 'will match an empty string if a "RE Pattern" if the pattern is omitted', () => {
 		const pathComponent = '(?P<id>)';
 		const result = pathComponent.match( namedGroupRE );
-		expect( result ).not.to.be.null;
-		expect( result[ 1 ] ).to.equal( 'id' );
-		expect( result[ 2 ] ).to.equal( '' );
+		expect( result ).not.toBeNull();
+		expect( result[ 1 ] ).toBe( 'id' );
+		expect( result[ 2 ] ).toBe( '' );
 	} );
 
 } );

--- a/tests/unit/lib/util/object-reduce.js
+++ b/tests/unit/lib/util/object-reduce.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 describe( 'Object reduction tools:', () => {
 	// Ensure parity with the relevant signature & functionality of lodash.reduce
@@ -17,15 +16,15 @@ describe( 'Object reduction tools:', () => {
 			const objectReduce = test.fn;
 
 			it( 'is defined', () => {
-				expect( objectReduce ).to.exist;
+				expect( objectReduce ).toBeDefined();
 			} );
 
 			it( 'is a function', () => {
-				expect( objectReduce ).to.be.a( 'function' );
+				expect( typeof objectReduce ).toBe( 'function' );
 			} );
 
 			it( 'resolves to the provided initial value if called on an empty object', () => {
-				expect( objectReduce( {}, () => {}, 'Sasquatch' ) ).to.equal( 'Sasquatch' );
+				expect( objectReduce( {}, () => {}, 'Sasquatch' ) ).toBe( 'Sasquatch' );
 			} );
 
 			it( 'can be used to reduce over an object', () => {
@@ -34,7 +33,7 @@ describe( 'Object reduction tools:', () => {
 					key2: 'val2',
 					key3: 'val3',
 				}, ( memo, val, key ) => memo + val + key, 'result:' );
-				expect( result ).to.equal( 'result:val1key1val2key2val3key3' );
+				expect( result ).toBe( 'result:val1key1val2key2val3key3' );
 			} );
 
 		} );

--- a/tests/unit/lib/util/parameter-setter.js
+++ b/tests/unit/lib/util/parameter-setter.js
@@ -1,8 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-const sinon = require( 'sinon' );
-chai.use( require( 'sinon-chai' ) );
-const expect = chai.expect;
 
 const paramSetter = require( '../../../../lib/util/parameter-setter' );
 
@@ -14,18 +10,18 @@ describe( 'parameterSetter utility', () => {
 	} );
 
 	it( 'is a function', () => {
-		expect( paramSetter ).to.be.a( 'function' );
+		expect( typeof paramSetter ).toBe( 'function' );
 	} );
 
 	it( 'returns a function', () => {
-		expect( paramSetter() ).to.be.a( 'function' );
+		expect( typeof paramSetter() ).toBe( 'function' );
 	} );
 
 	it( 'creates a setter that calls this.param()', () => {
-		obj.param = sinon.stub();
+		obj.param = jest.fn();
 		obj.setter = paramSetter( 'foo' );
 		obj.setter( 'bar' );
-		expect( obj.param ).to.have.been.calledWith( 'foo', 'bar' );
+		expect( obj.param ).toHaveBeenCalledWith( 'foo', 'bar' );
 	} );
 
 } );

--- a/tests/unit/lib/util/split-path.js
+++ b/tests/unit/lib/util/split-path.js
@@ -1,21 +1,20 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const splitPath = require( '../../../../lib/util/split-path' );
 
 describe( 'splitPath utility', () => {
 
 	it( 'is a function', () => {
-		expect( splitPath ).to.be.a( 'function' );
+		expect( typeof splitPath ).toBe( 'function' );
 	} );
 
 	it( 'splits a simple path on the "/" character', () => {
-		expect( splitPath( 'a/b/c/d' ) ).to.deep.equal( [ 'a', 'b', 'c', 'd' ] );
+		expect( splitPath( 'a/b/c/d' ) ).toEqual( [ 'a', 'b', 'c', 'd' ] );
 	} );
 
 	it( 'correctly splits a string containing named capture groups', () => {
 		const result = splitPath( '/posts/(?P<parent>[\\d]+)/revisions/(?P<id>[\\d]+)' );
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			'posts',
 			'(?P<parent>[\\d]+)',
 			'revisions',
@@ -25,7 +24,7 @@ describe( 'splitPath utility', () => {
 
 	it( 'correctly splits a string when a named group regex contains a "/"', () => {
 		const result = splitPath( '/plugin/(?P<plugin>[a-z\\/\\.\\-_]+)' );
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			'plugin',
 			'(?P<plugin>[a-z\\/\\.\\-_]+)',
 		] );
@@ -37,7 +36,7 @@ describe( 'splitPath utility', () => {
 		// common variants of path strings are split correctly avoids situations
 		// where an unexpected string format could cause an error.
 		const result = splitPath( '/users/market=(?P<market>[a-zA-Z0-9-]+)/lat=(?P<lat>[a-z0-9 .\\-]+)/long=(?P<long>[a-z0-9 .\\-]+)' );
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			'users',
 			'market=(?P<market>[a-zA-Z0-9-]+)',
 			'lat=(?P<lat>[a-z0-9 .\\-]+)',
@@ -47,7 +46,7 @@ describe( 'splitPath utility', () => {
 
 	it( 'correctly splits a string with this situation', () => {
 		const result = splitPath( '/plugin/(?P<plugin_slug>[^/]+)/committers/?' );
-		expect( result ).to.deep.equal( [
+		expect( result ).toEqual( [
 			'plugin',
 			'(?P<plugin_slug>[^/]+)',
 			'committers',

--- a/tests/unit/lib/wp-register-route.js
+++ b/tests/unit/lib/wp-register-route.js
@@ -1,6 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-const expect = chai.expect;
 
 const WPRequest = require( '../../../lib/constructors/wp-request' );
 const registerRoute = require( '../../../lib/wp-register-route' );
@@ -10,26 +8,26 @@ const mixins = require( '../../../lib/mixins' );
 describe( 'wp.registerRoute', () => {
 
 	it( 'is a function', () => {
-		expect( registerRoute ).to.be.a( 'function' );
+		expect( typeof registerRoute ).toBe( 'function' );
 	} );
 
 	it( 'returns a function', () => {
-		expect( registerRoute( 'a', 'b' ) ).to.be.a( 'function' );
+		expect( typeof registerRoute( 'a', 'b' ) ).toBe( 'function' );
 	} );
 
 	it( 'sets a Ctor property on the returned function', () => {
 		const result = registerRoute( 'a', 'b' );
-		expect( result ).to.have.property( 'Ctor' );
+		expect( result ).toHaveProperty( 'Ctor' );
 	} );
 
 	it( 'returns a factory that returns Ctor instances', () => {
 		const result = registerRoute( 'a', 'b' );
-		expect( result() ).to.be.an.instanceOf( result.Ctor );
+		expect( result() ).toBeInstanceOf( result.Ctor );
 	} );
 
 	it( 'returns a factory for an object which extends WPRequest', () => {
 		const result = registerRoute( 'a', 'b' );
-		expect( result() ).to.be.an.instanceOf( WPRequest );
+		expect( result() ).toBeInstanceOf( WPRequest );
 	} );
 
 	it( 'factory-generated handlers have all the expected WPRequest methods', () => {
@@ -38,14 +36,14 @@ describe( 'wp.registerRoute', () => {
 			endpoint: '/',
 		} );
 		// spot check
-		expect( handler.page ).to.be.a( 'function' );
-		expect( handler.perPage ).to.be.a( 'function' );
-		expect( handler.offset ).to.be.a( 'function' );
-		expect( handler.context ).to.be.a( 'function' );
-		expect( handler.include ).to.be.a( 'function' );
-		expect( handler.slug ).to.be.a( 'function' );
+		expect( typeof handler.page ).toBe( 'function' );
+		expect( typeof handler.perPage ).toBe( 'function' );
+		expect( typeof handler.offset ).toBe( 'function' );
+		expect( typeof handler.context ).toBe( 'function' );
+		expect( typeof handler.include ).toBe( 'function' );
+		expect( typeof handler.slug ).toBe( 'function' );
 		const result = handler.page( 7 ).perPage( 2 ).exclude( [ 42, 7 ] ).toString();
-		expect( result ).to.equal( '/a/b?exclude%5B%5D=42&exclude%5B%5D=7&page=7&per_page=2' );
+		expect( result ).toBe( '/a/b?exclude%5B%5D=42&exclude%5B%5D=7&page=7&per_page=2' );
 	} );
 
 	// custom route example for wp-api.org
@@ -60,25 +58,25 @@ describe( 'wp.registerRoute', () => {
 		} );
 
 		it( 'renders a route prefixed with the provided namespace', () => {
-			expect( handler.toString().match( /myplugin\/v1/ ) ).to.be.ok;
+			expect( handler.toString() ).toMatch( /myplugin\/v1/ );
 		} );
 
 		it( 'sets the /authors/ path part automatically', () => {
-			expect( handler.toString() ).to.equal( '/myplugin/v1/author' );
+			expect( handler.toString() ).toBe( '/myplugin/v1/author' );
 		} );
 
 		describe( '.id() method', () => {
 
 			it( 'is defined', () => {
-				expect( handler ).to.have.property( 'id' );
+				expect( handler ).toHaveProperty( 'id' );
 			} );
 
 			it( 'is a function', () => {
-				expect( handler.id ).to.be.a( 'function' );
+				expect( typeof handler.id ).toBe( 'function' );
 			} );
 
 			it( 'sets the ID component of the path', () => {
-				expect( handler.id( 3263827 ).toString() ).to.equal( '/myplugin/v1/author/3263827' );
+				expect( handler.id( 3263827 ).toString() ).toBe( '/myplugin/v1/author/3263827' );
 			} );
 
 		} );
@@ -93,9 +91,9 @@ describe( 'wp.registerRoute', () => {
 			const handler = factory( {
 				endpoint: '/',
 			} );
-			expect( handler ).to.have.property( 'plugin' );
-			expect( handler.plugin ).to.be.a( 'function' );
-			expect( handler.plugin( 'a/b_c' ).toString() ).to.equal( '/jetpack/v4/plugin/a/b_c' );
+			expect( handler ).toHaveProperty( 'plugin' );
+			expect( typeof handler.plugin ).toBe( 'function' );
+			expect( handler.plugin( 'a/b_c' ).toString() ).toBe( '/jetpack/v4/plugin/a/b_c' );
 		} );
 
 	} );
@@ -107,11 +105,11 @@ describe( 'wp.registerRoute', () => {
 			const handler = factory( {
 				endpoint: '/',
 			} );
-			expect( handler ).to.have.property( 'pluginSlug' );
-			expect( handler.pluginSlug ).to.be.a( 'function' );
-			expect( handler ).to.have.property( 'committers' );
-			expect( handler.committers ).to.be.a( 'function' );
-			expect( handler.pluginSlug( 'rest-api' ).committers().toString() ).to.equal( '/plugins/v1/plugin/rest-api/committers' );
+			expect( handler ).toHaveProperty( 'pluginSlug' );
+			expect( typeof handler.pluginSlug ).toBe( 'function' );
+			expect( handler ).toHaveProperty( 'committers' );
+			expect( typeof handler.committers ).toBe( 'function' );
+			expect( handler.pluginSlug( 'rest-api' ).committers().toString() ).toBe( '/plugins/v1/plugin/rest-api/committers' );
 		} );
 
 	} );
@@ -125,20 +123,20 @@ describe( 'wp.registerRoute', () => {
 					'mmw/v1',
 					'/users/market=(?P<market>[a-zA-Z0-9-]+)/lat=(?P<lat>[a-z0-9 .\\-]+)/long=(?P<long>[a-z0-9 .\\-]+)'
 				);
-			} ).not.to.throw();
+			} ).not.toThrow();
 			const handler = factory( {
 				endpoint: '/',
 			} );
-			expect( handler ).to.have.property( 'market' );
-			expect( handler.market ).to.be.a( 'function' );
-			expect( handler ).to.have.property( 'lat' );
-			expect( handler.lat ).to.be.a( 'function' );
-			expect( handler ).to.have.property( 'long' );
-			expect( handler.long ).to.be.a( 'function' );
+			expect( handler ).toHaveProperty( 'market' );
+			expect( typeof handler.market ).toBe( 'function' );
+			expect( handler ).toHaveProperty( 'lat' );
+			expect( typeof handler.lat ).toBe( 'function' );
+			expect( handler ).toHaveProperty( 'long' );
+			expect( typeof handler.long ).toBe( 'function' );
 			// This is not "correct", but this syntax is not supported: the purpose of this
 			// test is to ensure that the code executes without error
 			expect( handler.market( 'nz' ).lat( '40.9006 S' ).long( '174.8860 E' ).toString() )
-				.to.equal( '/mmw/v1/users/nz/40.9006 S/174.8860 E' );
+				.toBe( '/mmw/v1/users/nz/40.9006 S/174.8860 E' );
 		} );
 
 	} );
@@ -154,9 +152,9 @@ describe( 'wp.registerRoute', () => {
 		} );
 
 		it( 'camelCases the setter name', () => {
-			expect( handler ).not.to.have.property( 'snake_cased_path_setter' );
-			expect( handler ).to.have.property( 'snakeCasedPathSetter' );
-			expect( handler.snakeCasedPathSetter ).to.be.a( 'function' );
+			expect( handler ).not.toHaveProperty( 'snake_cased_path_setter' );
+			expect( handler ).toHaveProperty( 'snakeCasedPathSetter' );
+			expect( typeof handler.snakeCasedPathSetter ).toBe( 'function' );
 		} );
 
 	} );
@@ -172,9 +170,9 @@ describe( 'wp.registerRoute', () => {
 		} );
 
 		it( 'camelCases the setter name', () => {
-			expect( handler ).not.to.have.property( 'kebab-cased-path-setter' );
-			expect( handler ).to.have.property( 'kebabCasedPathSetter' );
-			expect( handler.kebabCasedPathSetter ).to.be.a( 'function' );
+			expect( handler ).not.toHaveProperty( 'kebab-cased-path-setter' );
+			expect( handler ).toHaveProperty( 'kebabCasedPathSetter' );
+			expect( typeof handler.kebabCasedPathSetter ).toBe( 'function' );
 		} );
 
 	} );
@@ -190,9 +188,9 @@ describe( 'wp.registerRoute', () => {
 		} );
 
 		it( 'does not mutate the setter name', () => {
-			expect( handler ).not.to.have.property( 'camelcasedpathsetter' );
-			expect( handler ).to.have.property( 'camelCasedPathSetter' );
-			expect( handler.camelCasedPathSetter ).to.be.a( 'function' );
+			expect( handler ).not.toHaveProperty( 'camelcasedpathsetter' );
+			expect( handler ).toHaveProperty( 'camelCasedPathSetter' );
+			expect( typeof handler.camelCasedPathSetter ).toBe( 'function' );
 		} );
 
 	} );
@@ -208,9 +206,9 @@ describe( 'wp.registerRoute', () => {
 		} );
 
 		it( 'does not overwrite preexisting methods', () => {
-			expect( handler.param ).to.equal( WPRequest.prototype.param );
-			expect( handler.param( 'foo', 'bar' ).toString() ).to.equal( '/ns/route?foo=bar' );
-			expect( handler.param( 'foo', 'bar' ).toString() ).not.to.equal( '/ns/route/foo' );
+			expect( handler.param ).toBe( WPRequest.prototype.param );
+			expect( handler.param( 'foo', 'bar' ).toString() ).toBe( '/ns/route?foo=bar' );
+			expect( handler.param( 'foo', 'bar' ).toString() ).not.toBe( '/ns/route/foo' );
 		} );
 
 	} );
@@ -228,15 +226,15 @@ describe( 'wp.registerRoute', () => {
 		describe( 'part1 method', () => {
 
 			it( 'is defined', () => {
-				expect( handler ).to.have.property( 'part1' );
+				expect( handler ).toHaveProperty( 'part1' );
 			} );
 
 			it( 'is a function', () => {
-				expect( handler.part1 ).to.be.a( 'function' );
+				expect( typeof handler.part1 ).toBe( 'function' );
 			} );
 
 			it( 'sets the part1 component of the path', () => {
-				expect( handler.part1( 12 ).toString() ).to.equal( '/ns/resource/12' );
+				expect( handler.part1( 12 ).toString() ).toBe( '/ns/resource/12' );
 			} );
 
 		} );
@@ -244,15 +242,15 @@ describe( 'wp.registerRoute', () => {
 		describe( 'part2 method', () => {
 
 			it( 'is defined', () => {
-				expect( handler ).to.have.property( 'part2' );
+				expect( handler ).toHaveProperty( 'part2' );
 			} );
 
 			it( 'is a function', () => {
-				expect( handler.part2 ).to.be.a( 'function' );
+				expect( typeof handler.part2 ).toBe( 'function' );
 			} );
 
 			it( 'sets the part2 component of the path', () => {
-				expect( handler.part1( 12 ).part2( 34 ).toString() ).to.equal( '/ns/resource/12/34' );
+				expect( handler.part1( 12 ).part2( 34 ).toString() ).toBe( '/ns/resource/12/34' );
 			} );
 
 		} );
@@ -269,10 +267,10 @@ describe( 'wp.registerRoute', () => {
 			handler = factory( {
 				endpoint: '/',
 			} );
-			expect( handler ).to.have.property( 'filter' );
-			expect( handler.filter ).to.equal( mixins.filter.filter );
-			expect( handler ).to.have.property( 'author' );
-			expect( handler.author ).to.equal( mixins.author.author );
+			expect( handler ).toHaveProperty( 'filter' );
+			expect( handler.filter ).toBe( mixins.filter.filter );
+			expect( handler ).toHaveProperty( 'author' );
+			expect( handler.author ).toBe( mixins.author.author );
 		} );
 
 		it( 'does nothing if non-string parameters are provided', () => {
@@ -280,15 +278,15 @@ describe( 'wp.registerRoute', () => {
 			const factory2 = registerRoute( 'a', 'b', {
 				params: [ null, () => {} ],
 			} );
-			expect( factory1 ).not.to.equal( factory2 );
-			expect( factory1.Ctor ).not.to.equal( factory2.Ctor );
+			expect( factory1 ).not.toBe( factory2 );
+			expect( factory1.Ctor ).not.toBe( factory2.Ctor );
 			const getPrototypeMethods = ( factoryFn ) => {
 				const proto = factoryFn.Ctor.prototype;
 				return Object.keys( proto ).filter( key => typeof proto[ key ] === 'function' );
 			};
 			const factory1PrototypeMethods = getPrototypeMethods( factory1 );
 			const factory2PrototypeMethods = getPrototypeMethods( factory2 );
-			expect( factory1PrototypeMethods ).to.deep.equal( factory2PrototypeMethods );
+			expect( factory1PrototypeMethods ).toEqual( factory2PrototypeMethods );
 		} );
 
 		it( 'creates a .param() wrapper for params that do not match existing mixins', () => {
@@ -298,15 +296,15 @@ describe( 'wp.registerRoute', () => {
 			handler = factory( {
 				endpoint: '/',
 			} );
-			expect( handler ).to.have.property( 'customtax' );
-			expect( handler.customtax ).to.be.a( 'function' );
-			expect( handler ).to.have.property( 'someparam' );
-			expect( handler.someparam ).to.be.a( 'function' );
+			expect( handler ).toHaveProperty( 'customtax' );
+			expect( typeof handler.customtax ).toBe( 'function' );
+			expect( handler ).toHaveProperty( 'someparam' );
+			expect( typeof handler.someparam ).toBe( 'function' );
 			const result = handler.customtax( 'techno' ).someparam( [
 				'tech',
 				'yes',
 			] );
-			expect( result.toString() ).to.equal( '/a/b?customtax=techno&someparam%5B%5D=tech&someparam%5B%5D=yes' );
+			expect( result.toString() ).toBe( '/a/b?customtax=techno&someparam%5B%5D=tech&someparam%5B%5D=yes' );
 		} );
 
 		it( 'will not overwrite existing methods', () => {
@@ -317,7 +315,7 @@ describe( 'wp.registerRoute', () => {
 				endpoint: '/',
 			} );
 			const result = handler.id( 7 ).param( 'a', 'b' ).edit().toString();
-			expect( result ).to.equal( '/myplugin/v1/author/7?a=b&context=edit' );
+			expect( result ).toBe( '/myplugin/v1/author/7?a=b&context=edit' );
 		} );
 
 	} );
@@ -342,20 +340,20 @@ describe( 'wp.registerRoute', () => {
 		} );
 
 		it( 'are set on the prototype of the handler constructor', () => {
-			expect( handler ).to.have.property( 'foo' );
-			expect( handler ).not.to.have.ownProperty( 'foo' );
-			expect( handler.foo ).to.be.a( 'function' );
-			expect( handler ).to.have.property( 'bar' );
-			expect( handler ).not.to.have.ownProperty( 'bar' );
-			expect( handler.bar ).to.be.a( 'function' );
+			expect( handler ).toHaveProperty( 'foo' );
+			expect( handler.hasOwnProperty( 'foo' ) ).toBe( false );
+			expect( typeof handler.foo ).toBe( 'function' );
+			expect( handler ).toHaveProperty( 'bar' );
+			expect( handler.hasOwnProperty( 'bar' ) ).toBe( false );
+			expect( typeof handler.bar ).toBe( 'function' );
 		} );
 
 		it( 'can set URL query parameters', () => {
-			expect( handler.foo().toString() ).to.equal( '/myplugin/v1/author?foo=true' );
+			expect( handler.foo().toString() ).toBe( '/myplugin/v1/author?foo=true' );
 		} );
 
 		it( 'can set dynamic URL query parameter values', () => {
-			expect( handler.bar( '1138' ).toString() ).to.equal( '/myplugin/v1/author?bar=1138' );
+			expect( handler.bar( '1138' ).toString() ).toBe( '/myplugin/v1/author?bar=1138' );
 		} );
 
 		it( 'will not overwrite existing endpoint handler prototype methods', () => {
@@ -369,8 +367,8 @@ describe( 'wp.registerRoute', () => {
 			const result = factory( {
 				endpoint: '/',
 			} ).id( 7 ).toString();
-			expect( result ).not.to.equal( '/myplugin/v1/author?id=as_a_param' );
-			expect( result ).to.equal( '/myplugin/v1/author/7' );
+			expect( result ).not.toBe( '/myplugin/v1/author?id=as_a_param' );
+			expect( result ).toBe( '/myplugin/v1/author/7' );
 		} );
 
 		it( 'will not overwrite WPRequest default methods', () => {
@@ -384,7 +382,7 @@ describe( 'wp.registerRoute', () => {
 			const result = factory( {
 				endpoint: '/',
 			} ).id( 7 ).param( 'a', 'b' ).toString();
-			expect( result ).to.equal( '/myplugin/v1/author/7?a=b' );
+			expect( result ).toBe( '/myplugin/v1/author/7?a=b' );
 		} );
 
 	} );
@@ -400,25 +398,25 @@ describe( 'wp.registerRoute', () => {
 		} );
 
 		it( 'sets the first static level of the route automatically', () => {
-			expect( handler.toString() ).to.equal( '/wp/v2/pages' );
+			expect( handler.toString() ).toBe( '/wp/v2/pages' );
 		} );
 
 		it( 'permits the first dynamic level of the route to be set with .parent', () => {
-			expect( handler.parent( 79 ).toString() ).to.equal( '/wp/v2/pages/79' );
+			expect( handler.parent( 79 ).toString() ).toBe( '/wp/v2/pages/79' );
 		} );
 
 		it( 'permits the second static level of the route to be set with .revisions', () => {
-			expect( handler.parent( 79 ).revisions().toString() ).to.equal( '/wp/v2/pages/79/revisions' );
+			expect( handler.parent( 79 ).revisions().toString() ).toBe( '/wp/v2/pages/79/revisions' );
 		} );
 
 		it( 'permits the second dynamic level of the route to be set with .id', () => {
-			expect( handler.parent( 79 ).revisions().id( 97 ).toString() ).to.equal( '/wp/v2/pages/79/revisions/97' );
+			expect( handler.parent( 79 ).revisions().id( 97 ).toString() ).toBe( '/wp/v2/pages/79/revisions/97' );
 		} );
 
 		it( 'throws an error if the parts of the route provided are not contiguous', () => {
 			expect( () => {
 				handler.parent( 101 ).id( 102 ).toString();
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 	} );
@@ -433,8 +431,8 @@ describe( 'wp.registerRoute', () => {
 			} );
 			expect( () => {
 				handler.a( 'foo' ).toString();
-			} ).to.throw;
-			expect( handler.a( 'foo_100' ).toString() ).to.equal( '/myplugin/one/foo_100' );
+			} ).toThrow;
+			expect( handler.a( 'foo_100' ).toString() ).toBe( '/myplugin/one/foo_100' );
 		} );
 
 		it( 'can be bypassed if no regex is provided for a capture group', () => {
@@ -444,8 +442,8 @@ describe( 'wp.registerRoute', () => {
 			} );
 			expect( () => {
 				handler.a( 'foo' ).two().b( 1000 ).toString();
-			} ).not.to.throw;
-			expect( handler.a( 'foo' ).two( 1000 ).toString() ).to.equal( '/myplugin/one/foo/two/1000' );
+			} ).not.toThrow;
+			expect( handler.a( 'foo' ).two( 1000 ).toString() ).toBe( '/myplugin/one/foo/two/1000' );
 		} );
 
 	} );
@@ -470,7 +468,7 @@ describe( 'wp.registerRoute', () => {
 					it( method, () => {
 						expect( () => {
 							checkMethodSupport( method, handler.a( 1 ).b( 2 ) );
-						} ).not.to.throw();
+						} ).not.toThrow();
 					} );
 				} );
 
@@ -482,7 +480,7 @@ describe( 'wp.registerRoute', () => {
 					it( method, () => {
 						expect( () => {
 							checkMethodSupport( method, handler.a( 1 ).b( 2 ) );
-						} ).to.throw();
+						} ).toThrow();
 					} );
 				} );
 
@@ -491,7 +489,7 @@ describe( 'wp.registerRoute', () => {
 			it( 'support "head" implicitly if "get" is whitelisted', () => {
 				expect( () => {
 					checkMethodSupport( 'head', handler.a( 1 ).b( 2 ) );
-				} ).not.to.throw();
+				} ).not.toThrow();
 			} );
 
 			it( 'support "get" implicitly if "head" is whitelisted', () => {
@@ -503,7 +501,7 @@ describe( 'wp.registerRoute', () => {
 				} );
 				expect( () => {
 					checkMethodSupport( 'head', handler.a( 1 ).b( 2 ) );
-				} ).not.to.throw();
+				} ).not.toThrow();
 			} );
 
 		} );
@@ -516,7 +514,7 @@ describe( 'wp.registerRoute', () => {
 					it( method, () => {
 						expect( () => {
 							checkMethodSupport( method, handler.a( 1 ) );
-						} ).not.to.throw();
+						} ).not.toThrow();
 					} );
 				} );
 
@@ -538,7 +536,7 @@ describe( 'wp.registerRoute', () => {
 			it( 'is properly whitelisted', () => {
 				expect( () => {
 					checkMethodSupport( 'post', handler.a( 1 ).b( 2 ) );
-				} ).not.to.throw();
+				} ).not.toThrow();
 			} );
 
 			describe( 'implicitly blacklists other method', () => {
@@ -547,7 +545,7 @@ describe( 'wp.registerRoute', () => {
 					it( method, () => {
 						expect( () => {
 							checkMethodSupport( method, handler.a( 1 ).b( 2 ) );
-						} ).to.throw();
+						} ).toThrow();
 					} );
 				} );
 
@@ -561,7 +559,7 @@ describe( 'wp.registerRoute', () => {
 
 		it( 'can be passed in to the factory method', () => {
 			const factory = registerRoute( 'myplugin', 'myroute' );
-			expect( factory( { endpoint: '/wp-yaml/' } ).toString() ).to.equal( '/wp-yaml/myplugin/myroute' );
+			expect( factory( { endpoint: '/wp-yaml/' } ).toString() ).toBe( '/wp-yaml/myplugin/myroute' );
 		} );
 
 		it( 'correctly defaults to the containing object\'s _options, if present', () => {
@@ -571,7 +569,7 @@ describe( 'wp.registerRoute', () => {
 					endpoint: '/foo/',
 				},
 			};
-			expect( obj.factory().toString() ).to.equal( '/foo/myplugin/myroute' );
+			expect( obj.factory().toString() ).toBe( '/foo/myplugin/myroute' );
 		} );
 
 	} );

--- a/tests/unit/route-handlers/comments.js
+++ b/tests/unit/route-handlers/comments.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const WPAPI = require( '../../../wpapi' );
 const WPRequest = require( '../../../lib/constructors/wp-request' );
@@ -23,26 +22,26 @@ describe( 'wp.comments', () => {
 			comments = site.comments( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( comments._options.endpoint ).to.equal( '/custom-endpoint/' );
+			expect( comments._options.endpoint ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should initialize _options to the site defaults', () => {
-			expect( comments._options.endpoint ).to.equal( '/wp-json/' );
-			expect( comments._options.username ).to.equal( 'foouser' );
-			expect( comments._options.password ).to.equal( 'barpass' );
+			expect( comments._options.endpoint ).toBe( '/wp-json/' );
+			expect( comments._options.username ).toBe( 'foouser' );
+			expect( comments._options.password ).toBe( 'barpass' );
 		} );
 
 		it( 'should initialize the base path component', () => {
-			expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments' );
+			expect( comments.toString() ).toBe( '/wp-json/wp/v2/comments' );
 		} );
 
 		it( 'should set a default _supportedMethods array', () => {
-			expect( comments ).to.have.property( '_supportedMethods' );
-			expect( comments._supportedMethods ).to.be.an( 'array' );
+			expect( comments ).toHaveProperty( '_supportedMethods' );
+			expect( Array.isArray( comments._supportedMethods ) ).toBe( true );
 		} );
 
 		it( 'should inherit CommentsRequest from WPRequest', () => {
-			expect( comments instanceof WPRequest ).to.be.true;
+			expect( comments instanceof WPRequest ).toBe( true );
 		} );
 
 	} );
@@ -52,24 +51,24 @@ describe( 'wp.comments', () => {
 		describe( '.id()', () => {
 
 			it( 'provides a method to set the ID', () => {
-				expect( comments ).to.have.property( 'id' );
-				expect( comments.id ).to.be.a( 'function' );
+				expect( comments ).toHaveProperty( 'id' );
+				expect( typeof comments.id ).toBe( 'function' );
 			} );
 
 			it( 'should set the ID value in the path', () => {
 				comments.id( 314159 );
-				expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/314159' );
+				expect( comments.toString() ).toBe( '/wp-json/wp/v2/comments/314159' );
 			} );
 
 			it( 'accepts ID parameters as strings', () => {
 				comments.id( '8' );
-				expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/8' );
+				expect( comments.toString() ).toBe( '/wp-json/wp/v2/comments/8' );
 			} );
 
 			it( 'should update the supported methods when setting ID', () => {
 				comments.id( 8 );
 				const _supportedMethods = comments._supportedMethods.sort().join( '|' );
-				expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
+				expect( _supportedMethods ).toBe( 'delete|get|head|patch|post|put' );
 			} );
 
 		} );
@@ -80,47 +79,47 @@ describe( 'wp.comments', () => {
 
 		it( 'should create the URL for retrieving all comments', () => {
 			const path = comments.toString();
-			expect( path ).to.equal( '/wp-json/wp/v2/comments' );
+			expect( path ).toBe( '/wp-json/wp/v2/comments' );
 		} );
 
 		it( 'should create the URL for retrieving a specific comment', () => {
 			const path = comments.id( 1337 ).toString();
-			expect( path ).to.equal( '/wp-json/wp/v2/comments/1337' );
+			expect( path ).toBe( '/wp-json/wp/v2/comments/1337' );
 		} );
 
 		it( 'does not throw an error if a valid numeric ID is specified', () => {
 			expect( () => {
 				comments.id( 8 );
 				comments.validatePath();
-			} ).not.to.throw();
+			} ).not.toThrow();
 		} );
 
 		it( 'does not throw an error if a valid numeric ID is specified as a string', () => {
 			expect( () => {
 				comments.id( '8' );
 				comments.validatePath();
-			} ).not.to.throw();
+			} ).not.toThrow();
 		} );
 
 		it( 'throws an error if a non-integer numeric string ID is specified', () => {
 			expect( () => {
 				comments.id( 4.019 );
 				comments.validatePath();
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 		it( 'throws an error if a non-numeric string ID is specified', () => {
 			expect( () => {
 				comments.id( 'wombat' );
 				comments.validatePath();
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 		it( 'should restrict path changes to a single instance', () => {
 			comments.id( 2 );
 			const newComments = site.comments().id( 3 );
-			expect( comments.toString() ).to.equal( '/wp-json/wp/v2/comments/2' );
-			expect( newComments.toString() ).to.equal( '/wp-json/wp/v2/comments/3' );
+			expect( comments.toString() ).toBe( '/wp-json/wp/v2/comments/2' );
+			expect( newComments.toString() ).toBe( '/wp-json/wp/v2/comments/3' );
 		} );
 
 	} );

--- a/tests/unit/route-handlers/media.js
+++ b/tests/unit/route-handlers/media.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const WPAPI = require( '../../../wpapi' );
 const WPRequest = require( '../../../lib/constructors/wp-request' );
@@ -23,26 +22,26 @@ describe( 'wp.media', () => {
 			media = site.media( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( media._options.endpoint ).to.equal( '/custom-endpoint/' );
+			expect( media._options.endpoint ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should initialize _options to the site defaults', () => {
-			expect( media._options.endpoint ).to.equal( '/wp-json/' );
-			expect( media._options.username ).to.equal( 'foouser' );
-			expect( media._options.password ).to.equal( 'barpass' );
+			expect( media._options.endpoint ).toBe( '/wp-json/' );
+			expect( media._options.username ).toBe( 'foouser' );
+			expect( media._options.password ).toBe( 'barpass' );
 		} );
 
 		it( 'should initialize the base path component', () => {
-			expect( media.toString() ).to.equal( '/wp-json/wp/v2/media' );
+			expect( media.toString() ).toBe( '/wp-json/wp/v2/media' );
 		} );
 
 		it( 'should set a default _supportedMethods array', () => {
-			expect( media ).to.have.property( '_supportedMethods' );
-			expect( media._supportedMethods ).to.be.an( 'array' );
+			expect( media ).toHaveProperty( '_supportedMethods' );
+			expect( Array.isArray( media._supportedMethods ) ).toBe( true );
 		} );
 
 		it( 'should inherit MediaRequest from WPRequest', () => {
-			expect( media instanceof WPRequest ).to.be.true;
+			expect( media instanceof WPRequest ).toBe( true );
 		} );
 
 	} );
@@ -50,46 +49,46 @@ describe( 'wp.media', () => {
 	describe( '.id()', () => {
 
 		it( 'is defined', () => {
-			expect( media ).to.have.property( 'id' );
+			expect( media ).toHaveProperty( 'id' );
 		} );
 
 		it( 'is a function', () => {
-			expect( media.id ).to.be.a( 'function' );
+			expect( typeof media.id ).toBe( 'function' );
 		} );
 
 		it( 'should set the ID value in the path', () => {
 			media.id( 8 );
-			expect( media.toString() ).to.equal( '/wp-json/wp/v2/media/8' );
+			expect( media.toString() ).toBe( '/wp-json/wp/v2/media/8' );
 		} );
 
 		it( 'should update the supported methods', () => {
 			media.id( 8 );
 			const _supportedMethods = media._supportedMethods.sort().join( '|' );
-			expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
+			expect( _supportedMethods ).toBe( 'delete|get|head|patch|post|put' );
 		} );
 
 		it( 'throws an error on successive calls', () => {
 			expect( () => {
 				media.id( 8 ).id( 3 );
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 		it( 'passes validation when called with a number', () => {
 			expect( () => {
 				media.id( 8 )._renderPath();
-			} ).not.to.throw();
+			} ).not.toThrow();
 		} );
 
 		it( 'passes validation when called with a number formatted as a string', () => {
 			expect( () => {
 				media.id( '9' )._renderPath();
-			} ).not.to.throw();
+			} ).not.toThrow();
 		} );
 
 		it( 'causes a validation error when called with a non-number', () => {
 			expect( () => {
 				media.id( 'wombat' )._renderPath();
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 	} );
@@ -98,17 +97,17 @@ describe( 'wp.media', () => {
 
 		it( 'should create the URL for the media collection', () => {
 			const uri = media.toString();
-			expect( uri ).to.equal( '/wp-json/wp/v2/media' );
+			expect( uri ).toBe( '/wp-json/wp/v2/media' );
 		} );
 
 		it( 'can paginate the media collection responses', () => {
 			const uri = media.page( 4 ).toString();
-			expect( uri ).to.equal( '/wp-json/wp/v2/media?page=4' );
+			expect( uri ).toBe( '/wp-json/wp/v2/media?page=4' );
 		} );
 
 		it( 'should create the URL for a specific media object', () => {
 			const uri = media.id( 1492 ).toString();
-			expect( uri ).to.equal( '/wp-json/wp/v2/media/1492' );
+			expect( uri ).toBe( '/wp-json/wp/v2/media/1492' );
 		} );
 
 	} );

--- a/tests/unit/route-handlers/pages.js
+++ b/tests/unit/route-handlers/pages.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const WPAPI = require( '../../../wpapi' );
 const WPRequest = require( '../../../lib/constructors/wp-request' );
@@ -23,26 +22,26 @@ describe( 'wp.pages', () => {
 			pages = site.pages( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( pages._options.endpoint ).to.equal( '/custom-endpoint/' );
+			expect( pages._options.endpoint ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should initialize _options to the site defaults', () => {
-			expect( pages._options.endpoint ).to.equal( '/wp-json/' );
-			expect( pages._options.username ).to.equal( 'foouser' );
-			expect( pages._options.password ).to.equal( 'barpass' );
+			expect( pages._options.endpoint ).toBe( '/wp-json/' );
+			expect( pages._options.username ).toBe( 'foouser' );
+			expect( pages._options.password ).toBe( 'barpass' );
 		} );
 
 		it( 'should initialize the base path component', () => {
-			expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages' );
+			expect( pages.toString() ).toBe( '/wp-json/wp/v2/pages' );
 		} );
 
 		it( 'should set a default _supportedMethods array', () => {
-			expect( pages ).to.have.property( '_supportedMethods' );
-			expect( pages._supportedMethods ).to.be.an( 'array' );
+			expect( pages ).toHaveProperty( '_supportedMethods' );
+			expect( Array.isArray( pages._supportedMethods ) ).toBe( true );
 		} );
 
 		it( 'should inherit PagesRequest from WPRequest', () => {
-			expect( pages instanceof WPRequest ).to.be.true;
+			expect( pages instanceof WPRequest ).toBe( true );
 		} );
 
 	} );
@@ -52,21 +51,20 @@ describe( 'wp.pages', () => {
 		it( 'should restrict path changes to a single instance', () => {
 			pages.id( 2 );
 			const newPages = site.pages().id( 3 ).revisions();
-			expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages/2' );
-			expect( newPages.toString() ).to.equal( '/wp-json/wp/v2/pages/3/revisions' );
+			expect( pages.toString() ).toBe( '/wp-json/wp/v2/pages/2' );
+			expect( newPages.toString() ).toBe( '/wp-json/wp/v2/pages/3/revisions' );
 		} );
 
 		describe( 'page collections', () => {
 
 			it( 'should create the URL for retrieving all pages', () => {
-				expect( pages.toString() ).to.equal( '/wp-json/wp/v2/pages' );
+				expect( pages.toString() ).toBe( '/wp-json/wp/v2/pages' );
 			} );
 
 			it( 'should provide filtering methods', () => {
-				expect( pages ).to.have.property( 'slug' );
-				expect( pages.slug ).to.be.a( 'function' );
+				expect( typeof pages.slug ).toBe( 'function' );
 				const path = pages.slug( 'some-slug' ).toString();
-				expect( path ).to.equal( '/wp-json/wp/v2/pages?slug=some-slug' );
+				expect( path ).toBe( '/wp-json/wp/v2/pages?slug=some-slug' );
 			} );
 
 		} );
@@ -74,19 +72,19 @@ describe( 'wp.pages', () => {
 		describe( '.id()', () => {
 
 			it( 'is defined', () => {
-				expect( pages ).to.have.property( 'id' );
-				expect( pages.id ).to.be.a( 'function' );
+				expect( pages ).toHaveProperty( 'id' );
+				expect( typeof pages.id ).toBe( 'function' );
 			} );
 
 			it( 'should create the URL for retrieving a specific post', () => {
 				const path = pages.id( 1337 ).toString();
-				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337' );
+				expect( path ).toBe( '/wp-json/wp/v2/pages/1337' );
 			} );
 
 			it( 'should update the supported methods when setting ID', () => {
 				pages.id( 8 );
 				const _supportedMethods = pages._supportedMethods.sort().join( '|' );
-				expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
+				expect( _supportedMethods ).toBe( 'delete|get|head|patch|post|put' );
 			} );
 
 		} );
@@ -94,16 +92,16 @@ describe( 'wp.pages', () => {
 		describe( '.revisions()', () => {
 
 			it( 'is defined', () => {
-				expect( pages ).to.have.property( 'revisions' );
+				expect( pages ).toHaveProperty( 'revisions' );
 			} );
 
 			it( 'is a function', () => {
-				expect( pages.revisions ).to.be.a( 'function' );
+				expect( typeof pages.revisions ).toBe( 'function' );
 			} );
 
 			it( 'should create the URL for retrieving the revisions for a specific post', () => {
 				const path = pages.id( 1337 ).revisions().toString();
-				expect( path ).to.equal( '/wp-json/wp/v2/pages/1337/revisions' );
+				expect( path ).toBe( '/wp-json/wp/v2/pages/1337/revisions' );
 			} );
 
 		} );

--- a/tests/unit/route-handlers/posts.js
+++ b/tests/unit/route-handlers/posts.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const WPAPI = require( '../../../wpapi' );
 const WPRequest = require( '../../../lib/constructors/wp-request' );
@@ -23,26 +22,26 @@ describe( 'wp.posts', () => {
 			posts = site.posts( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( posts._options.endpoint ).to.equal( '/custom-endpoint/' );
+			expect( posts._options.endpoint ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should initialize _options to the site defaults', () => {
-			expect( posts._options.endpoint ).to.equal( '/wp-json/' );
-			expect( posts._options.username ).to.equal( 'foouser' );
-			expect( posts._options.password ).to.equal( 'barpass' );
+			expect( posts._options.endpoint ).toBe( '/wp-json/' );
+			expect( posts._options.username ).toBe( 'foouser' );
+			expect( posts._options.password ).toBe( 'barpass' );
 		} );
 
 		it( 'should initialize the base path component', () => {
-			expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts' );
+			expect( posts.toString() ).toBe( '/wp-json/wp/v2/posts' );
 		} );
 
 		it( 'should set a default _supportedMethods array', () => {
-			expect( posts ).to.have.property( '_supportedMethods' );
-			expect( posts._supportedMethods ).to.be.an( 'array' );
+			expect( posts ).toHaveProperty( '_supportedMethods' );
+			expect( Array.isArray( posts._supportedMethods ) ).toBe( true );
 		} );
 
 		it( 'should inherit PostsRequest from WPRequest', () => {
-			expect( posts instanceof WPRequest ).to.be.true;
+			expect( posts instanceof WPRequest ).toBe( true );
 		} );
 
 	} );
@@ -52,24 +51,24 @@ describe( 'wp.posts', () => {
 		describe( '.id()', () => {
 
 			it( 'provides a method to set the ID', () => {
-				expect( posts ).to.have.property( 'id' );
-				expect( posts.id ).to.be.a( 'function' );
+				expect( posts ).toHaveProperty( 'id' );
+				expect( typeof posts.id ).toBe( 'function' );
 			} );
 
 			it( 'should set the ID value in the path', () => {
 				posts.id( 314159 );
-				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/314159' );
+				expect( posts.toString() ).toBe( '/wp-json/wp/v2/posts/314159' );
 			} );
 
 			it( 'accepts ID parameters as strings', () => {
 				posts.id( '8' );
-				expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/8' );
+				expect( posts.toString() ).toBe( '/wp-json/wp/v2/posts/8' );
 			} );
 
 			it( 'should update the supported methods when setting ID', () => {
 				posts.id( 8 );
 				const _supportedMethods = posts._supportedMethods.sort().join( '|' );
-				expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
+				expect( _supportedMethods ).toBe( 'delete|get|head|patch|post|put' );
 			} );
 
 		} );
@@ -89,8 +88,7 @@ describe( 'wp.posts', () => {
 			'status',
 			'sticky',
 		].forEach( ( methodName ) => {
-			expect( posts ).to.have.property( methodName );
-			expect( posts[ methodName ] ).to.be.a( 'function' );
+			expect( typeof posts[ methodName ] ).toBe( 'function' );
 		} );
 	} );
 
@@ -98,57 +96,57 @@ describe( 'wp.posts', () => {
 
 		it( 'should create the URL for retrieving all posts', () => {
 			const path = posts.toString();
-			expect( path ).to.equal( '/wp-json/wp/v2/posts' );
+			expect( path ).toBe( '/wp-json/wp/v2/posts' );
 		} );
 
 		it( 'should create the URL for retrieving a specific post', () => {
 			const path = posts.id( 1337 ).toString();
-			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337' );
+			expect( path ).toBe( '/wp-json/wp/v2/posts/1337' );
 		} );
 
 		it( 'does not throw an error if a valid numeric ID is specified', () => {
 			expect( () => {
 				posts.id( 8 );
 				posts.validatePath();
-			} ).not.to.throw();
+			} ).not.toThrow();
 		} );
 
 		it( 'does not throw an error if a valid numeric ID is specified as a string', () => {
 			expect( () => {
 				posts.id( '8' );
 				posts.validatePath();
-			} ).not.to.throw();
+			} ).not.toThrow();
 		} );
 
 		it( 'throws an error if a non-integer numeric string ID is specified', () => {
 			expect( () => {
 				posts.id( 4.019 );
 				posts.validatePath();
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 		it( 'throws an error if a non-numeric string ID is specified', () => {
 			expect( () => {
 				posts.id( 'wombat' );
 				posts.validatePath();
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 		it( 'should create the URL for retrieving the revisions for a specific post', () => {
 			const path = posts.id( 1337 ).revisions().toString();
-			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/revisions' );
+			expect( path ).toBe( '/wp-json/wp/v2/posts/1337/revisions' );
 		} );
 
 		it( 'should create the URL for retrieving a specific revision item', () => {
 			const path = posts.id( 1337 ).revisions( 2001 ).toString();
-			expect( path ).to.equal( '/wp-json/wp/v2/posts/1337/revisions/2001' );
+			expect( path ).toBe( '/wp-json/wp/v2/posts/1337/revisions/2001' );
 		} );
 
 		it( 'should restrict path changes to a single instance', () => {
 			posts.id( 2 );
 			const newPosts = site.posts().id( 3 ).revisions();
-			expect( posts.toString() ).to.equal( '/wp-json/wp/v2/posts/2' );
-			expect( newPosts.toString() ).to.equal( '/wp-json/wp/v2/posts/3/revisions' );
+			expect( posts.toString() ).toBe( '/wp-json/wp/v2/posts/2' );
+			expect( newPosts.toString() ).toBe( '/wp-json/wp/v2/posts/3/revisions' );
 		} );
 
 	} );

--- a/tests/unit/route-handlers/taxonomies.js
+++ b/tests/unit/route-handlers/taxonomies.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const WPAPI = require( '../../../wpapi' );
 const WPRequest = require( '../../../lib/constructors/wp-request' );
@@ -23,26 +22,26 @@ describe( 'wp.taxonomies', () => {
 			taxonomies = site.taxonomies( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( taxonomies._options.endpoint ).to.equal( '/custom-endpoint/' );
+			expect( taxonomies._options.endpoint ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should initialize _options to the site defaults', () => {
-			expect( taxonomies._options.endpoint ).to.equal( '/wp-json/' );
-			expect( taxonomies._options.username ).to.equal( 'foouser' );
-			expect( taxonomies._options.password ).to.equal( 'barpass' );
+			expect( taxonomies._options.endpoint ).toBe( '/wp-json/' );
+			expect( taxonomies._options.username ).toBe( 'foouser' );
+			expect( taxonomies._options.password ).toBe( 'barpass' );
 		} );
 
 		it( 'should initialize the base path component', () => {
-			expect( taxonomies.toString() ).to.equal( '/wp-json/wp/v2/taxonomies' );
+			expect( taxonomies.toString() ).toBe( '/wp-json/wp/v2/taxonomies' );
 		} );
 
 		it( 'should set a default _supportedMethods array', () => {
-			expect( taxonomies ).to.have.property( '_supportedMethods' );
-			expect( taxonomies._supportedMethods ).to.be.an( 'array' );
+			expect( taxonomies ).toHaveProperty( '_supportedMethods' );
+			expect( Array.isArray( taxonomies._supportedMethods ) ).toBe( true );
 		} );
 
 		it( 'should inherit TaxonomiesRequest from WPRequest', () => {
-			expect( taxonomies instanceof WPRequest ).to.be.true;
+			expect( taxonomies instanceof WPRequest ).toBe( true );
 		} );
 
 	} );
@@ -52,8 +51,8 @@ describe( 'wp.taxonomies', () => {
 		describe( '.taxonomy()', () => {
 
 			it( 'provides a method to set the taxonomy', () => {
-				expect( taxonomies ).to.have.property( 'taxonomy' );
-				expect( taxonomies.taxonomy ).to.be.a( 'function' );
+				expect( taxonomies ).toHaveProperty( 'taxonomy' );
+				expect( typeof taxonomies.taxonomy ).toBe( 'function' );
 			} );
 
 		} );
@@ -64,12 +63,12 @@ describe( 'wp.taxonomies', () => {
 
 		it( 'should create the URL for retrieving all taxonomies', () => {
 			const url = taxonomies.toString();
-			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies' );
+			expect( url ).toBe( '/wp-json/wp/v2/taxonomies' );
 		} );
 
 		it( 'should create the URL for retrieving a specific taxonomy', () => {
 			const url = taxonomies.taxonomy( 'category' ).toString();
-			expect( url ).to.equal( '/wp-json/wp/v2/taxonomies/category' );
+			expect( url ).toBe( '/wp-json/wp/v2/taxonomies/category' );
 		} );
 
 	} );

--- a/tests/unit/route-handlers/types.js
+++ b/tests/unit/route-handlers/types.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const WPAPI = require( '../../../wpapi' );
 const WPRequest = require( '../../../lib/constructors/wp-request' );
@@ -23,26 +22,26 @@ describe( 'wp.types', () => {
 			types = site.types( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( types._options.endpoint ).to.equal( '/custom-endpoint/' );
+			expect( types._options.endpoint ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should initialize _options to the site defaults', () => {
-			expect( types._options.endpoint ).to.equal( '/wp-json/' );
-			expect( types._options.username ).to.equal( 'foouser' );
-			expect( types._options.password ).to.equal( 'barpass' );
+			expect( types._options.endpoint ).toBe( '/wp-json/' );
+			expect( types._options.username ).toBe( 'foouser' );
+			expect( types._options.password ).toBe( 'barpass' );
 		} );
 
 		it( 'should initialize the base path component', () => {
-			expect( types.toString() ).to.equal( '/wp-json/wp/v2/types' );
+			expect( types.toString() ).toBe( '/wp-json/wp/v2/types' );
 		} );
 
 		it( 'should set a default _supportedMethods array', () => {
-			expect( types ).to.have.property( '_supportedMethods' );
-			expect( types._supportedMethods ).to.be.an( 'array' );
+			expect( types ).toHaveProperty( '_supportedMethods' );
+			expect( Array.isArray( types._supportedMethods ) ).toBe( true );
 		} );
 
 		it( 'should inherit PostsRequest from WPRequest', () => {
-			expect( types instanceof WPRequest ).to.be.true;
+			expect( types instanceof WPRequest ).toBe( true );
 		} );
 
 	} );
@@ -51,12 +50,12 @@ describe( 'wp.types', () => {
 
 		it( 'should create the URL for retrieving all types', () => {
 			const url = types.toString();
-			expect( url ).to.equal( '/wp-json/wp/v2/types' );
+			expect( url ).toBe( '/wp-json/wp/v2/types' );
 		} );
 
 		it( 'should create the URL for retrieving a specific term', () => {
 			const url = types.type( 'some_type' ).toString();
-			expect( url ).to.equal( '/wp-json/wp/v2/types/some_type' );
+			expect( url ).toBe( '/wp-json/wp/v2/types/some_type' );
 		} );
 
 	} );

--- a/tests/unit/route-handlers/users.js
+++ b/tests/unit/route-handlers/users.js
@@ -1,5 +1,4 @@
 'use strict';
-const { expect } = require( 'chai' );
 
 const WPAPI = require( '../../../wpapi' );
 const WPRequest = require( '../../../lib/constructors/wp-request' );
@@ -23,26 +22,26 @@ describe( 'wp.users', () => {
 			users = site.users( {
 				endpoint: '/custom-endpoint/',
 			} );
-			expect( users._options.endpoint ).to.equal( '/custom-endpoint/' );
+			expect( users._options.endpoint ).toBe( '/custom-endpoint/' );
 		} );
 
 		it( 'should initialize _options to the site defaults', () => {
-			expect( users._options.endpoint ).to.equal( '/wp-json/' );
-			expect( users._options.username ).to.equal( 'foouser' );
-			expect( users._options.password ).to.equal( 'barpass' );
+			expect( users._options.endpoint ).toBe( '/wp-json/' );
+			expect( users._options.username ).toBe( 'foouser' );
+			expect( users._options.password ).toBe( 'barpass' );
 		} );
 
 		it( 'should initialize the base path component', () => {
-			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users' );
+			expect( users.toString() ).toBe( '/wp-json/wp/v2/users' );
 		} );
 
 		it( 'should set a default _supportedMethods array', () => {
-			expect( users ).to.have.property( '_supportedMethods' );
-			expect( users._supportedMethods ).to.be.an( 'array' );
+			expect( users ).toHaveProperty( '_supportedMethods' );
+			expect( Array.isArray( users._supportedMethods ) ).toBe( true );
 		} );
 
 		it( 'should inherit UsersRequest from WPRequest', () => {
-			expect( users instanceof WPRequest ).to.be.true;
+			expect( users instanceof WPRequest ).toBe( true );
 		} );
 
 	} );
@@ -51,7 +50,7 @@ describe( 'wp.users', () => {
 
 		it( 'sets the path to users/me', () => {
 			users.me();
-			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users/me' );
+			expect( users.toString() ).toBe( '/wp-json/wp/v2/users/me' );
 		} );
 
 	} );
@@ -59,16 +58,16 @@ describe( 'wp.users', () => {
 	describe( '.id()', () => {
 
 		it( 'is defined', () => {
-			expect( users ).to.have.property( 'id' );
+			expect( users ).toHaveProperty( 'id' );
 		} );
 
 		it( 'is a function', () => {
-			expect( users.id ).to.be.a( 'function' );
+			expect( typeof users.id ).toBe( 'function' );
 		} );
 
 		it( 'sets the path ID to the passed-in value', () => {
 			users.id( 2501 );
-			expect( users.toString() ).to.equal( '/wp-json/wp/v2/users/2501' );
+			expect( users.toString() ).toBe( '/wp-json/wp/v2/users/2501' );
 		} );
 
 	} );
@@ -77,19 +76,19 @@ describe( 'wp.users', () => {
 
 		it( 'should create the URL for retrieving all users', () => {
 			const url = users.toString();
-			expect( url ).to.equal( '/wp-json/wp/v2/users' );
+			expect( url ).toBe( '/wp-json/wp/v2/users' );
 		} );
 
 		it( 'should create the URL for retrieving the current user', () => {
 			const url = users.me().toString();
-			expect( url ).to.equal( '/wp-json/wp/v2/users/me' );
+			expect( url ).toBe( '/wp-json/wp/v2/users/me' );
 		} );
 
 		it( 'should create the URL for retrieving a specific user by ID', () => {
 			const url = users.id( 1337 ).toString();
 			const _supportedMethods = users._supportedMethods.sort().join( '|' );
-			expect( url ).to.equal( '/wp-json/wp/v2/users/1337' );
-			expect( _supportedMethods ).to.equal( 'delete|get|head|patch|post|put' );
+			expect( url ).toBe( '/wp-json/wp/v2/users/1337' );
+			expect( _supportedMethods ).toBe( 'delete|get|head|patch|post|put' );
 		} );
 
 	} );

--- a/tests/unit/wpapi.js
+++ b/tests/unit/wpapi.js
@@ -1,14 +1,4 @@
 'use strict';
-const chai = require( 'chai' );
-// Variable to use as our "success token" in promise assertions
-const SUCCESS = 'success';
-// Chai-as-promised and the `expect( prom ).to.eventually.equal( SUCCESS ) is
-// used to ensure that the assertions running within the promise chains are
-// actually run.
-chai.use( require( 'chai-as-promised' ) );
-chai.use( require( 'sinon-chai' ) );
-const expect = chai.expect;
-const sinon = require( 'sinon' );
 
 const WPAPI = require( '../../' );
 
@@ -17,6 +7,9 @@ const WPRequest = require( '../../lib/constructors/wp-request' );
 
 // HTTP transport, for stubbing
 const httpTransport = require( '../../lib/http-transport' );
+
+// Variable to use as our "success token" in promise assertions
+const SUCCESS = 'success';
 
 describe( 'WPAPI', () => {
 
@@ -30,30 +23,30 @@ describe( 'WPAPI', () => {
 
 		it( 'enforces new', () => {
 			const site1 = new WPAPI( { endpoint: '/' } );
-			expect( site1 instanceof WPAPI ).to.be.true;
+			expect( site1 instanceof WPAPI ).toBe( true );
 			const site2 = WPAPI( { endpoint: '/' } );
-			expect( site2 instanceof WPAPI ).to.be.true;
+			expect( site2 instanceof WPAPI ).toBe( true );
 		} );
 
 		it( 'throws an error if no endpoint is provided', () => {
 			expect( () => {
 				new WPAPI( { endpoint: '/' } );
-			} ).not.to.throw();
+			} ).not.toThrow();
 			expect( () => {
 				new WPAPI();
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 		it( 'throws an error if a non-string endpoint is provided', () => {
 			expect( () => {
 				new WPAPI( { endpoint: 42 } );
-			} ).to.throw();
+			} ).toThrow();
 			expect( () => {
 				new WPAPI( { endpoint: [] } );
-			} ).to.throw();
+			} ).toThrow();
 			expect( () => {
 				new WPAPI( { endpoint: { lob: 'ster' } } );
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 		it( 'sets options on an instance variable', () => {
@@ -62,9 +55,9 @@ describe( 'WPAPI', () => {
 				username: 'fyodor',
 				password: 'dostoyevsky',
 			} );
-			expect( site._options.endpoint ).to.equal( 'http://some.url.com/wp-json/' );
-			expect( site._options.username ).to.equal( 'fyodor' );
-			expect( site._options.password ).to.equal( 'dostoyevsky' );
+			expect( site._options.endpoint ).toBe( 'http://some.url.com/wp-json/' );
+			expect( site._options.username ).toBe( 'fyodor' );
+			expect( site._options.password ).toBe( 'dostoyevsky' );
 		} );
 
 		it( 'activates authentication when credentials are provided', () => {
@@ -73,62 +66,62 @@ describe( 'WPAPI', () => {
 				username: 'fyodor',
 				password: 'dostoyevsky',
 			} );
-			expect( site._options.username ).to.equal( 'fyodor' );
-			expect( site._options.password ).to.equal( 'dostoyevsky' );
-			expect( site._options.auth ).to.be.true;
+			expect( site._options.username ).toBe( 'fyodor' );
+			expect( site._options.password ).toBe( 'dostoyevsky' );
+			expect( site._options.auth ).toBe( true );
 		} );
 
 		describe( 'assigns default HTTP transport', () => {
 
 			it( 'for GET requests', () => {
-				sinon.stub( httpTransport, 'get' );
+				jest.spyOn( httpTransport, 'get' ).mockImplementation( () => {} );
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 				} );
 				const query = site.root( '' );
 				query.get();
-				expect( httpTransport.get ).to.have.been.calledWith( query );
-				httpTransport.get.restore();
+				expect( httpTransport.get ).toHaveBeenCalledWith( query, undefined );
+				httpTransport.get.mockRestore();
 			} );
 
 			it( 'for POST requests', () => {
-				sinon.stub( httpTransport, 'post' );
+				jest.spyOn( httpTransport, 'post' ).mockImplementation( () => {} );
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 				} );
 				const query = site.root( '' );
 				const data = {};
 				query.create( data );
-				expect( httpTransport.post ).to.have.been.calledWith( query, data );
-				httpTransport.post.restore();
+				expect( httpTransport.post ).toHaveBeenCalledWith( query, data, undefined );
+				httpTransport.post.mockRestore();
 			} );
 
 			it( 'for POST requests', () => {
-				sinon.stub( httpTransport, 'post' );
+				jest.spyOn( httpTransport, 'post' ).mockImplementation( () => {} );
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 				} );
 				const query = site.root( '' );
 				const data = {};
 				query.create( data );
-				expect( httpTransport.post ).to.have.been.calledWith( query, data );
-				httpTransport.post.restore();
+				expect( httpTransport.post ).toHaveBeenCalledWith( query, data, undefined );
+				httpTransport.post.mockRestore();
 			} );
 
 			it( 'for PUT requests', () => {
-				sinon.stub( httpTransport, 'put' );
+				jest.spyOn( httpTransport, 'put' ).mockImplementation( () => {} );
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 				} );
 				const query = site.root( 'a-resource' );
 				const data = {};
 				query.update( data );
-				expect( httpTransport.put ).to.have.been.calledWith( query, data );
-				httpTransport.put.restore();
+				expect( httpTransport.put ).toHaveBeenCalledWith( query, data, undefined );
+				httpTransport.put.mockRestore();
 			} );
 
 			it( 'for DELETE requests', () => {
-				sinon.stub( httpTransport, 'delete' );
+				jest.spyOn( httpTransport, 'delete' ).mockImplementation( () => {} );
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 				} );
@@ -137,8 +130,8 @@ describe( 'WPAPI', () => {
 					force: true,
 				};
 				query.delete( data );
-				expect( httpTransport.delete ).to.have.been.calledWith( query, data );
-				httpTransport.delete.restore();
+				expect( httpTransport.delete ).toHaveBeenCalledWith( query, data, undefined );
+				httpTransport.delete.mockRestore();
 			} );
 
 		} );
@@ -146,8 +139,8 @@ describe( 'WPAPI', () => {
 		describe( 'custom HTTP transport methods', () => {
 
 			it( 'can be set for an individual HTTP action', () => {
-				sinon.stub( httpTransport, 'get' );
-				const customGet = sinon.stub();
+				jest.spyOn( httpTransport, 'get' ).mockImplementation( () => {} );
+				const customGet = jest.fn();
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 					transport: {
@@ -156,14 +149,14 @@ describe( 'WPAPI', () => {
 				} );
 				const query = site.root( '' );
 				query.get();
-				expect( httpTransport.get ).not.to.have.been.called;
-				expect( customGet ).to.have.been.calledWith( query );
-				httpTransport.get.restore();
+				expect( customGet ).toHaveBeenCalledWith( query, undefined );
+				expect( httpTransport.get ).not.toHaveBeenCalled();
+				httpTransport.get.mockRestore();
 			} );
 
 			it( 'can extend the default HTTP transport methods', () => {
-				sinon.stub( httpTransport, 'get' );
-				const customGet = sinon.spy( ( ...args ) => {
+				jest.spyOn( httpTransport, 'get' ).mockImplementation( () => {} );
+				const customGet = jest.fn( ( ...args ) => {
 					WPAPI.transport.get.apply( null, args );
 				} );
 				const site = new WPAPI( {
@@ -174,16 +167,16 @@ describe( 'WPAPI', () => {
 				} );
 				const query = site.root( '' );
 				query.get();
-				expect( customGet ).to.have.been.calledWith( query );
-				expect( httpTransport.get ).to.have.been.calledWith( query );
-				httpTransport.get.restore();
+				expect( customGet ).toHaveBeenCalledWith( query, undefined );
+				expect( httpTransport.get ).toHaveBeenCalledWith( query, undefined );
+				httpTransport.get.mockRestore();
 			} );
 
 			it( 'can be set for multiple HTTP actions', () => {
-				sinon.stub( httpTransport, 'post' );
-				sinon.stub( httpTransport, 'put' );
-				const customPost = sinon.stub();
-				const customPut = sinon.stub();
+				jest.spyOn( httpTransport, 'post' ).mockImplementation( () => {} );
+				jest.spyOn( httpTransport, 'put' ).mockImplementation( () => {} );
+				const customPost = jest.fn();
+				const customPut = jest.fn();
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 					transport: {
@@ -194,18 +187,18 @@ describe( 'WPAPI', () => {
 				const query = site.root( 'a-resource' );
 				const data = {};
 				query.create( data );
-				expect( httpTransport.post ).not.to.have.been.called;
-				expect( customPost ).to.have.been.calledWith( query, data );
+				expect( customPost ).toHaveBeenCalledWith( query, data, undefined );
+				expect( httpTransport.post ).not.toHaveBeenCalled();
 				query.update( data );
-				expect( httpTransport.put ).not.to.have.been.called;
-				expect( customPut ).to.have.been.calledWith( query, data );
-				httpTransport.post.restore();
-				httpTransport.put.restore();
+				expect( customPut ).toHaveBeenCalledWith( query, data, undefined );
+				expect( httpTransport.put ).not.toHaveBeenCalled();
+				httpTransport.post.mockRestore();
+				httpTransport.put.mockRestore();
 			} );
 
 			it( 'only apply to a specific WPAPI instance', () => {
-				sinon.stub( httpTransport, 'get' );
-				const customGet = sinon.stub();
+				jest.spyOn( httpTransport, 'get' ).mockImplementation( () => {} );
+				const customGet = jest.fn();
 				const site = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 					transport: {
@@ -215,12 +208,12 @@ describe( 'WPAPI', () => {
 				const site2 = new WPAPI( {
 					endpoint: 'http://some.url.com/wp-json',
 				} );
-				expect( site ).not.to.equal( site2 );
+				expect( site ).not.toBe( site2 );
 				const query = site2.root( '' );
 				query.get();
-				expect( httpTransport.get ).to.have.been.calledWith( query );
-				expect( customGet ).not.to.have.been.called;
-				httpTransport.get.restore();
+				expect( httpTransport.get ).toHaveBeenCalledWith( query, undefined );
+				expect( customGet ).not.toHaveBeenCalled();
+				httpTransport.get.mockRestore();
 			} );
 
 		} );
@@ -230,25 +223,25 @@ describe( 'WPAPI', () => {
 	describe( '.transport constructor property', () => {
 
 		it( 'is defined', () => {
-			expect( WPAPI ).to.have.property( 'transport' );
+			expect( WPAPI ).toHaveProperty( 'transport' );
 		} );
 
 		it( 'is an object', () => {
-			expect( WPAPI.transport ).to.be.an( 'object' );
+			expect( typeof WPAPI.transport ).toBe( 'object' );
 		} );
 
 		it( 'has methods for each http transport action', () => {
-			expect( WPAPI.transport.delete ).to.be.a( 'function' );
-			expect( WPAPI.transport.get ).to.be.a( 'function' );
-			expect( WPAPI.transport.head ).to.be.a( 'function' );
-			expect( WPAPI.transport.post ).to.be.a( 'function' );
-			expect( WPAPI.transport.put ).to.be.a( 'function' );
+			expect( typeof WPAPI.transport.delete ).toBe( 'function' );
+			expect( typeof WPAPI.transport.get ).toBe( 'function' );
+			expect( typeof WPAPI.transport.head ).toBe( 'function' );
+			expect( typeof WPAPI.transport.post ).toBe( 'function' );
+			expect( typeof WPAPI.transport.put ).toBe( 'function' );
 		} );
 
 		it( 'is frozen (properties cannot be modified directly)', () => {
 			expect( () => {
 				WPAPI.transport.get = () => {};
-			} ).to.throw();
+			} ).toThrow();
 		} );
 
 	} );
@@ -256,14 +249,14 @@ describe( 'WPAPI', () => {
 	describe( '.site() constructor method', () => {
 
 		it( 'is a function', () => {
-			expect( WPAPI ).to.have.property( 'site' );
-			expect( WPAPI.site ).to.be.a( 'function' );
+			expect( WPAPI ).toHaveProperty( 'site' );
+			expect( typeof WPAPI.site ).toBe( 'function' );
 		} );
 
 		it( 'creates and returns a new WPAPI instance', () => {
 			const site = WPAPI.site( 'endpoint/url' );
-			expect( site instanceof WPAPI ).to.be.true;
-			expect( site._options.endpoint ).to.equal( 'endpoint/url/' );
+			expect( site instanceof WPAPI ).toBe( true );
+			expect( site._options.endpoint ).toBe( 'endpoint/url/' );
 		} );
 
 		it( 'can take a routes configuration object to bootstrap the returned instance', () => {
@@ -279,19 +272,18 @@ describe( 'WPAPI', () => {
 					} ],
 				},
 			} );
-			expect( site instanceof WPAPI ).to.be.true;
-			expect( site.posts ).to.be.a( 'function' );
-			expect( site ).not.to.have.property( 'comments' );
-			expect( site.posts() ).not.to.have.property( 'id' );
-			expect( site.posts().filter ).to.be.a( 'function' );
-			expect( site.posts().toString() ).to.equal( 'endpoint/url/wp/v2/posts' );
+			expect( site instanceof WPAPI ).toBe( true );
+			expect( typeof site.posts ).toBe( 'function' );
+			expect( site ).not.toHaveProperty( 'comments' );
+			expect( site.posts() ).not.toHaveProperty( 'id' );
+			expect( typeof site.posts().filter ).toBe( 'function' );
+			expect( site.posts().toString() ).toBe( 'endpoint/url/wp/v2/posts' );
 		} );
 
 	} );
 
 	describe( '.discover() constructor method', () => {
 		let responses;
-		let sinonSandbox;
 
 		beforeEach( () => {
 			responses = {
@@ -326,114 +318,114 @@ describe( 'WPAPI', () => {
 				},
 			};
 			// Stub HTTP methods
-			sinon.stub( httpTransport, 'head' );
-			sinon.stub( httpTransport, 'get' );
+			jest.spyOn( httpTransport, 'head' ).mockImplementation( () => {} );
+			jest.spyOn( httpTransport, 'get' ).mockImplementation( () => {} );
 			// Stub warn and error
-			sinonSandbox = sinon.sandbox.create();
-			sinonSandbox.stub( global.console, 'warn' );
-			sinonSandbox.stub( global.console, 'error' );
+			jest.spyOn( global.console, 'warn' ).mockImplementation( () => {} );
+			jest.spyOn( global.console, 'error' ).mockImplementation( () => {} );
 		} );
 
 		afterEach( () => {
 			// Restore HTTP methods
-			httpTransport.head.restore();
-			httpTransport.get.restore();
-			// Restore sandbox
-			sinonSandbox.restore();
+			httpTransport.head.mockRestore();
+			httpTransport.get.mockRestore();
 		} );
 
 		it( 'is a function', () => {
-			expect( WPAPI ).to.have.property( 'discover' );
-			expect( WPAPI.discover ).to.be.a( 'function' );
+			expect( WPAPI ).toHaveProperty( 'discover' );
+			expect( typeof WPAPI.discover ).toBe( 'function' );
 		} );
 
 		it( 'throws an error if no API endpoint can be discovered', () => {
 			const url = 'http://we.made.it/to/mozarts/house';
-			httpTransport.head.onFirstCall().returns( Promise.reject() );
-			httpTransport.get.onFirstCall().returns( Promise.reject( 'Some error' ) );
+			httpTransport.head.mockImplementationOnce( () => Promise.reject() );
+			httpTransport.get.mockImplementationOnce( () => Promise.reject( 'Some error' ) );
 			const prom = WPAPI.discover( url )
 				.catch( ( err ) => {
-					expect( global.console.error ).to.have.been.calledWith( 'Some error' );
-					expect( err.message ).to.equal( 'Autodiscovery failed' );
+					expect( global.console.error ).toHaveBeenCalledWith( 'Some error' );
+					expect( err.message ).toBe( 'Autodiscovery failed' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'discovers the API root with a HEAD request', () => {
 			const url = 'http://mozarts.house';
-			httpTransport.head.returns( Promise.resolve( responses.head.withLink ) );
-			httpTransport.get.returns( Promise.resolve( responses.apiRoot ) );
+			httpTransport.head.mockImplementation( () => Promise.resolve( responses.head.withLink ) );
+			httpTransport.get.mockImplementation( () => Promise.resolve( responses.apiRoot ) );
 			const prom = WPAPI.discover( url )
 				.then( ( result ) => {
-					expect( result ).to.be.an.instanceOf( WPAPI );
-					expect( httpTransport.head.calledOnce ).to.equal( true );
-					expect( httpTransport.get.calledOnce ).to.equal( true );
-					expect( result.root().toString() ).to.equal( 'http://mozarts.house/wp-json/' );
+					expect( result ).toBeInstanceOf( WPAPI );
+					expect( httpTransport.head ).toBeCalledTimes( 1 );
+					expect( httpTransport.get ).toBeCalledTimes( 1 );
+					expect( result.root().toString() ).toBe( 'http://mozarts.house/wp-json/' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'throws an error if HEAD succeeds but no link is present', () => {
 			const url = 'http://we.made.it/to/mozarts/house';
-			httpTransport.head.onFirstCall().returns( Promise.resolve( responses.head.withoutLink ) );
+			httpTransport.head.mockImplementationOnce( () => Promise.resolve( responses.head.withoutLink ) );
 			const prom = WPAPI.discover( url )
 				.catch( ( err ) => {
-					expect( global.console.error ).to.have.been
-						.calledWith( new Error( 'No header link found with rel="https://api.w.org/"' ) );
-					expect( err.message ).to.equal( 'Autodiscovery failed' );
+					expect( global.console.error ).toHaveBeenCalledWith(
+						new Error( 'No header link found with rel="https://api.w.org/"' )
+					);
+					expect( err.message ).toBe( 'Autodiscovery failed' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'retries the initial site request as a GET if HEAD fails', () => {
 			const url = 'http://mozarts.house';
-			httpTransport.head.returns( Promise.reject() );
-			httpTransport.get.onFirstCall().returns( Promise.resolve( responses.get.withLink ) );
-			httpTransport.get.onSecondCall().returns( Promise.resolve( responses.apiRoot ) );
+			httpTransport.head.mockImplementation( () => Promise.reject() );
+			httpTransport.get.mockImplementationOnce( () => Promise.resolve( responses.get.withLink ) );
+			httpTransport.get.mockImplementationOnce( () => Promise.resolve( responses.apiRoot ) );
 			const prom = WPAPI.discover( url )
 				.then( ( result ) => {
-					expect( result ).to.be.an.instanceOf( WPAPI );
-					expect( httpTransport.head.calledOnce ).to.equal( true );
-					expect( httpTransport.get.calledTwice ).to.equal( true );
-					expect( result.root().toString() ).to.equal( 'http://mozarts.house/wp-json/' );
+					expect( result ).toBeInstanceOf( WPAPI );
+					expect( httpTransport.head ).toBeCalledTimes( 1 );
+					expect( httpTransport.get ).toBeCalledTimes( 2 );
+					expect( result.root().toString() ).toBe( 'http://mozarts.house/wp-json/' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'throws an error if GET retry succeeds but no link is present', () => {
 			const url = 'http://we.made.it/to/mozarts/house';
-			httpTransport.head.returns( Promise.reject() );
-			httpTransport.get.onFirstCall().returns( Promise.resolve( responses.get.withoutLink ) );
+			httpTransport.head.mockImplementation( () => Promise.reject() );
+			httpTransport.get.mockImplementationOnce( () => Promise.resolve( responses.get.withoutLink ) );
 			const prom = WPAPI.discover( url )
 				.catch( ( err ) => {
-					expect( global.console.error ).to.have.been
-						.calledWith( new Error( 'No header link found with rel="https://api.w.org/"' ) );
-					expect( err.message ).to.equal( 'Autodiscovery failed' );
+					expect( global.console.error ).toHaveBeenCalledWith(
+						new Error( 'No header link found with rel="https://api.w.org/"' )
+					);
+					expect( err.message ).toBe( 'Autodiscovery failed' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 		it( 'returns WPAPI instance bound to discovered root even when route request errors', () => {
 			const url = 'http://mozarts.house';
-			httpTransport.head.returns( Promise.reject() );
-			httpTransport.get.onFirstCall().returns( Promise.resolve( responses.get.withLink ) );
-			httpTransport.get.onSecondCall().returns( Promise.reject( 'Some error' ) );
+			httpTransport.head.mockImplementation( () => Promise.reject() );
+			httpTransport.get
+				.mockImplementationOnce( () => Promise.resolve( responses.get.withLink ) )
+				.mockImplementationOnce( () => Promise.reject( 'Some error' ) );
 			const prom = WPAPI.discover( url )
 				.then( ( result ) => {
-					expect( result ).to.be.an.instanceOf( WPAPI );
-					expect( httpTransport.head.calledOnce ).to.equal( true );
-					expect( httpTransport.get.calledTwice ).to.equal( true );
-					expect( global.console.error ).to.have.been.calledWith( 'Some error' );
-					expect( global.console.warn ).to.have.been.calledWith( 'Endpoint detected, proceeding despite error...' );
-					expect( result.root().toString() ).to.equal( 'http://mozarts.house/wp-json/' );
+					expect( result ).toBeInstanceOf( WPAPI );
+					expect( httpTransport.head ).toBeCalledTimes( 1 );
+					expect( httpTransport.get ).toBeCalledTimes( 2 );
+					expect( global.console.error ).toHaveBeenCalledWith( 'Some error' );
+					expect( global.console.warn ).toHaveBeenCalledWith( 'Endpoint detected, proceeding despite error...' );
+					expect( result.root().toString() ).toBe( 'http://mozarts.house/wp-json/' );
 					return SUCCESS;
 				} );
-			return expect( prom ).to.eventually.equal( SUCCESS );
+			return expect( prom ).resolves.toBe( SUCCESS );
 		} );
 
 	} );
@@ -443,18 +435,18 @@ describe( 'WPAPI', () => {
 		describe( '.namespace()', () => {
 
 			it( 'is a function', () => {
-				expect( site ).to.have.property( 'namespace' );
-				expect( site.namespace ).to.be.a( 'function' );
+				expect( site ).toHaveProperty( 'namespace' );
+				expect( typeof site.namespace ).toBe( 'function' );
 			} );
 
 			it( 'returns a namespace object with relevant endpoint handler methods', () => {
 				const wpV2 = site.namespace( 'wp/v2' );
 				// Spot check
-				expect( wpV2 ).to.be.an( 'object' );
-				expect( wpV2 ).to.have.property( 'posts' );
-				expect( wpV2.posts ).to.be.a( 'function' );
-				expect( wpV2 ).to.have.property( 'comments' );
-				expect( wpV2.comments ).to.be.a( 'function' );
+				expect( typeof wpV2 ).toBe( 'object' );
+				expect( wpV2 ).toHaveProperty( 'posts' );
+				expect( typeof wpV2.posts ).toBe( 'function' );
+				expect( wpV2 ).toHaveProperty( 'comments' );
+				expect( typeof wpV2.comments ).toBe( 'function' );
 			} );
 
 			it( 'passes options from the parent WPAPI instance to the namespaced handlers', () => {
@@ -463,11 +455,11 @@ describe( 'WPAPI', () => {
 					password: 'p',
 				} );
 				const pages = site.namespace( 'wp/v2' ).pages();
-				expect( pages._options ).to.be.an( 'object' );
-				expect( pages._options ).to.have.property( 'username' );
-				expect( pages._options.username ).to.equal( 'u' );
-				expect( pages._options ).to.have.property( 'password' );
-				expect( pages._options.password ).to.equal( 'p' );
+				expect( typeof pages._options ).toBe( 'object' );
+				expect( pages._options ).toHaveProperty( 'username' );
+				expect( pages._options.username ).toBe( 'u' );
+				expect( pages._options ).toHaveProperty( 'password' );
+				expect( pages._options.password ).toBe( 'p' );
 			} );
 
 			it( 'permits the namespace to be stored in a variable without disrupting options', () => {
@@ -477,23 +469,23 @@ describe( 'WPAPI', () => {
 				} );
 				const wpV2 = site.namespace( 'wp/v2' );
 				const pages = wpV2.pages();
-				expect( pages._options ).to.be.an( 'object' );
-				expect( pages._options ).to.have.property( 'username' );
-				expect( pages._options.username ).to.equal( 'u' );
-				expect( pages._options ).to.have.property( 'password' );
-				expect( pages._options.password ).to.equal( 'p' );
+				expect( typeof pages._options ).toBe( 'object' );
+				expect( pages._options ).toHaveProperty( 'username' );
+				expect( pages._options.username ).toBe( 'u' );
+				expect( pages._options ).toHaveProperty( 'password' );
+				expect( pages._options.password ).toBe( 'p' );
 			} );
 
 			it( 'throws an error when provided no namespace', () => {
 				expect( () => {
 					site.namespace();
-				} ).to.throw();
+				} ).toThrow();
 			} );
 
 			it( 'throws an error when provided an unregistered namespace', () => {
 				expect( () => {
 					site.namespace( 'foo/baz' );
-				} ).to.throw();
+				} ).toThrow();
 			} );
 
 		} );
@@ -526,45 +518,43 @@ describe( 'WPAPI', () => {
 			} );
 
 			it( 'is a function', () => {
-				expect( site ).to.have.property( 'bootstrap' );
-				expect( site.bootstrap ).to.be.a( 'function' );
+				expect( site ).toHaveProperty( 'bootstrap' );
+				expect( typeof site.bootstrap ).toBe( 'function' );
 			} );
 
 			it( 'is chainable', () => {
-				expect( site.bootstrap() ).to.equal( site );
+				expect( site.bootstrap() ).toBe( site );
 			} );
 
 			it( 'creates handlers for all provided route definitions', () => {
-				expect( site.namespace( 'myplugin/v1' ) ).to.be.an( 'object' );
-				expect( site.namespace( 'myplugin/v1' ) ).to.have.property( 'authors' );
-				expect( site.namespace( 'myplugin/v1' ).authors ).to.be.a( 'function' );
-				expect( site.namespace( 'wp/v2' ) ).to.be.an( 'object' );
-				expect( site.namespace( 'wp/v2' ) ).to.have.property( 'customendpoint' );
-				expect( site.namespace( 'wp/v2' ).customendpoint ).to.be.a( 'function' );
+				expect( typeof site.namespace( 'myplugin/v1' ) ).toBe( 'object' );
+				expect( site.namespace( 'myplugin/v1' ) ).toHaveProperty( 'authors' );
+				expect( typeof site.namespace( 'myplugin/v1' ).authors ).toBe( 'function' );
+				expect( typeof site.namespace( 'wp/v2' ) ).toBe( 'object' );
+				expect( site.namespace( 'wp/v2' ) ).toHaveProperty( 'customendpoint' );
+				expect( typeof site.namespace( 'wp/v2' ).customendpoint ).toBe( 'function' );
 			} );
 
 			it( 'properly assigns setter methods for detected path parts', () => {
 				const thingHandler = site.customendpoint();
-				expect( thingHandler ).to.have.property( 'thing' );
-				expect( thingHandler.thing ).to.be.a( 'function' );
-				expect( thingHandler.thing( 'foobar' ).toString() ).to.equal( 'endpoint/url/wp/v2/customendpoint/foobar' );
+				expect( thingHandler ).toHaveProperty( 'thing' );
+				expect( typeof thingHandler.thing ).toBe( 'function' );
+				expect( thingHandler.thing( 'foobar' ).toString() ).toBe( 'endpoint/url/wp/v2/customendpoint/foobar' );
 			} );
 
 			it( 'assigns any mixins for detected GET arguments for custom namespace handlers', () => {
 				const authorsHandler = site.namespace( 'myplugin/v1' ).authors();
-				expect( authorsHandler ).to.have.property( 'name' );
-				expect( authorsHandler ).not.to.have.ownProperty( 'name' );
-				expect( authorsHandler.name ).to.be.a( 'function' );
+				expect( authorsHandler ).toHaveProperty( 'name' );
+				expect( typeof authorsHandler.name ).toBe( 'function' );
 				const customEndpoint = site.customendpoint();
-				expect( customEndpoint ).to.have.property( 'parent' );
-				expect( customEndpoint ).not.to.have.ownProperty( 'parent' );
-				expect( customEndpoint.parent ).to.be.a( 'function' );
+				expect( customEndpoint ).toHaveProperty( 'parent' );
+				expect( typeof customEndpoint.parent ).toBe( 'function' );
 			} );
 
 			it( 'assigns handlers for wp/v2 routes to the instance object itself', () => {
-				expect( site ).to.have.property( 'customendpoint' );
-				expect( site.customendpoint ).to.be.a( 'function' );
-				expect( site.namespace( 'wp/v2' ).customendpoint ).to.equal( site.customendpoint );
+				expect( site ).toHaveProperty( 'customendpoint' );
+				expect( typeof site.customendpoint ).toBe( 'function' );
+				expect( site.namespace( 'wp/v2' ).customendpoint ).toBe( site.customendpoint );
 			} );
 
 		} );
@@ -572,29 +562,29 @@ describe( 'WPAPI', () => {
 		describe( '.transport()', () => {
 
 			it( 'is defined', () => {
-				expect( site ).to.have.property( 'transport' );
+				expect( site ).toHaveProperty( 'transport' );
 			} );
 
 			it( 'is a function', () => {
-				expect( site.transport ).to.be.a( 'function' );
+				expect( typeof site.transport ).toBe( 'function' );
 			} );
 
 			it( 'is chainable', () => {
-				expect( site.transport() ).to.equal( site );
+				expect( site.transport() ).toBe( site );
 			} );
 
 			it( 'sets transport methods on the instance', () => {
-				sinon.stub( httpTransport, 'get' );
-				const customGet = sinon.stub();
+				jest.spyOn( httpTransport, 'get' );
+				const customGet = jest.fn();
 				site.transport( {
 					get: customGet,
 				} );
 				const cb = () => {};
 				const query = site.root( '' );
 				query.get( cb );
-				expect( httpTransport.get ).not.to.have.been.called;
-				expect( customGet ).to.have.been.calledWith( query, cb );
-				httpTransport.get.restore();
+				expect( customGet ).toHaveBeenCalledWith( query, cb );
+				expect( httpTransport.get ).not.toHaveBeenCalled();
+				httpTransport.get.mockRestore();
 			} );
 
 			it( 'does not impact or overwrite unspecified transport methods', () => {
@@ -604,11 +594,11 @@ describe( 'WPAPI', () => {
 					put() {},
 				} );
 				const newMethods = Object.assign( {}, site._options.transport );
-				expect( newMethods.delete ).to.equal( originalMethods.delete );
-				expect( newMethods.post ).to.equal( originalMethods.post );
+				expect( newMethods.delete ).toBe( originalMethods.delete );
+				expect( newMethods.post ).toBe( originalMethods.post );
 
-				expect( newMethods.get ).not.to.equal( originalMethods.get );
-				expect( newMethods.put ).not.to.equal( originalMethods.put );
+				expect( newMethods.get ).not.toBe( originalMethods.get );
+				expect( newMethods.put ).not.toBe( originalMethods.put );
 			} );
 
 		} );
@@ -616,15 +606,15 @@ describe( 'WPAPI', () => {
 		describe( '.url()', () => {
 
 			it( 'is defined', () => {
-				expect( site ).to.have.property( 'url' );
-				expect( site.url ).to.be.a( 'function' );
+				expect( site ).toHaveProperty( 'url' );
+				expect( typeof site.url ).toBe( 'function' );
 			} );
 
 			it( 'creates a basic WPRequest object bound to the provided URL', () => {
 				const request = site.url( 'http://new-endpoint.com/' );
-				expect( request._options ).to.have.property( 'endpoint' );
-				expect( request._options.endpoint ).to.equal( 'http://new-endpoint.com/' );
-				expect( request._options ).not.to.have.property( 'identifier' );
+				expect( request._options ).toHaveProperty( 'endpoint' );
+				expect( request._options.endpoint ).toBe( 'http://new-endpoint.com/' );
+				expect( request._options ).not.toHaveProperty( 'identifier' );
 			} );
 
 		} );
@@ -636,13 +626,13 @@ describe( 'WPAPI', () => {
 			} );
 
 			it( 'is defined', () => {
-				expect( site ).to.have.property( 'root' );
-				expect( site.root ).to.be.a( 'function' );
+				expect( site ).toHaveProperty( 'root' );
+				expect( typeof site.root ).toBe( 'function' );
 			} );
 
 			it( 'creates a get request against the root endpoint', () => {
 				const pathRequest = site.root( 'some/collection/endpoint' );
-				expect( pathRequest instanceof WPRequest ).to.be.true;
+				expect( pathRequest instanceof WPRequest ).toBe( true );
 			} );
 
 			it( 'inherits options from the parent WPAPI instance', () => {
@@ -650,8 +640,8 @@ describe( 'WPAPI', () => {
 					endpoint: 'http://cat.website.com/',
 				} );
 				const request = site.root( 'custom-path' );
-				expect( request._options ).to.have.property( 'endpoint' );
-				expect( request._options.endpoint ).to.equal( 'http://cat.website.com/' );
+				expect( request._options ).toHaveProperty( 'endpoint' );
+				expect( request._options.endpoint ).toBe( 'http://cat.website.com/' );
 			} );
 
 		} );
@@ -663,15 +653,15 @@ describe( 'WPAPI', () => {
 			} );
 
 			it( 'is defined', () => {
-				expect( site ).to.have.property( 'auth' );
-				expect( site.auth ).to.be.a( 'function' );
+				expect( site ).toHaveProperty( 'auth' );
+				expect( typeof site.auth ).toBe( 'function' );
 			} );
 
 			it( 'activates authentication for the site', () => {
-				expect( site._options ).not.to.have.property( 'auth' );
+				expect( site._options ).not.toHaveProperty( 'auth' );
 				site.auth();
-				expect( site._options ).to.have.property( 'auth' );
-				expect( site._options.auth ).to.be.true;
+				expect( site._options ).toHaveProperty( 'auth' );
+				expect( site._options.auth ).toBe( true );
 			} );
 
 			it( 'sets the username and password when provided in an object', () => {
@@ -679,12 +669,12 @@ describe( 'WPAPI', () => {
 					username: 'user1',
 					password: 'pass1',
 				} );
-				expect( site._options ).to.have.property( 'username' );
-				expect( site._options ).to.have.property( 'password' );
-				expect( site._options.username ).to.equal( 'user1' );
-				expect( site._options.password ).to.equal( 'pass1' );
-				expect( site._options ).to.have.property( 'auth' );
-				expect( site._options.auth ).to.be.true;
+				expect( site._options ).toHaveProperty( 'username' );
+				expect( site._options ).toHaveProperty( 'password' );
+				expect( site._options.username ).toBe( 'user1' );
+				expect( site._options.password ).toBe( 'pass1' );
+				expect( site._options ).toHaveProperty( 'auth' );
+				expect( site._options.auth ).toBe( true );
 			} );
 
 			it( 'can update previously-set usernames and passwords', () => {
@@ -695,22 +685,22 @@ describe( 'WPAPI', () => {
 					username: 'admin',
 					password: 'sandwich',
 				} );
-				expect( site._options ).to.have.property( 'username' );
-				expect( site._options ).to.have.property( 'password' );
-				expect( site._options.username ).to.equal( 'admin' );
-				expect( site._options.password ).to.equal( 'sandwich' );
-				expect( site._options ).to.have.property( 'auth' );
-				expect( site._options.auth ).to.be.true;
+				expect( site._options ).toHaveProperty( 'username' );
+				expect( site._options ).toHaveProperty( 'password' );
+				expect( site._options.username ).toBe( 'admin' );
+				expect( site._options.password ).toBe( 'sandwich' );
+				expect( site._options ).toHaveProperty( 'auth' );
+				expect( site._options.auth ).toBe( true );
 			} );
 
 			it( 'sets the nonce when provided in an object', () => {
 				site.auth( {
 					nonce: 'somenonce',
 				} );
-				expect( site._options ).to.have.property( 'nonce' );
-				expect( site._options.nonce ).to.equal( 'somenonce' );
-				expect( site._options ).to.have.property( 'auth' );
-				expect( site._options.auth ).to.be.true;
+				expect( site._options ).toHaveProperty( 'nonce' );
+				expect( site._options.nonce ).toBe( 'somenonce' );
+				expect( site._options ).toHaveProperty( 'auth' );
+				expect( site._options.auth ).toBe( true );
 			} );
 
 			it( 'can update nonce credentials', () => {
@@ -719,10 +709,10 @@ describe( 'WPAPI', () => {
 				} ).auth( {
 					nonce: 'refreshednonce',
 				} );
-				expect( site._options ).to.have.property( 'nonce' );
-				expect( site._options.nonce ).to.equal( 'refreshednonce' );
-				expect( site._options ).to.have.property( 'auth' );
-				expect( site._options.auth ).to.be.true;
+				expect( site._options ).toHaveProperty( 'nonce' );
+				expect( site._options.nonce ).toBe( 'refreshednonce' );
+				expect( site._options ).toHaveProperty( 'auth' );
+				expect( site._options.auth ).toBe( true );
 			} );
 
 			it( 'passes authentication status to all subsequently-instantiated handlers', () => {
@@ -731,14 +721,14 @@ describe( 'WPAPI', () => {
 					password: 'pass',
 				} );
 				const req = site.root( '' );
-				expect( req ).to.have.property( '_options' );
-				expect( req._options ).to.be.an( 'object' );
-				expect( req._options ).to.have.property( 'username' );
-				expect( req._options.username ).to.equal( 'user' );
-				expect( req._options ).to.have.property( 'password' );
-				expect( req._options.password ).to.equal( 'pass' );
-				expect( req._options ).to.have.property( 'password' );
-				expect( req._options.auth ).to.equal( true );
+				expect( req ).toHaveProperty( '_options' );
+				expect( typeof req._options ).toBe( 'object' );
+				expect( req._options ).toHaveProperty( 'username' );
+				expect( req._options.username ).toBe( 'user' );
+				expect( req._options ).toHaveProperty( 'password' );
+				expect( req._options.password ).toBe( 'pass' );
+				expect( req._options ).toHaveProperty( 'password' );
+				expect( req._options.auth ).toBe( true );
 			} );
 
 		} );
@@ -750,21 +740,21 @@ describe( 'WPAPI', () => {
 			} );
 
 			it( 'is defined', () => {
-				expect( site ).to.have.property( 'setHeaders' );
-				expect( site.setHeaders ).to.be.a( 'function' );
+				expect( site ).toHaveProperty( 'setHeaders' );
+				expect( typeof site.setHeaders ).toBe( 'function' );
 			} );
 
 			it( 'initializes site-wide headers object if called with no arguments', () => {
-				expect( site._options ).not.to.have.property( 'headers' );
+				expect( site._options ).not.toHaveProperty( 'headers' );
 				site.setHeaders();
-				expect( site._options ).to.have.property( 'headers' );
-				expect( site._options.headers ).to.deep.equal( {} );
+				expect( site._options ).toHaveProperty( 'headers' );
+				expect( site._options.headers ).toEqual( {} );
 			} );
 
 			it( 'sets site-wide headers when provided a name-value pair', () => {
 				site.setHeaders( 'Accept-Language', 'en-US' );
-				expect( site._options ).to.have.property( 'headers' );
-				expect( site._options.headers ).to.deep.equal( {
+				expect( site._options ).toHaveProperty( 'headers' );
+				expect( site._options.headers ).toEqual( {
 					'Accept-Language': 'en-US',
 				} );
 			} );
@@ -774,8 +764,8 @@ describe( 'WPAPI', () => {
 					'Accept-Language': 'en-CA',
 					Authorization: 'Bearer sometoken',
 				} );
-				expect( site._options ).to.have.property( 'headers' );
-				expect( site._options.headers ).to.deep.equal( {
+				expect( site._options ).toHaveProperty( 'headers' );
+				expect( site._options.headers ).toEqual( {
 					'Accept-Language': 'en-CA',
 					Authorization: 'Bearer sometoken',
 				} );
@@ -787,10 +777,10 @@ describe( 'WPAPI', () => {
 					Authorization: 'Bearer chicagostylepizza',
 				} );
 				const req = site.root( '' );
-				expect( req ).to.have.property( '_options' );
-				expect( req._options ).to.be.an( 'object' );
-				expect( req._options ).to.have.property( 'headers' );
-				expect( req._options.headers ).to.deep.equal( {
+				expect( req ).toHaveProperty( '_options' );
+				expect( typeof req._options ).toBe( 'object' );
+				expect( req._options ).toHaveProperty( 'headers' );
+				expect( req._options.headers ).toEqual( {
 					'Accept-Language': 'en-IL',
 					Authorization: 'Bearer chicagostylepizza',
 				} );
@@ -801,8 +791,8 @@ describe( 'WPAPI', () => {
 		describe( '.registerRoute()', () => {
 
 			it( 'is a function', () => {
-				expect( site ).to.have.property( 'registerRoute' );
-				expect( site.registerRoute ).to.be.a( 'function' );
+				expect( site ).toHaveProperty( 'registerRoute' );
+				expect( typeof site.registerRoute ).toBe( 'function' );
 			} );
 
 		} );
@@ -812,43 +802,43 @@ describe( 'WPAPI', () => {
 	describe( 'instance has endpoint accessors', () => {
 
 		it( 'for the media endpoint', () => {
-			expect( site ).to.have.property( 'media' );
-			expect( site.media ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'media' );
+			expect( typeof site.media ).toBe( 'function' );
 		} );
 
 		it( 'for the pages endpoint', () => {
-			expect( site ).to.have.property( 'pages' );
-			expect( site.pages ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'pages' );
+			expect( typeof site.pages ).toBe( 'function' );
 		} );
 
 		it( 'for the posts endpoint', () => {
-			expect( site ).to.have.property( 'posts' );
-			expect( site.posts ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'posts' );
+			expect( typeof site.posts ).toBe( 'function' );
 		} );
 
 		it( 'for the taxonomies endpoint', () => {
-			expect( site ).to.have.property( 'taxonomies' );
-			expect( site.taxonomies ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'taxonomies' );
+			expect( typeof site.taxonomies ).toBe( 'function' );
 		} );
 
 		it( 'for the categories endpoint', () => {
-			expect( site ).to.have.property( 'categories' );
-			expect( site.categories ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'categories' );
+			expect( typeof site.categories ).toBe( 'function' );
 		} );
 
 		it( 'for the tags endpoint', () => {
-			expect( site ).to.have.property( 'tags' );
-			expect( site.tags ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'tags' );
+			expect( typeof site.tags ).toBe( 'function' );
 		} );
 
 		it( 'for the types endpoint', () => {
-			expect( site ).to.have.property( 'types' );
-			expect( site.types ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'types' );
+			expect( typeof site.types ).toBe( 'function' );
 		} );
 
 		it( 'for the users endpoint', () => {
-			expect( site ).to.have.property( 'users' );
-			expect( site.users ).to.be.a( 'function' );
+			expect( site ).toHaveProperty( 'users' );
+			expect( typeof site.users ).toBe( 'function' );
 		} );
 
 	} );


### PR DESCRIPTION
Now that we are using Jest as our test runner, there is no reason to continue maintaining Chai and Sinon assertions if the same functionality is provided by Jest.