### PR TITLE
Safeguard against custom response header inconsistencies

### DIFF
--- a/lib/http-transport.js
+++ b/lib/http-transport.js
@@ -125,7 +125,7 @@ function createPaginationObject( result, options, httpTransport ) {
 		return _paging;
 	}
 
-	const totalPages = result.headers[ 'x-wp-totalpages' ];
+	const totalPages = +result.headers[ 'x-wp-totalpages' ];
 
 	if ( ! totalPages || totalPages === '0' ) {
 		// No paging: return as-is
@@ -139,7 +139,7 @@ function createPaginationObject( result, options, httpTransport ) {
 
 	// Store pagination data from response headers on the response collection
 	_paging = {
-		total: result.headers[ 'x-wp-total' ],
+		total: +result.headers[ 'x-wp-total' ],
 		totalPages: totalPages,
 		links: links,
 	};

--- a/lib/http-transport.js
+++ b/lib/http-transport.js
@@ -120,14 +120,24 @@ function extractResponseBody( response ) {
 function createPaginationObject( result, options, httpTransport ) {
 	let _paging = null;
 
-	if ( ! result.headers || ! result.headers[ 'x-wp-totalpages' ] ) {
+	if ( ! result.headers ) {
 		// No headers: return as-is
+		return _paging;
+	}
+
+	// Guard against capitalization inconsistencies in returned headers
+	Object.keys( result.headers ).forEach( ( header ) => {
+		result.headers[ header.toLowerCase() ] = result.headers[ header ];
+	} );
+
+	if ( ! result.headers[ 'x-wp-totalpages' ] ) {
+		// No paging: return as-is
 		return _paging;
 	}
 
 	const totalPages = +result.headers[ 'x-wp-totalpages' ];
 
-	if ( ! totalPages || totalPages === '0' ) {
+	if ( ! totalPages || totalPages === 0 ) {
 		// No paging: return as-is
 		return _paging;
 	}

--- a/tests/integration/categories.js
+++ b/tests/integration/categories.js
@@ -97,7 +97,7 @@ describe( 'integration: categories()', () => {
 				.get()
 				.then( ( categories ) => {
 					expect( categories._paging ).toHaveProperty( 'total' );
-					expect( categories._paging.total ).toBe( '65' );
+					expect( categories._paging.total ).toBe( 65 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );
@@ -108,7 +108,7 @@ describe( 'integration: categories()', () => {
 				.get()
 				.then( ( categories ) => {
 					expect( categories._paging ).toHaveProperty( 'totalPages' );
-					expect( categories._paging.totalPages ).toBe( '7' );
+					expect( categories._paging.totalPages ).toBe( 7 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );

--- a/tests/integration/comments.js
+++ b/tests/integration/comments.js
@@ -121,7 +121,7 @@ describe( 'integration: comments()', () => {
 				.get()
 				.then( ( posts ) => {
 					expect( posts._paging ).toHaveProperty( 'total' );
-					expect( posts._paging.total ).toBe( '25' );
+					expect( posts._paging.total ).toBe( 25 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );
@@ -132,7 +132,7 @@ describe( 'integration: comments()', () => {
 				.get()
 				.then( ( posts ) => {
 					expect( posts._paging ).toHaveProperty( 'totalPages' );
-					expect( posts._paging.totalPages ).toBe( '3' );
+					expect( posts._paging.totalPages ).toBe( 3 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );

--- a/tests/integration/media.js
+++ b/tests/integration/media.js
@@ -120,7 +120,7 @@ describe( 'integration: media()', () => {
 				.get()
 				.then( ( media ) => {
 					expect( media._paging ).toHaveProperty( 'totalPages' );
-					expect( media._paging.totalPages ).toBe( '4' );
+					expect( media._paging.totalPages ).toBe( 4 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );

--- a/tests/integration/pages.js
+++ b/tests/integration/pages.js
@@ -87,7 +87,7 @@ describe( 'integration: pages()', () => {
 				.get()
 				.then( ( pages ) => {
 					expect( pages._paging ).toHaveProperty( 'total' );
-					expect( pages._paging.total ).toBe( '18' );
+					expect( pages._paging.total ).toBe( 18 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );
@@ -98,7 +98,7 @@ describe( 'integration: pages()', () => {
 				.get()
 				.then( ( pages ) => {
 					expect( pages._paging ).toHaveProperty( 'totalPages' );
-					expect( pages._paging.totalPages ).toBe( '2' );
+					expect( pages._paging.totalPages ).toBe( 2 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );

--- a/tests/integration/posts.js
+++ b/tests/integration/posts.js
@@ -140,7 +140,7 @@ describe( 'integration: posts()', () => {
 				.get()
 				.then( ( posts ) => {
 					expect( posts._paging ).toHaveProperty( 'totalPages' );
-					expect( posts._paging.totalPages ).toBe( '4' );
+					expect( posts._paging.totalPages ).toBe( 4 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );

--- a/tests/integration/tags.js
+++ b/tests/integration/tags.js
@@ -102,7 +102,7 @@ describe( 'integration: tags()', () => {
 				.get()
 				.then( ( tags ) => {
 					expect( tags._paging ).toHaveProperty( 'total' );
-					expect( tags._paging.total ).toBe( '110' );
+					expect( tags._paging.total ).toBe( 110 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );
@@ -113,7 +113,7 @@ describe( 'integration: tags()', () => {
 				.get()
 				.then( ( tags ) => {
 					expect( tags._paging ).toHaveProperty( 'totalPages' );
-					expect( tags._paging.totalPages ).toBe( '11' );
+					expect( tags._paging.totalPages ).toBe( 11 );
 					return SUCCESS;
 				} );
 			return expect( prom ).resolves.toBe( SUCCESS );


### PR DESCRIPTION
#332 describes situations where the library will think that there is no paging information available, despite those headers being present in the received response. While I have not been able to replicate the exact scenario, two possibilities which suggest themselves are that Superagent does not consistently lowercase the header property names (causing a lookup failure), and that the total and totalPages values may be improperly parsed (due perhaps to carriage returns, etc). This PR adds a defensive guard against capitalization by ensuring that every key on the headers object is assigned as its lowercase equivalent, so that a `headers[ 'X-Capital-Header' ]` will get duplicated as `headers[ 'x-capital-header' ]`.

We also add type coercion to convert the total and total pages headers into Numbers. This may break code making strict type checks against those header values, but it will ensure that we can consistently treat them as numbers and avoid any spacing issues (as `Number( '  4\r\n' ) === 4`)