### PR TITLE
Plugin route fix

### DIFF
--- a/lib/util/named-group-regexp.js
+++ b/lib/util/named-group-regexp.js
@@ -14,7 +14,7 @@ const pattern = [
 	'[>\']',
 	// Get everything up to the end of the capture group: this is the RegExp used
 	// when matching URLs to this route, which we can use for validation purposes.
-	'([^\\)]*)',
+	'([^\\)]*(\))?)\??)',
 	// Capture group end
 	'\\)',
 ].join( '' );

--- a/lib/util/named-group-regexp.js
+++ b/lib/util/named-group-regexp.js
@@ -14,7 +14,7 @@ const pattern = [
 	'[>\']',
 	// Get everything up to the end of the capture group: this is the RegExp used
 	// when matching URLs to this route, which we can use for validation purposes.
-	'([^\\)]*(\))?)\??)',
+	'([^\\)]*(\\))?)\\??',
 	// Capture group end
 	'\\)',
 ].join( '' );


### PR DESCRIPTION
I modified the regex so it can correctly capture plugins Rest API Routes.
I've tested autodiscovery on a WordPress 5.5.3 and the autodiscovery works.

So far i'm not proficients with node to get test modified to check if it correctly works in every situations or on new versions of WP by now 5.6.*

Thanks

